### PR TITLE
Upgrade to latest Rust

### DIFF
--- a/length.rs
+++ b/length.rs
@@ -71,7 +71,7 @@ impl<Unit, T0: NumCast + Clone, T1: NumCast + Clone> Length<Unit, T0> {
     }
 }
 
-// FIXME: Switch to `deriving(Clone, Eq, Ord, Zero)` after this Rust issue is fixed:
+// FIXME: Switch to `deriving(Clone, PartialEq, PartialOrd, Zero)` after this Rust issue is fixed:
 // https://github.com/mozilla/rust/issues/7671
 
 impl<Unit, T: Clone> Clone for Length<Unit, T> {
@@ -80,20 +80,20 @@ impl<Unit, T: Clone> Clone for Length<Unit, T> {
     }
 }
 
-impl<Unit, T: Clone + Eq> Eq for Length<Unit, T> {
+impl<Unit, T: Clone + PartialEq> PartialEq for Length<Unit, T> {
     fn eq(&self, other: &Length<Unit, T>) -> bool { self.get().eq(&other.get()) }
 }
 
-impl<Unit, T: Clone + Ord> Ord for Length<Unit, T> {
+impl<Unit, T: Clone + PartialOrd> PartialOrd for Length<Unit, T> {
     fn lt(&self, other: &Length<Unit, T>) -> bool { self.get().lt(&other.get()) }
     fn le(&self, other: &Length<Unit, T>) -> bool { self.get().le(&other.get()) }
     fn gt(&self, other: &Length<Unit, T>) -> bool { self.get().gt(&other.get()) }
     fn ge(&self, other: &Length<Unit, T>) -> bool { self.get().ge(&other.get()) }
 }
 
-impl<Unit, T: Clone + TotalEq> TotalEq for Length<Unit, T> {}
+impl<Unit, T: Clone + Eq> Eq for Length<Unit, T> {}
 
-impl<Unit, T: Clone + TotalOrd> TotalOrd for Length<Unit, T> {
+impl<Unit, T: Clone + Ord> Ord for Length<Unit, T> {
     fn cmp(&self, other: &Length<Unit, T>) -> Ordering { self.get().cmp(&other.get()) }
 }
 

--- a/lib.rs
+++ b/lib.rs
@@ -14,7 +14,7 @@
 
 #![feature(asm, phase, simd)]
 
-#[phase(syntax, link)]
+#[phase(plugin, link)]
 extern crate log;
 extern crate serialize;
 extern crate std;

--- a/point.rs
+++ b/point.rs
@@ -12,7 +12,7 @@ use length::Length;
 use std::fmt;
 use std::num::Zero;
 
-#[deriving(Clone, Decodable, Encodable, Eq)]
+#[deriving(Clone, Decodable, Encodable, PartialEq)]
 pub struct Point2D<T> {
     pub x: T,
     pub y: T

--- a/rect.rs
+++ b/rect.rs
@@ -11,11 +11,11 @@ use length::Length;
 
 use point::Point2D;
 use size::Size2D;
-use std::cmp::{Eq, Ord};
+use std::cmp::{PartialEq, PartialOrd};
 use std::fmt;
 use std::num::Zero;
 
-#[deriving(Clone, Decodable, Encodable, Eq)]
+#[deriving(Clone, Decodable, Encodable, PartialEq)]
 pub struct Rect<T> {
     pub origin: Point2D<T>,
     pub size: Size2D<T>,
@@ -34,7 +34,7 @@ pub fn Rect<T:Clone>(origin: Point2D<T>, size: Size2D<T>) -> Rect<T> {
     }
 }
 
-impl<T: Clone + Ord + Add<T,T> + Sub<T,T>> Rect<T> {
+impl<T: Clone + PartialOrd + Add<T,T> + Sub<T,T>> Rect<T> {
     #[inline]
     pub fn intersects(&self, other: &Rect<T>) -> bool {
         self.origin.x < other.origin.x + other.size.width &&
@@ -100,11 +100,11 @@ impl<T:Clone + Zero> Rect<T> {
 }
 
 
-pub fn min<T:Clone + Ord>(x: T, y: T) -> T {
+pub fn min<T:Clone + PartialOrd>(x: T, y: T) -> T {
     if x <= y { x } else { y }
 }
 
-pub fn max<T:Clone + Ord>(x: T, y: T) -> T {
+pub fn max<T:Clone + PartialOrd>(x: T, y: T) -> T {
     if x >= y { x } else { y }
 }
 

--- a/scale_factor.rs
+++ b/scale_factor.rs
@@ -80,10 +80,10 @@ impl<Src, Dst, T0: NumCast + Clone, T1: NumCast + Clone> ScaleFactor<Src, Dst, T
     }
 }
 
-// FIXME: Switch to `deriving(Eq, Clone)` after this Rust issue is fixed:
+// FIXME: Switch to `deriving(PartialEq, Clone)` after this Rust issue is fixed:
 // https://github.com/mozilla/rust/issues/7671
 
-impl<Src, Dst, T: Clone + Eq> Eq for ScaleFactor<Src, Dst, T> {
+impl<Src, Dst, T: Clone + PartialEq> PartialEq for ScaleFactor<Src, Dst, T> {
     fn eq(&self, other: &ScaleFactor<Src, Dst, T>) -> bool {
         self.get().eq(&other.get())
     }

--- a/side_offsets.rs
+++ b/side_offsets.rs
@@ -14,7 +14,7 @@ use std::num::Zero;
 
 /// A group of side offsets, which correspond to top/left/bottom/right for borders, padding,
 /// and margins in CSS.
-#[deriving(Clone, Eq)]
+#[deriving(Clone, PartialEq)]
 pub struct SideOffsets2D<T> {
     pub top: T,
     pub right: T,
@@ -76,7 +76,7 @@ impl<T:Num> Zero for SideOffsets2D<T> {
 }
 
 /// A SIMD enabled version of SideOffsets2D specialized for i32.
-#[deriving(Clone, Eq, Rand)]
+#[deriving(Clone, PartialEq, Rand)]
 #[simd]
 pub struct SideOffsets2DSimdI32 {
     pub top: i32,

--- a/size.rs
+++ b/size.rs
@@ -9,11 +9,11 @@
 
 use length::Length;
 
-use std::cmp::Eq;
+use std::cmp::PartialEq;
 use std::fmt;
 use std::num::Zero;
 
-#[deriving(Clone, Decodable, Encodable, Eq)]
+#[deriving(Clone, Decodable, Encodable, PartialEq)]
 pub struct Size2D<T> {
     pub width: T,
     pub height: T


### PR DESCRIPTION
Brings us to [`9f8d2205f0518389993a9b5de6646ba8b14e5a12`](https://github.com/rust-lang/rust/tree/9f8d2205f0518389993a9b5de6646ba8b14e5a12) (June 17)

See https://github.com/mozilla/servo/pull/2677
