### PR TITLE
clippy run and test for Rect::translate_by_size

### DIFF
--- a/src/length.rs
+++ b/src/length.rs
@@ -29,7 +29,7 @@ use std::marker::PhantomData;
 /// enum.
 ///
 /// You can multiply a Length by a `scale_factor::ScaleFactor` to convert it from one unit to
-/// another.  See the ScaleFactor docs for an example.
+/// another. See the `ScaleFactor` docs for an example.
 // Uncomment the derive, and remove the macro call, once heapsize gets
 // PhantomData<T> support.
 #[derive(Copy, RustcDecodable, RustcEncodable, Debug)]

--- a/src/matrix2d.rs
+++ b/src/matrix2d.rs
@@ -48,30 +48,30 @@ impl<T:Add<T, Output=T> +
 
     pub fn translate(&self, x: T, y: T) -> Matrix2D<T> {
          let (_0, _1): (T, T) = (Zero::zero(), One::one());
-         let matrix = Matrix2D::new(_1.clone(), _0.clone(),
-                                    _0.clone(), _1.clone(),
+         let matrix = Matrix2D::new(_1, _0,
+                                    _0, _1,
                                     x, y);
-        return self.mul(&matrix);
+        self.mul(&matrix)
     }
 
     pub fn scale(&self, x: T, y: T) -> Matrix2D<T> {
-        Matrix2D::new(self.m11 * x,     self.m12.clone(),
-                      self.m21.clone(), self.m22 * y,
-                      self.m31.clone(), self.m32.clone())
+        Matrix2D::new(self.m11 * x, self.m12,
+                      self.m21, self.m22 * y,
+                      self.m31, self.m32)
     }
 
     pub fn identity() -> Matrix2D<T> {
-        let (_0, _1): (T, T) = (Zero::zero(), One::one());
-        return Matrix2D::new(_1.clone(), _0.clone(),
-                             _0.clone(), _1.clone(),
-                             _0.clone(), _0.clone());
+        let (_0, _1) = (Zero::zero(), One::one());
+        Matrix2D::new(_1, _0,
+                      _0, _1,
+                      _0, _0)
     }
 
     pub fn to_array(&self) -> [T; 6] {
         [
-            self.m11.clone(), self.m12.clone(),
-            self.m21.clone(), self.m22.clone(),
-            self.m31.clone(), self.m32.clone()
+            self.m11, self.m12,
+            self.m21, self.m22,
+            self.m31, self.m32
         ]
     }
 
@@ -90,23 +90,23 @@ impl<T:Add<T, Output=T> +
         let top_right = self.transform_point(&rect.top_right());
         let bottom_left = self.transform_point(&rect.bottom_left());
         let bottom_right = self.transform_point(&rect.bottom_right());
-        let (mut min_x, mut min_y) = (top_left.x.clone(), top_left.y.clone());
-        let (mut max_x, mut max_y) = (min_x.clone(), min_y.clone());
-        for point in [ top_right, bottom_left, bottom_right ].iter() {
+        let (mut min_x, mut min_y) = (top_left.x, top_left.y);
+        let (mut max_x, mut max_y) = (min_x, min_y);
+        for point in &[top_right, bottom_left, bottom_right] {
             if point.x < min_x {
-                min_x = point.x.clone()
+                min_x = point.x
             }
             if point.x > max_x {
-                max_x = point.x.clone()
+                max_x = point.x
             }
             if point.y < min_y {
-                min_y = point.y.clone()
+                min_y = point.y
             }
             if point.y > max_y {
-                max_y = point.y.clone()
+                max_y = point.y
             }
         }
-        Rect::new(Point2D::new(min_x.clone(), min_y.clone()),
+        Rect::new(Point2D::new(min_x, min_y),
                   Size2D::new(max_x - min_x, max_y - min_y))
     }
 }

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -88,7 +88,7 @@ impl<T: Copy + Clone + PartialOrd + Add<T, Output=T> + Sub<T, Output=T>> Rect<T>
 
     #[inline]
     pub fn min_x(&self) -> T {
-        self.origin.x.clone()
+        self.origin.x
     }
 
     #[inline]
@@ -98,7 +98,7 @@ impl<T: Copy + Clone + PartialOrd + Add<T, Output=T> + Sub<T, Output=T>> Rect<T>
 
     #[inline]
     pub fn min_y(&self) -> T {
-        self.origin.y.clone()
+        self.origin.y
     }
 
     #[inline]
@@ -112,15 +112,15 @@ impl<T: Copy + Clone + PartialOrd + Add<T, Output=T> + Sub<T, Output=T>> Rect<T>
         let lower_right = Point2D::new(min(self.max_x(), other.max_x()),
                                        min(self.max_y(), other.max_y()));
 
-        Some(Rect::new(upper_left.clone(), Size2D::new(lower_right.x - upper_left.x,
-                                                       lower_right.y - upper_left.y)))
+        Some(Rect::new(upper_left, Size2D::new(lower_right.x - upper_left.x,
+                                               lower_right.y - upper_left.y)))
     }
 
     #[inline]
     pub fn translate(&self, other: &Point2D<T>) -> Rect<T> {
         Rect {
             origin: Point2D::new(self.origin.x + other.x, self.origin.y + other.y),
-            size: self.size.clone()
+            size: self.size
         }
     }
 
@@ -140,12 +140,12 @@ impl<T: Copy + Clone + PartialOrd + Add<T, Output=T> + Sub<T, Output=T>> Rect<T>
 
     #[inline]
     pub fn top_right(&self) -> Point2D<T> {
-        Point2D::new(self.max_x(), self.origin.y.clone())
+        Point2D::new(self.max_x(), self.origin.y)
     }
 
     #[inline]
     pub fn bottom_left(&self) -> Point2D<T> {
-        Point2D::new(self.origin.x.clone(), self.max_y())
+        Point2D::new(self.origin.x, self.max_y())
     }
 
     #[inline]
@@ -155,8 +155,7 @@ impl<T: Copy + Clone + PartialOrd + Add<T, Output=T> + Sub<T, Output=T>> Rect<T>
 
     #[inline]
     pub fn translate_by_size(&self, size: &Size2D<T>) -> Rect<T> {
-        Rect::new(Point2D::new(self.origin.x + size.width, self.origin.y + size.height),
-                  self.size.clone())
+        self.translate(&Point2D::new(size.width, size.height))
     }
 }
 
@@ -177,7 +176,7 @@ impl<T: Copy + Clone + PartialOrd + Add<T, Output=T> + Sub<T, Output=T> + Zero> 
                                        max(self.max_y(), other.max_y()));
 
         Rect {
-            origin: upper_left.clone(),
+            origin: upper_left,
             size: Size2D::new(lower_right.x - upper_left.x, lower_right.y - upper_left.y)
         }
     }
@@ -297,6 +296,26 @@ mod tests {
 
         let r = Rect::new(Point2D::new(-10, -5), Size2D::new(50, 40));
         let rr = r.translate(&Point2D::new(0,-10));
+
+        assert!(rr.size.width == 50);
+        assert!(rr.size.height == 40);
+        assert!(rr.origin.x == -10);
+        assert!(rr.origin.y == -15);
+    }
+
+    #[test]
+    fn test_translate_by_size() {
+        let p = Rect::new(Point2D::new(0u32, 0u32), Size2D::new(50u32, 40u32));
+        let pp = p.translate_by_size(&Size2D::new(10,15));
+
+        assert!(pp.size.width == 50);
+        assert!(pp.size.height == 40);
+        assert!(pp.origin.x == 10);
+        assert!(pp.origin.y == 15);
+
+
+        let r = Rect::new(Point2D::new(-10, -5), Size2D::new(50, 40));
+        let rr = r.translate_by_size(&Size2D::new(0,-10));
 
         assert!(rr.size.width == 50);
         assert!(rr.size.height == 40);

--- a/src/scale_factor.rs
+++ b/src/scale_factor.rs
@@ -21,7 +21,7 @@ use std::marker::PhantomData;
 /// This is effectively a type-safe float, intended to be used in combination with other types like
 /// `length::Length` to enforce conversion between systems of measurement at compile time.
 ///
-/// `Src` and `Dst` represent the units before and after multiplying a value by a ScaleFactor.  They
+/// `Src` and `Dst` represent the units before and after multiplying a value by a `ScaleFactor`. They
 /// may be types without values, such as empty enums.  For example:
 ///
 /// ```rust


### PR DESCRIPTION
Mostly remove calling `.clone()` on `Copy` types. Refactored `Rect::translate_by_size` to use `Rect::translate`. Add test for `Rect::translate_by_size`. I think it would be best to have `Point2D` implement `From<Size2D>` and have only one generic `Rect::translate`, deprecating `Rect::translate_by_size`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/142)
<!-- Reviewable:end -->
