### PR TITLE
Change simd to repr simd & bump version number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["The Servo Project Developers"]
 description = "Geometry primitives"
 documentation = "http://doc.servo.org/euclid/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(asm, custom_derive, plugin, simd, zero_one, test)]
+#![feature(asm, custom_derive, plugin, repr_simd, zero_one, test)]
 
 #![plugin(serde_macros)]
 

--- a/src/side_offsets.rs
+++ b/src/side_offsets.rs
@@ -76,7 +76,7 @@ impl<T: Zero> SideOffsets2D<T> {
 
 /// A SIMD enabled version of SideOffsets2D specialized for i32.
 #[derive(Clone, Copy, PartialEq)]
-#[simd]
+#[repr(simd)]
 #[cfg_attr(feature = "heap_size", derive(HeapSizeOf))]
 pub struct SideOffsets2DSimdI32 {
     pub top: i32,


### PR DESCRIPTION
With [SIMD groundwork part 1](https://github.com/rust-lang/rust/pull/27169)
the simd feature is now repr_simd.

Bump the version number since this relies on the rust PR. 

r? @metajack

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/euclid/101)
<!-- Reviewable:end -->
