### PR TITLE
Loosen bounds on `horizontal`/`vertical` in `SideOffsets2D`

### DIFF
--- a/src/side_offsets.rs
+++ b/src/side_offsets.rs
@@ -40,7 +40,7 @@ impl<T:Clone> SideOffsets2D<T> {
     }
 }
 
-impl<T:Num> SideOffsets2D<T> {
+impl<T> SideOffsets2D<T> where T: Add<T,T> {
     pub fn horizontal(&self) -> T {
         self.left + self.right
     }


### PR DESCRIPTION
r? @SimonSapin (or whoever)

This allows the methods in question to be used with `Au`.
