### PR TITLE
Implement zero() methods for Point2D, Rect, Size2D

### DIFF
--- a/point.rs
+++ b/point.rs
@@ -8,11 +8,22 @@
 // except according to those terms.
 
 use std::fmt;
+use std::num::Zero;
 
 #[deriving(Clone, Decodable, Encodable, Eq)]
 pub struct Point2D<T> {
     pub x: T,
     pub y: T
+}
+
+impl<T: Zero + Clone> Zero for Point2D<T> {
+    fn zero() -> Point2D<T> {
+        Point2D { x: Zero::zero(), y: Zero::zero() }
+    }
+
+    fn is_zero(&self) -> bool {
+        self.x.is_zero() && self.y.is_zero()
+    }
 }
 
 impl<T: fmt::Show> fmt::Show for Point2D<T> {

--- a/rect.rs
+++ b/rect.rs
@@ -11,6 +11,7 @@ use point::Point2D;
 use size::Size2D;
 use std::cmp::{Eq, Ord};
 use std::fmt;
+use std::num::Zero;
 
 #[deriving(Clone, Decodable, Encodable, Eq)]
 pub struct Rect<T> {
@@ -84,6 +85,20 @@ impl<T: Clone + Ord + Add<T,T> + Sub<T,T>> Rect<T> {
         }
     }
 }
+
+impl<T:Clone + Zero> Rect<T> {
+    pub fn zero() -> Rect<T> {
+        Rect {
+            origin: Zero::zero(),
+            size: Size2D::zero(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.size.is_empty()
+    }
+}
+
 
 pub fn min<T:Clone + Ord>(x: T, y: T) -> T {
     if x <= y { x } else { y }

--- a/size.rs
+++ b/size.rs
@@ -9,6 +9,7 @@
 
 use std::cmp::Eq;
 use std::fmt;
+use std::num::Zero;
 
 #[deriving(Clone, Decodable, Encodable, Eq)]
 pub struct Size2D<T> {
@@ -33,3 +34,15 @@ impl<T:Clone + Mul<T,T>> Size2D<T> {
     pub fn area(&self) -> T { self.width * self.height }
 }
 
+impl<T:Clone + Zero> Size2D<T> {
+    pub fn zero() -> Size2D<T> {
+        Size2D {
+            width: Zero::zero(),
+            height: Zero::zero(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.width.is_zero() || self.height.is_zero()
+    }
+}


### PR DESCRIPTION
Note that Rect and Size2D do not implement std::num::Zero, because the zero
laws do not hold for these types (they have no addition operation).
