### PR TITLE
Add unary negation support for Point2D and Length

### DIFF
--- a/src/length.rs
+++ b/src/length.rs
@@ -64,6 +64,14 @@ impl<Src, Dst, T: Clone + Div<T, T>> Div<ScaleFactor<Src, Dst, T>, Length<Src, T
     }
 }
 
+// -length
+impl <U, T:Clone + Neg<T>> Neg<Length<U, T>> for Length<U, T> {
+    #[inline]
+    fn neg(&self) -> Length<U, T> {
+        Length(-self.get())
+    }
+}
+
 impl<Unit, T0: NumCast + Clone, T1: NumCast + Clone> Length<Unit, T0> {
     /// Cast from one numeric representation to another, preserving the units.
     pub fn cast(&self) -> Option<Length<Unit, T1>> {
@@ -151,5 +159,15 @@ mod tests {
 
         let int_foot: Length<Inch, int> = one_foot.cast().unwrap();
         assert_eq!(int_foot.get(), 12);
+
+        let negative_one_foot = -one_foot;
+        assert_eq!(negative_one_foot.get(), -12.0);
+
+        let negative_two_feet = -two_feet;
+        assert_eq!(negative_two_feet.get(), -24.0);
+
+        let zero_feet: Length<Inch, f32> = Length(0.0);
+        let negative_zero_feet = -zero_feet;
+        assert_eq!(negative_zero_feet.get(), 0.0);
     }
 }

--- a/src/point.rs
+++ b/src/point.rs
@@ -58,6 +58,13 @@ impl<T:Clone + Sub<T,T>> Sub<Point2D<T>, Point2D<T>> for Point2D<T> {
     }
 }
 
+impl <T:Clone + Neg<T>> Neg<Point2D<T>> for Point2D<T> {
+    #[inline]
+    fn neg(&self) -> Point2D<T> {
+        Point2D(-self.x, -self.y)
+    }
+}
+
 impl<Scale, T0: Mul<Scale, T1>, T1: Clone> Mul<Scale, Point2D<T1>> for Point2D<T0> {
     #[inline]
     fn mul(&self, scale: &Scale) -> Point2D<T1> {


### PR DESCRIPTION
This will allow doing things like rect.translate(&-point), which make
the code much simpler and easier to read.
