### PR TITLE
Fix doc test failures after ScaleFactor changes

### DIFF
--- a/src/scale_factor.rs
+++ b/src/scale_factor.rs
@@ -19,10 +19,12 @@ use std::num::{cast, One};
 /// may be types without values, such as empty enums.  For example:
 ///
 /// ```rust
+/// use geom::scale_factor::ScaleFactor;
+/// use geom::length::Length;
 /// enum Mm {};
 /// enum Inch {};
 ///
-/// let mm_per_inch: ScaleFactor<Inch, Mm> = ScaleFactor(25.4);
+/// let mm_per_inch: ScaleFactor<Inch, Mm, f32> = ScaleFactor(25.4);
 ///
 /// let one_foot: Length<Inch, f32> = Length(12.0);
 /// let one_foot_in_mm: Length<Mm, f32> = one_foot * mm_per_inch;


### PR DESCRIPTION
This package failed it's doc tests for me using:

```
cargo 0.0.1-pre-nightly (603f29d 2014-11-01 19:29:48 +0000)
rustc 0.13.0-nightly (ec28b4a6c 2014-11-04 03:36:55 +0000)
```

ScaleFactor now needs a number type annotation in addition to the units.
Incidentally needed to include use statements.

I'm just looking into Rust, so hopefully these changes are correct but comment if not.
