### PR TITLE
Add += and -= support for Length (Issue #104)

### DIFF
--- a/src/length.rs
+++ b/src/length.rs
@@ -14,7 +14,7 @@ use num::Zero;
 use num_lib::NumCast;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::cmp::Ordering;
-use std::ops::{Add, Sub, Mul, Div, Neg};
+use std::ops::{Add, AddAssign, Sub, SubAssign, Mul, Div, Neg};
 use std::marker::PhantomData;
 
 /// A one-dimensional distance, with value represented by `T` and unit of measurement `Unit`.
@@ -67,11 +67,25 @@ impl<U, T: Clone + Add<T, Output=T>> Add for Length<U, T> {
     }
 }
 
+// length += length
+impl<U, T: Clone + AddAssign<T>> AddAssign for Length<U, T> {
+    fn add_assign(&mut self, other: Length<U, T>) {
+        self.0 += other.get();
+    }
+}
+
 // length - length
 impl<U, T: Clone + Sub<T, Output=T>> Sub<Length<U, T>> for Length<U, T> {
     type Output = Length<U, T>;
     fn sub(self, other: Length<U, T>) -> <Self as Sub>::Output {
         Length::new(self.get() - other.get())
+    }
+}
+
+// length -= length
+impl<U, T: Clone + SubAssign<T>> SubAssign for Length<U, T> {
+    fn sub_assign(&mut self, other: Length<U, T>) {
+        self.0 -= other.get();
     }
 }
 
@@ -204,5 +218,25 @@ mod tests {
         let zero_feet: Length<Inch, f32> = Length::new(0.0);
         let negative_zero_feet = -zero_feet;
         assert_eq!(negative_zero_feet.get(), 0.0);
+    }
+
+    #[test]
+    fn test_addassign() {
+        let one_cm: Length<Mm, f32> = Length::new(10.0);
+        let mut measurement: Length<Mm, f32> = Length::new(5.0);
+
+        measurement += one_cm;
+
+        assert_eq!(measurement.get(), 15.0);
+    }
+
+    #[test]
+    fn test_subassign() {
+        let one_cm: Length<Mm, f32> = Length::new(10.0);
+        let mut measurement: Length<Mm, f32> = Length::new(5.0);
+
+        measurement -= one_cm;
+
+        assert_eq!(measurement.get(), -5.0);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@
 // except according to those terms.
 
 #![feature(asm, custom_derive, plugin, repr_simd, zero_one, test)]
+#![feature(augmented_assignments)]
+#![feature(op_assign_traits)]
 
 #![plugin(serde_macros)]
 


### PR DESCRIPTION
More of a learning exercise for a first try of Rust, with a few questions :)

* I noticed the current tests are all in one single test function. I've added a test for each operator I added here - is there any disadvantage to more unit-like tests?

* When I run `cargo test`, all 23 tests pass, but the process doesn't exit successfully?
```
Process didn't exit successfully: `/home/michael/code/rust/euclid/target/debug/euclid-9d296e662001f41b` (signal: 4)

Caused by:
  Process didn't exit successfully: `/home/michael/code/rust/euclid/target/debug/euclid-9d296e662001f41b` (signal: 4)
```
* I assume I should also (as another PR) add *= and /=, but currently there's not length * length (only length * scalefactor). Ah - is that because it'd be returning an area unit - so really just need length *= scalefactor and length /= scalefacter right? Anyway, I can add those, but was hoping to first understand more about what complex impl's like:

```
impl<Src, Dst, T: Clone + Div<T, Output=T>> Div<Length<Src, T>> for Length<Dst, T> {
```
are trying to declare...

Thanks

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/euclid/107)
<!-- Reviewable:end -->
