### PR TITLE
Make the serde support behave better

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.6.8"
+version = "0.7.0"
 authors = ["The Servo Project Developers"]
 description = "Geometry primitives"
 documentation = "http://doc.servo.org/euclid/"

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -31,12 +31,11 @@ impl<T: HeapSizeOf> HeapSizeOf for Rect<T> {
     }
 }
 
-impl<T: Deserialize> Deserialize for Rect<T> {
+impl<T: Clone + Deserialize> Deserialize for Rect<T> {
     fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
         where D: Deserializer
     {
-        let origin = try!(Deserialize::deserialize(deserializer));
-        let size = try!(Deserialize::deserialize(deserializer));
+        let (origin, size) = try!(Deserialize::deserialize(deserializer));
         Ok(Rect {
             origin: origin,
             size: size,
@@ -48,9 +47,7 @@ impl<T: Serialize> Serialize for Rect<T> {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer
     {
-        try!(self.origin.serialize(serializer));
-        try!(self.size.serialize(serializer));
-        Ok(())
+        (&self.origin, &self.size).serialize(serializer)
     }
 }
 

--- a/src/side_offsets.rs
+++ b/src/side_offsets.rs
@@ -10,6 +10,7 @@
 //! A group of side offsets, which correspond to top/left/bottom/right for borders, padding,
 //! and margins in CSS.
 
+#[cfg(feature = "unstable")]
 use heapsize::HeapSizeOf;
 use num::Zero;
 use std::ops::Add;


### PR DESCRIPTION
The previous implementation could produce illegal JSON when used
with serde_json.

This is a breaking change because we have to add a Clone bound on
the Deserialize impls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/141)
<!-- Reviewable:end -->
