### PR TITLE
Specify versions for serde and serde_macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["The Servo Project Developers"]
 description = "Geometry primitives"
 documentation = "http://doc.servo.org/euclid/"
@@ -16,8 +16,8 @@ unstable = []
 rustc-serialize = "0.3.2"
 num = {version = "0.1.24", default-features = false}
 log = "0.3.1"
-serde = {version = "*", optional = true}
-serde_macros = {version = "*", optional = true}
+serde = {version = "0.6.6", optional = true}
+serde_macros = {version = "0.6.5", optional = true}
 
 [dependencies.heapsize]
 version = "0.2"


### PR DESCRIPTION
I just used the versions currently found in Servo.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/euclid/121)
<!-- Reviewable:end -->
