### PR TITLE
Make Rect::is_empty return true when either dimension is empty

### DIFF
--- a/src/rect.rs
+++ b/src/rect.rs
@@ -174,7 +174,7 @@ impl<T: PartialEq + Zero> Rect<T> {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.size == Size2D::zero()
+        self.size.width == Zero::zero() || self.size.height == Zero::zero()
     }
 }
 
@@ -393,4 +393,16 @@ fn test_min_max_x_y() {
     assert!(r.min_y() == -5);
     assert!(r.max_x() == 40);
     assert!(r.min_x() == -10);
+}
+
+#[test]
+fn test_is_empty() {
+    assert!(Rect::new(Point2D::new(0u32, 0u32), Size2D::new(0u32, 0u32)).is_empty());
+    assert!(Rect::new(Point2D::new(0u32, 0u32), Size2D::new(10u32, 0u32)).is_empty());
+    assert!(Rect::new(Point2D::new(0u32, 0u32), Size2D::new(0u32, 10u32)).is_empty());
+    assert!(!Rect::new(Point2D::new(0u32, 0u32), Size2D::new(1u32, 1u32)).is_empty());
+    assert!(Rect::new(Point2D::new(10u32, 10u32), Size2D::new(0u32, 0u32)).is_empty());
+    assert!(Rect::new(Point2D::new(10u32, 10u32), Size2D::new(10u32, 0u32)).is_empty());
+    assert!(Rect::new(Point2D::new(10u32, 10u32), Size2D::new(0u32, 10u32)).is_empty());
+    assert!(!Rect::new(Point2D::new(10u32, 10u32), Size2D::new(1u32, 1u32)).is_empty());
 }


### PR DESCRIPTION
Instead of only returning true when both dimensions of a Rect are
empty, is_empty should return true when either is empty. This makes
Rect much easier to use, because applications rarely want to
distinguish between situations where a Rect is empty in only one
direction or both.

Fixes #109.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/euclid/110)
<!-- Reviewable:end -->
