### PR TITLE
Avoid some pointless string allocations in <Rect as Display>::fmt.

### DIFF
--- a/src/rect.rs
+++ b/src/rect.rs
@@ -59,7 +59,7 @@ impl<T: fmt::Debug> fmt::Debug for Rect<T> {
 
 impl<T: fmt::Display> fmt::Display for Rect<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "Rect({} at {})", self.size.to_string(), self.origin.to_string())
+        write!(formatter, "Rect({} at {})", self.size, self.origin)
     }
 }
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/147)
<!-- Reviewable:end -->
