### PR TITLE
Don't use SSE4.1 instructions unless the target supports it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.6.8"
+version = "0.6.9"
 authors = ["The Servo Project Developers"]
 description = "Geometry primitives"
 documentation = "http://doc.servo.org/euclid/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![cfg_attr(feature = "unstable", feature(asm, repr_simd, test))]
+#![cfg_attr(feature = "unstable", feature(asm, cfg_target_feature, repr_simd, test))]
 
 extern crate heapsize;
 

--- a/src/side_offsets.rs
+++ b/src/side_offsets.rs
@@ -146,13 +146,13 @@ impl SideOffsets2DSimdI32 {
         }
     }
 
-    #[cfg(not(target_arch = "x86_64"))]
+    #[cfg(not(target_feature = "sse4.1"))]
     #[inline]
     pub fn is_zero(&self) -> bool {
         self.top == 0 && self.right == 0 && self.bottom == 0 && self.left == 0
     }
 
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(target_feature = "sse4.1")]
     #[inline]
     pub fn is_zero(&self) -> bool {
         let is_zero: bool;


### PR DESCRIPTION
Fixes #48. r? @pcwalton

Enabling the SIMD code path now requires building with
`RUSTFLAGS="-C target-feature=+sse4.1"` or similar.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/140)

<!-- Reviewable:end -->
