### PR TITLE
Integrate the units system proposed in issue #144 into Euclid types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["The Servo Project Developers"]
 description = "Geometry primitives"
 documentation = "http://doc.servo.org/euclid/"

--- a/src/length.rs
+++ b/src/length.rs
@@ -18,6 +18,10 @@ use std::cmp::Ordering;
 use std::ops::{Add, Sub, Mul, Div, Neg};
 use std::ops::{AddAssign, SubAssign};
 use std::marker::PhantomData;
+use std::fmt;
+
+#[derive(RustcDecodable, RustcEncodable)]
+pub struct UnknownUnit;
 
 /// A one-dimensional distance, with value represented by `T` and unit of measurement `Unit`.
 ///
@@ -32,109 +36,123 @@ use std::marker::PhantomData;
 /// another. See the `ScaleFactor` docs for an example.
 // Uncomment the derive, and remove the macro call, once heapsize gets
 // PhantomData<T> support.
-#[derive(Copy, RustcDecodable, RustcEncodable, Debug)]
-pub struct Length<Unit, T>(pub T, PhantomData<Unit>);
+#[derive(RustcDecodable, RustcEncodable)]
+pub struct Length<T, Unit>(pub T, PhantomData<Unit>);
 
-impl<Unit, T: HeapSizeOf> HeapSizeOf for Length<Unit, T> {
+impl<Unit, T: HeapSizeOf> HeapSizeOf for Length<T, Unit> {
     fn heap_size_of_children(&self) -> usize {
         self.0.heap_size_of_children()
     }
 }
 
-impl<Unit, T> Deserialize for Length<Unit, T> where T: Deserialize {
-    fn deserialize<D>(deserializer: &mut D) -> Result<Length<Unit,T>,D::Error>
+impl<Unit, T> Deserialize for Length<T, Unit> where T: Deserialize {
+    fn deserialize<D>(deserializer: &mut D) -> Result<Length<T, Unit>,D::Error>
                       where D: Deserializer {
         Ok(Length(try!(Deserialize::deserialize(deserializer)), PhantomData))
     }
 }
 
-impl<Unit, T> Serialize for Length<Unit, T> where T: Serialize {
+impl<T, Unit> Serialize for Length<T, Unit> where T: Serialize {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(),S::Error> where S: Serializer {
         self.0.serialize(serializer)
     }
 }
 
-impl<Unit, T> Length<Unit, T> {
-    pub fn new(x: T) -> Length<Unit, T> {
+impl<T, Unit> Length<T, Unit> {
+    pub fn new(x: T) -> Length<T, Unit> {
         Length(x, PhantomData)
     }
 }
 
-impl<Unit, T: Clone> Length<Unit, T> {
+impl<T: Copy, Unit> Copy for Length<T, Unit> {}
+
+impl<Unit, T: Clone> Length<T, Unit> {
     pub fn get(&self) -> T {
         self.0.clone()
     }
 }
 
+impl<T: fmt::Debug + Clone, U> fmt::Debug for Length<T, U> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.get().fmt(f)
+    }
+}
+
+impl<T: fmt::Display + Clone, U> fmt::Display for Length<T, U> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.get().fmt(f)
+    }
+}
+
 // length + length
-impl<U, T: Clone + Add<T, Output=T>> Add for Length<U, T> {
-    type Output = Length<U, T>;
-    fn add(self, other: Length<U, T>) -> Length<U, T> {
+impl<U, T: Clone + Add<T, Output=T>> Add for Length<T, U> {
+    type Output = Length<T, U>;
+    fn add(self, other: Length<T, U>) -> Length<T, U> {
         Length::new(self.get() + other.get())
     }
 }
 
 // length += length
-impl<U, T: Clone + AddAssign<T>> AddAssign for Length<U, T> {
-    fn add_assign(&mut self, other: Length<U, T>) {
+impl<U, T: Clone + AddAssign<T>> AddAssign for Length<T, U> {
+    fn add_assign(&mut self, other: Length<T, U>) {
         self.0 += other.get();
     }
 }
 
 // length - length
-impl<U, T: Clone + Sub<T, Output=T>> Sub<Length<U, T>> for Length<U, T> {
-    type Output = Length<U, T>;
-    fn sub(self, other: Length<U, T>) -> <Self as Sub>::Output {
+impl<U, T: Clone + Sub<T, Output=T>> Sub<Length<T, U>> for Length<T, U> {
+    type Output = Length<T, U>;
+    fn sub(self, other: Length<T, U>) -> <Self as Sub>::Output {
         Length::new(self.get() - other.get())
     }
 }
 
 // length -= length
-impl<U, T: Clone + SubAssign<T>> SubAssign for Length<U, T> {
-    fn sub_assign(&mut self, other: Length<U, T>) {
+impl<U, T: Clone + SubAssign<T>> SubAssign for Length<T, U> {
+    fn sub_assign(&mut self, other: Length<T, U>) {
         self.0 -= other.get();
     }
 }
 
 // length / length
-impl<Src, Dst, T: Clone + Div<T, Output=T>> Div<Length<Src, T>> for Length<Dst, T> {
-    type Output = ScaleFactor<Src, Dst, T>;
+impl<Src, Dst, T: Clone + Div<T, Output=T>> Div<Length<T, Src>> for Length<T, Dst> {
+    type Output = ScaleFactor<T, Src, Dst>;
     #[inline]
-    fn div(self, other: Length<Src, T>) -> ScaleFactor<Src, Dst, T> {
+    fn div(self, other: Length<T, Src>) -> ScaleFactor<T, Src, Dst> {
         ScaleFactor::new(self.get() / other.get())
     }
 }
 
 // length * scaleFactor
-impl<Src, Dst, T: Clone + Mul<T, Output=T>> Mul<ScaleFactor<Src, Dst, T>> for Length<Src, T> {
-    type Output = Length<Dst, T>;
+impl<Src, Dst, T: Clone + Mul<T, Output=T>> Mul<ScaleFactor<T, Src, Dst>> for Length<T, Src> {
+    type Output = Length<T, Dst>;
     #[inline]
-    fn mul(self, scale: ScaleFactor<Src, Dst, T>) -> Length<Dst, T> {
+    fn mul(self, scale: ScaleFactor<T, Src, Dst>) -> Length<T, Dst> {
         Length::new(self.get() * scale.get())
     }
 }
 
 // length / scaleFactor
-impl<Src, Dst, T: Clone + Div<T, Output=T>> Div<ScaleFactor<Src, Dst, T>> for Length<Dst, T> {
-    type Output = Length<Src, T>;
+impl<Src, Dst, T: Clone + Div<T, Output=T>> Div<ScaleFactor<T, Src, Dst>> for Length<T, Dst> {
+    type Output = Length<T, Src>;
     #[inline]
-    fn div(self, scale: ScaleFactor<Src, Dst, T>) -> Length<Src, T> {
+    fn div(self, scale: ScaleFactor<T, Src, Dst>) -> Length<T, Src> {
         Length::new(self.get() / scale.get())
     }
 }
 
 // -length
-impl <U, T:Clone + Neg<Output=T>> Neg for Length<U, T> {
-    type Output = Length<U, T>;
+impl <U, T:Clone + Neg<Output=T>> Neg for Length<T, U> {
+    type Output = Length<T, U>;
     #[inline]
-    fn neg(self) -> Length<U, T> {
+    fn neg(self) -> Length<T, U> {
         Length::new(-self.get())
     }
 }
 
-impl<Unit, T0: NumCast + Clone> Length<Unit, T0> {
+impl<Unit, T0: NumCast + Clone> Length<T0, Unit> {
     /// Cast from one numeric representation to another, preserving the units.
-    pub fn cast<T1: NumCast + Clone>(&self) -> Option<Length<Unit, T1>> {
+    pub fn cast<T1: NumCast + Clone>(&self) -> Option<Length<T1, Unit>> {
         NumCast::from(self.get()).map(Length::new)
     }
 }
@@ -142,30 +160,30 @@ impl<Unit, T0: NumCast + Clone> Length<Unit, T0> {
 // FIXME: Switch to `derive(Clone, PartialEq, PartialOrd, Zero)` after this Rust issue is fixed:
 // https://github.com/mozilla/rust/issues/7671
 
-impl<Unit, T: Clone> Clone for Length<Unit, T> {
-    fn clone(&self) -> Length<Unit, T> {
+impl<Unit, T: Clone> Clone for Length<T, Unit> {
+    fn clone(&self) -> Length<T, Unit> {
         Length::new(self.get())
     }
 }
 
-impl<Unit, T: Clone + PartialEq> PartialEq for Length<Unit, T> {
-    fn eq(&self, other: &Length<Unit, T>) -> bool { self.get().eq(&other.get()) }
+impl<Unit, T: Clone + PartialEq> PartialEq for Length<T, Unit> {
+    fn eq(&self, other: &Length<T, Unit>) -> bool { self.get().eq(&other.get()) }
 }
 
-impl<Unit, T: Clone + PartialOrd> PartialOrd for Length<Unit, T> {
-    fn partial_cmp(&self, other: &Length<Unit, T>) -> Option<Ordering> {
+impl<Unit, T: Clone + PartialOrd> PartialOrd for Length<T, Unit> {
+    fn partial_cmp(&self, other: &Length<T, Unit>) -> Option<Ordering> {
         self.get().partial_cmp(&other.get())
     }
 }
 
-impl<Unit, T: Clone + Eq> Eq for Length<Unit, T> {}
+impl<Unit, T: Clone + Eq> Eq for Length<T, Unit> {}
 
-impl<Unit, T: Clone + Ord> Ord for Length<Unit, T> {
-    fn cmp(&self, other: &Length<Unit, T>) -> Ordering { self.get().cmp(&other.get()) }
+impl<Unit, T: Clone + Ord> Ord for Length<T, Unit> {
+    fn cmp(&self, other: &Length<T, Unit>) -> Ordering { self.get().cmp(&other.get()) }
 }
 
-impl<Unit, T: Zero> Zero for Length<Unit, T> {
-    fn zero() -> Length<Unit, T> {
+impl<Unit, T: Zero> Zero for Length<T, Unit> {
+    fn zero() -> Length<T, Unit> {
         Length::new(Zero::zero())
     }
 }
@@ -182,9 +200,9 @@ mod tests {
 
     #[test]
     fn test_length() {
-        let mm_per_inch: ScaleFactor<Inch, Mm, f32> = ScaleFactor::new(25.4);
+        let mm_per_inch: ScaleFactor<f32, Inch, Mm> = ScaleFactor::new(25.4);
 
-        let one_foot: Length<Inch, f32> = Length::new(12.0);
+        let one_foot: Length<f32, Inch> = Length::new(12.0);
         let two_feet = one_foot.clone() + one_foot.clone();
         let zero_feet = one_foot.clone() - one_foot.clone();
 
@@ -205,15 +223,15 @@ mod tests {
         assert!(!(two_feet >  two_feet));
         assert!(!(two_feet <  two_feet));
 
-        let one_foot_in_mm: Length<Mm, f32> = one_foot * mm_per_inch;
+        let one_foot_in_mm: Length<f32, Mm> = one_foot * mm_per_inch;
 
         assert_eq!(one_foot_in_mm, Length::new(304.8));
         assert_eq!(one_foot_in_mm / one_foot, mm_per_inch);
 
-        let back_to_inches: Length<Inch, f32> = one_foot_in_mm / mm_per_inch;
+        let back_to_inches: Length<f32, Inch> = one_foot_in_mm / mm_per_inch;
         assert_eq!(one_foot, back_to_inches);
 
-        let int_foot: Length<Inch, isize> = one_foot.cast().unwrap();
+        let int_foot: Length<isize, Inch> = one_foot.cast().unwrap();
         assert_eq!(int_foot.get(), 12);
 
         let negative_one_foot = -one_foot;
@@ -222,15 +240,15 @@ mod tests {
         let negative_two_feet = -two_feet;
         assert_eq!(negative_two_feet.get(), -24.0);
 
-        let zero_feet: Length<Inch, f32> = Length::new(0.0);
+        let zero_feet: Length<f32, Inch> = Length::new(0.0);
         let negative_zero_feet = -zero_feet;
         assert_eq!(negative_zero_feet.get(), 0.0);
     }
 
     #[test]
     fn test_addassign() {
-        let one_cm: Length<Mm, f32> = Length::new(10.0);
-        let mut measurement: Length<Mm, f32> = Length::new(5.0);
+        let one_cm: Length<f32, Mm> = Length::new(10.0);
+        let mut measurement: Length<f32, Mm> = Length::new(5.0);
 
         measurement += one_cm;
 
@@ -239,8 +257,8 @@ mod tests {
 
     #[test]
     fn test_subassign() {
-        let one_cm: Length<Mm, f32> = Length::new(10.0);
-        let mut measurement: Length<Mm, f32> = Length::new(5.0);
+        let one_cm: Length<f32, Mm> = Length::new(10.0);
+        let mut measurement: Length<f32, Mm> = Length::new(5.0);
 
         measurement -= one_cm;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,13 +23,17 @@ extern crate test;
 extern crate num_traits;
 
 pub use matrix::Matrix4;
-pub use matrix2d::Matrix2D;
-pub use matrix4d::Matrix4D;
-pub use point::{Point2D, Point3D, Point4D};
-pub use rect::Rect;
-pub use side_offsets::SideOffsets2D;
+pub use matrix2d::{Matrix2D, TypedMatrix2D};
+pub use matrix4d::{Matrix4D, TypedMatrix4D};
+pub use point::{
+    Point2D, TypedPoint2D,
+    Point3D, TypedPoint3D,
+    Point4D, TypedPoint4D,
+};
+pub use rect::{Rect, TypedRect};
+pub use side_offsets::{SideOffsets2D, TypedSideOffsets2D};
 #[cfg(feature = "unstable")] pub use side_offsets::SideOffsets2DSimdI32;
-pub use size::Size2D;
+pub use size::{Size2D, TypedSize2D};
 
 pub mod approxeq;
 pub mod length;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -33,25 +33,25 @@ macro_rules! deserialize {
         $T:ty
     ) => ({
         let values = try!(<[$T; $total]>::deserialize($deserializer));
-        Ok($name { $($field: values[$index].clone(),)+ })
+        Ok($name { $($field: values[$index].clone(),)+ _unit: PhantomData })
     })
 }
 
 macro_rules! define_matrix {
-    ($(#[$attr:meta])* pub struct $name:ident<T> { $(pub $field:ident: T,)+ }) => (
+    ($(#[$attr:meta])* pub struct $name:ident<T, Src, Dst> { $(pub $field:ident: T,)+ }) => (
         $(#[$attr])*
-        #[derive(Clone, Copy, Eq, Hash, PartialEq)]
-        pub struct $name<T> {
+        pub struct $name<T, Src, Dst> {
             $(pub $field: T,)+
+            _unit: PhantomData<(Src, Dst)>
         }
 
-        impl<T: ::heapsize::HeapSizeOf> ::heapsize::HeapSizeOf for $name<T> {
+        impl<T: ::heapsize::HeapSizeOf, Src, Dst> ::heapsize::HeapSizeOf for $name<T, Src, Dst> {
             fn heap_size_of_children(&self) -> usize {
                 $(self.$field.heap_size_of_children() +)+ 0
             }
         }
 
-        impl<T: Clone + ::serde::Deserialize> ::serde::Deserialize for $name<T> {
+        impl<T: Clone + ::serde::Deserialize, Src, Dst> ::serde::Deserialize for $name<T, Src, Dst> {
             fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
                 where D: ::serde::Deserializer
             {
@@ -59,7 +59,39 @@ macro_rules! define_matrix {
             }
         }
 
-        impl<T: ::serde::Serialize> ::serde::Serialize for $name<T> {
+        impl<T: ::serde::Serialize, Src, Dst> ::serde::Serialize for $name<T, Src, Dst> {
+            fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+                where S: ::serde::Serializer
+            {
+                [$(&self.$field,)+].serialize(serializer)
+            }
+        }
+    )
+}
+
+macro_rules! define_vector {
+    ($(#[$attr:meta])* pub struct $name:ident<T, U> { $(pub $field:ident: T,)+ }) => (
+        $(#[$attr])*
+        pub struct $name<T, U> {
+            $(pub $field: T,)+
+            _unit: PhantomData<U>,
+        }
+
+        impl<T: ::heapsize::HeapSizeOf, U> ::heapsize::HeapSizeOf for $name<T, U> {
+            fn heap_size_of_children(&self) -> usize {
+                $(self.$field.heap_size_of_children() +)+ 0
+            }
+        }
+
+        impl<T: Clone + ::serde::Deserialize, U> ::serde::Deserialize for $name<T, U> {
+            fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
+                where D: ::serde::Deserializer
+            {
+                deserialize!({ $($field,)+ } 0 {} $name deserializer T)
+            }
+        }
+
+        impl<T: ::serde::Serialize, U> ::serde::Serialize for $name<T, U> {
             fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
                 where S: ::serde::Serializer
             {

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -7,7 +7,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use matrix4d::Matrix4D;
+use matrix4d::TypedMatrix4D;
+use length::UnknownUnit;
 
 #[cfg_attr(feature = "unstable", deprecated(note = "Use matrix4d::Matrix4D instead"))]
-pub type Matrix4 = Matrix4D<f32>;
+pub type Matrix4 = TypedMatrix4D<f32, UnknownUnit, UnknownUnit>;

--- a/src/matrix2d.rs
+++ b/src/matrix2d.rs
@@ -8,65 +8,35 @@
 // except according to those terms.
 
 use num::{One, Zero};
-use point::Point2D;
-use rect::Rect;
-use size::Size2D;
+use point::TypedPoint2D;
+use rect::TypedRect;
+use size::TypedSize2D;
+use length::UnknownUnit;
 use std::ops::{Add, Mul, Sub};
+use std::marker::PhantomData;
 
 define_matrix! {
-    pub struct Matrix2D<T> {
+    pub struct TypedMatrix2D<T, Src, Dst> {
         pub m11: T, pub m12: T,
         pub m21: T, pub m22: T,
         pub m31: T, pub m32: T,
     }
 }
 
-impl<T:Add<T, Output=T> +
-       Copy +
-       Clone +
-       Mul<T, Output=T> +
-       One +
-       PartialOrd +
-       Sub<T, Output=T> +
-       Zero> Matrix2D<T> {
-    pub fn new(m11: T, m12: T, m21: T, m22: T, m31: T, m32: T) -> Matrix2D<T> {
-        Matrix2D {
+pub type Matrix2D<T> = TypedMatrix2D<T, UnknownUnit, UnknownUnit>;
+
+impl<T, Src, Dst> TypedMatrix2D<T, Src, Dst> {
+    pub fn new(m11: T, m12: T, m21: T, m22: T, m31: T, m32: T) -> TypedMatrix2D<T, Src, Dst> {
+        TypedMatrix2D {
             m11: m11, m12: m12,
             m21: m21, m22: m22,
-            m31: m31, m32: m32
+            m31: m31, m32: m32,
+            _unit: PhantomData,
         }
     }
+}
 
-    pub fn mul(&self, m: &Matrix2D<T>) -> Matrix2D<T> {
-        Matrix2D::new(m.m11*self.m11 + m.m12*self.m21,
-                      m.m11*self.m12 + m.m12*self.m22,
-                      m.m21*self.m11 + m.m22*self.m21,
-                      m.m21*self.m12 + m.m22*self.m22,
-                      m.m31*self.m11 + m.m32*self.m21 + self.m31,
-                      m.m31*self.m12 + m.m32*self.m22 + self.m32)
-    }
-
-    pub fn translate(&self, x: T, y: T) -> Matrix2D<T> {
-         let (_0, _1): (T, T) = (Zero::zero(), One::one());
-         let matrix = Matrix2D::new(_1, _0,
-                                    _0, _1,
-                                    x, y);
-        self.mul(&matrix)
-    }
-
-    pub fn scale(&self, x: T, y: T) -> Matrix2D<T> {
-        Matrix2D::new(self.m11 * x, self.m12,
-                      self.m21, self.m22 * y,
-                      self.m31, self.m32)
-    }
-
-    pub fn identity() -> Matrix2D<T> {
-        let (_0, _1) = (Zero::zero(), One::one());
-        Matrix2D::new(_1, _0,
-                      _0, _1,
-                      _0, _0)
-    }
-
+impl<T: Copy, Src, Dst> TypedMatrix2D<T, Src, Dst> {
     pub fn to_array(&self) -> [T; 6] {
         [
             self.m11, self.m12,
@@ -74,18 +44,59 @@ impl<T:Add<T, Output=T> +
             self.m31, self.m32
         ]
     }
+}
+
+impl<T, Src, Dst> TypedMatrix2D<T, Src, Dst>
+where T: Copy + Clone +
+         Add<T, Output=T> +
+         Mul<T, Output=T> +
+         Sub<T, Output=T> +
+         PartialOrd +
+         One + Zero  {
+
+    pub fn mul<NewSrc>(&self, m: &TypedMatrix2D<T, NewSrc, Src>) -> TypedMatrix2D<T, NewSrc, Dst> {
+        TypedMatrix2D::new(
+            m.m11*self.m11 + m.m12*self.m21,
+            m.m11*self.m12 + m.m12*self.m22,
+            m.m21*self.m11 + m.m22*self.m21,
+            m.m21*self.m12 + m.m22*self.m22,
+            m.m31*self.m11 + m.m32*self.m21 + self.m31,
+            m.m31*self.m12 + m.m32*self.m22 + self.m32
+        )
+    }
+
+    pub fn translate(&self, x: T, y: T) -> TypedMatrix2D<T, Src, Dst> {
+         let (_0, _1): (T, T) = (Zero::zero(), One::one());
+         let matrix = TypedMatrix2D::new(_1, _0,
+                                         _0, _1,
+                                         x, y);
+        self.mul(&matrix)
+    }
+
+    pub fn scale(&self, x: T, y: T) -> TypedMatrix2D<T, Src, Dst> {
+        TypedMatrix2D::new(self.m11 * x, self.m12,
+                           self.m21, self.m22 * y,
+                           self.m31, self.m32)
+    }
+
+    pub fn identity() -> TypedMatrix2D<T, Src, Dst> {
+        let (_0, _1) = (Zero::zero(), One::one());
+        TypedMatrix2D::new(_1, _0,
+                           _0, _1,
+                           _0, _0)
+    }
 
     /// Returns the given point transformed by this matrix.
     #[inline]
-    pub fn transform_point(&self, point: &Point2D<T>) -> Point2D<T> {
-        Point2D::new(point.x * self.m11 + point.y * self.m21 + self.m31,
-                     point.x * self.m12 + point.y * self.m22 + self.m32)
+    pub fn transform_point(&self, point: &TypedPoint2D<T, Src>) -> TypedPoint2D<T, Dst> {
+        TypedPoint2D::new(point.x * self.m11 + point.y * self.m21 + self.m31,
+                          point.x * self.m12 + point.y * self.m22 + self.m32)
     }
 
     /// Returns a rectangle that encompasses the result of transforming the given rectangle by this
     /// matrix.
     #[inline]
-    pub fn transform_rect(&self, rect: &Rect<T>) -> Rect<T> {
+    pub fn transform_rect(&self, rect: &TypedRect<T, Src>) -> TypedRect<T, Dst> {
         let top_left = self.transform_point(&rect.origin);
         let top_right = self.transform_point(&rect.top_right());
         let bottom_left = self.transform_point(&rect.bottom_left());
@@ -106,7 +117,28 @@ impl<T:Add<T, Output=T> +
                 max_y = point.y
             }
         }
-        Rect::new(Point2D::new(min_x, min_y),
-                  Size2D::new(max_x - min_x, max_y - min_y))
+        TypedRect::new(TypedPoint2D::new(min_x, min_y),
+                       TypedSize2D::new(max_x - min_x, max_y - min_y))
+    }
+}
+
+// Convenient aliases for TypedPoint2D with typed units
+impl<T: Copy, Src, Dst> TypedMatrix2D<T, Src, Dst> {
+    /// Drop the units, preserving only the numeric value.
+    pub fn to_untyped(&self) -> Matrix2D<T> {
+        Matrix2D::new(
+            self.m11, self.m12,
+            self.m21, self.m22,
+            self.m31, self.m32
+        )
+    }
+
+    /// Tag a unitless value with units.
+    pub fn from_untyped(p: &Matrix2D<T>) -> TypedMatrix2D<T, Src, Dst> {
+        TypedMatrix2D::new(
+            p.m11, p.m12,
+            p.m21, p.m22,
+            p.m31, p.m32
+        )
     }
 }

--- a/src/matrix4d.rs
+++ b/src/matrix4d.rs
@@ -9,13 +9,17 @@
 
 use approxeq::ApproxEq;
 use trig::Trig;
-use point::{Point2D, Point4D};
+use point::{TypedPoint2D, TypedPoint4D};
+use matrix2d::TypedMatrix2D;
+use length::UnknownUnit;
+use scale_factor::ScaleFactor;
 use num::{One, Zero};
 use std::ops::{Add, Mul, Sub, Div, Neg};
+use std::marker::PhantomData;
+use std::fmt;
 
 define_matrix! {
-    #[derive(Debug)]
-    pub struct Matrix4D<T> {
+    pub struct TypedMatrix4D<T, Src, Dst> {
         pub m11: T, pub m12: T, pub m13: T, pub m14: T,
         pub m21: T, pub m22: T, pub m23: T, pub m24: T,
         pub m31: T, pub m32: T, pub m33: T, pub m34: T,
@@ -23,55 +27,65 @@ define_matrix! {
     }
 }
 
-impl <T:Add<T, Output=T> +
-       ApproxEq<T> +
-       Copy +
-       Clone +
-       Div<T, Output=T> +
-       Mul<T, Output=T> +
-       Neg<Output=T> +
-       One +
-       PartialOrd +
-       Sub<T, Output=T> +
-       Trig +
-       Zero> Matrix4D<T> {
+pub type Matrix4D<T> = TypedMatrix4D<T, UnknownUnit, UnknownUnit>;
 
+impl<T, Src, Dst> TypedMatrix4D<T, Src, Dst> {
     #[inline]
     pub fn new(
             m11: T, m12: T, m13: T, m14: T,
             m21: T, m22: T, m23: T, m24: T,
             m31: T, m32: T, m33: T, m34: T,
             m41: T, m42: T, m43: T, m44: T)
-         -> Matrix4D<T> {
-        Matrix4D {
+         -> TypedMatrix4D<T, Src, Dst> {
+        TypedMatrix4D {
             m11: m11, m12: m12, m13: m13, m14: m14,
             m21: m21, m22: m22, m23: m23, m24: m24,
             m31: m31, m32: m32, m33: m33, m34: m34,
-            m41: m41, m42: m42, m43: m43, m44: m44
+            m41: m41, m42: m42, m43: m43, m44: m44,
+            _unit: PhantomData,
         }
     }
+}
+
+impl<T: Copy, Src, Dst> Copy for TypedMatrix4D<T, Src, Dst> {}
+
+impl<T: Copy, Src, Dst> Clone for TypedMatrix4D<T, Src, Dst> {
+    fn clone(&self) -> Self { *self }
+}
+
+impl <T, Src, Dst> TypedMatrix4D<T, Src, Dst>
+where T: Copy + Clone +
+         Add<T, Output=T> +
+         Sub<T, Output=T> +
+         Mul<T, Output=T> +
+         Div<T, Output=T> +
+         Neg<Output=T> +
+         ApproxEq<T> +
+         PartialOrd +
+         Trig +
+         One + Zero {
 
     #[inline]
-    pub fn new_2d(m11: T, m12: T, m21: T, m22: T, m41: T, m42: T) -> Matrix4D<T> {
+    pub fn new_2d(m11: T, m12: T, m21: T, m22: T, m41: T, m42: T) -> TypedMatrix4D<T, Src, Dst> {
         let (_0, _1): (T, T) = (Zero::zero(), One::one());
-        Matrix4D {
-            m11: m11, m12: m12, m13:  _0, m14: _0,
-            m21: m21, m22: m22, m23:  _0, m24: _0,
-            m31:  _0, m32:  _0, m33:  _1, m34: _0,
-            m41: m41, m42: m42, m43:  _0, m44: _1
-       }
+        TypedMatrix4D::new(
+            m11, m12, _0, _0,
+            m21, m22, _0, _0,
+             _0,  _0, _1, _0,
+            m41, m42, _0, _1
+       )
     }
 
     pub fn ortho(left: T, right: T,
                  bottom: T, top: T,
-                 near: T, far: T) -> Matrix4D<T> {
+                 near: T, far: T) -> TypedMatrix4D<T, Src, Dst> {
         let tx = -((right + left) / (right - left));
         let ty = -((top + bottom) / (top - bottom));
         let tz = -((far + near) / (far - near));
 
         let (_0, _1): (T, T) = (Zero::zero(), One::one());
         let _2 = _1 + _1;
-        Matrix4D::new(_2 / (right - left),
+        TypedMatrix4D::new(_2 / (right - left),
                       _0,
                       _0,
                       _0,
@@ -93,12 +107,14 @@ impl <T:Add<T, Output=T> +
     }
 
     #[inline]
-    pub fn identity() -> Matrix4D<T> {
+    pub fn identity() -> TypedMatrix4D<T, Src, Dst> {
         let (_0, _1): (T, T) = (Zero::zero(), One::one());
-        Matrix4D::new(_1, _0, _0, _0,
-                      _0, _1, _0, _0,
-                      _0, _0, _1, _0,
-                      _0, _0, _0, _1)
+        TypedMatrix4D::new(
+            _1, _0, _0, _0,
+            _0, _1, _0, _0,
+            _0, _0, _1, _0,
+            _0, _0, _0, _1
+        )
     }
 
 
@@ -113,8 +129,15 @@ impl <T:Add<T, Output=T> +
         self.m33 == _1 && self.m44 == _1
     }
 
+    pub fn to_2d(&self) -> TypedMatrix2D<T, Src, Dst> {
+        TypedMatrix2D::new(
+            self.m11, self.m12,
+            self.m21, self.m22,
+            self.m41, self.m42
+        )
+    }
 
-    pub fn approx_eq(&self, other: &Matrix4D<T>) -> bool {
+    pub fn approx_eq(&self, other: &TypedMatrix4D<T, Src, Dst>) -> bool {
         self.m11.approx_eq(&other.m11) && self.m12.approx_eq(&other.m12) &&
         self.m13.approx_eq(&other.m13) && self.m14.approx_eq(&other.m14) &&
         self.m21.approx_eq(&other.m21) && self.m22.approx_eq(&other.m22) &&
@@ -125,35 +148,46 @@ impl <T:Add<T, Output=T> +
         self.m43.approx_eq(&other.m43) && self.m44.approx_eq(&other.m44)
     }
 
-    pub fn mul(&self, m: &Matrix4D<T>) -> Matrix4D<T> {
-        Matrix4D::new(m.m11*self.m11 + m.m12*self.m21 + m.m13*self.m31 + m.m14*self.m41,
-                     m.m11*self.m12 + m.m12*self.m22 + m.m13*self.m32 + m.m14*self.m42,
-                     m.m11*self.m13 + m.m12*self.m23 + m.m13*self.m33 + m.m14*self.m43,
-                     m.m11*self.m14 + m.m12*self.m24 + m.m13*self.m34 + m.m14*self.m44,
-                     m.m21*self.m11 + m.m22*self.m21 + m.m23*self.m31 + m.m24*self.m41,
-                     m.m21*self.m12 + m.m22*self.m22 + m.m23*self.m32 + m.m24*self.m42,
-                     m.m21*self.m13 + m.m22*self.m23 + m.m23*self.m33 + m.m24*self.m43,
-                     m.m21*self.m14 + m.m22*self.m24 + m.m23*self.m34 + m.m24*self.m44,
-                     m.m31*self.m11 + m.m32*self.m21 + m.m33*self.m31 + m.m34*self.m41,
-                     m.m31*self.m12 + m.m32*self.m22 + m.m33*self.m32 + m.m34*self.m42,
-                     m.m31*self.m13 + m.m32*self.m23 + m.m33*self.m33 + m.m34*self.m43,
-                     m.m31*self.m14 + m.m32*self.m24 + m.m33*self.m34 + m.m34*self.m44,
-                     m.m41*self.m11 + m.m42*self.m21 + m.m43*self.m31 + m.m44*self.m41,
-                     m.m41*self.m12 + m.m42*self.m22 + m.m43*self.m32 + m.m44*self.m42,
-                     m.m41*self.m13 + m.m42*self.m23 + m.m43*self.m33 + m.m44*self.m43,
-                     m.m41*self.m14 + m.m42*self.m24 + m.m43*self.m34 + m.m44*self.m44)
+    pub fn to<Destination>(&self) -> TypedMatrix4D<T, Src, Destination> {
+        TypedMatrix4D::new(
+            self.m11, self.m12, self.m13, self.m14,
+            self.m21, self.m22, self.m23, self.m24,
+            self.m31, self.m32, self.m33, self.m34,
+            self.m41, self.m42, self.m43, self.m44,
+        )
     }
 
-    pub fn invert(&self) -> Matrix4D<T> {
+    pub fn mul<NewSrc>(&self, mat: &TypedMatrix4D<T, NewSrc, Src>) -> TypedMatrix4D<T, NewSrc, Dst> {
+        TypedMatrix4D::new(
+            mat.m11*self.m11 + mat.m12*self.m21 + mat.m13*self.m31 + mat.m14*self.m41,
+            mat.m11*self.m12 + mat.m12*self.m22 + mat.m13*self.m32 + mat.m14*self.m42,
+            mat.m11*self.m13 + mat.m12*self.m23 + mat.m13*self.m33 + mat.m14*self.m43,
+            mat.m11*self.m14 + mat.m12*self.m24 + mat.m13*self.m34 + mat.m14*self.m44,
+            mat.m21*self.m11 + mat.m22*self.m21 + mat.m23*self.m31 + mat.m24*self.m41,
+            mat.m21*self.m12 + mat.m22*self.m22 + mat.m23*self.m32 + mat.m24*self.m42,
+            mat.m21*self.m13 + mat.m22*self.m23 + mat.m23*self.m33 + mat.m24*self.m43,
+            mat.m21*self.m14 + mat.m22*self.m24 + mat.m23*self.m34 + mat.m24*self.m44,
+            mat.m31*self.m11 + mat.m32*self.m21 + mat.m33*self.m31 + mat.m34*self.m41,
+            mat.m31*self.m12 + mat.m32*self.m22 + mat.m33*self.m32 + mat.m34*self.m42,
+            mat.m31*self.m13 + mat.m32*self.m23 + mat.m33*self.m33 + mat.m34*self.m43,
+            mat.m31*self.m14 + mat.m32*self.m24 + mat.m33*self.m34 + mat.m34*self.m44,
+            mat.m41*self.m11 + mat.m42*self.m21 + mat.m43*self.m31 + mat.m44*self.m41,
+            mat.m41*self.m12 + mat.m42*self.m22 + mat.m43*self.m32 + mat.m44*self.m42,
+            mat.m41*self.m13 + mat.m42*self.m23 + mat.m43*self.m33 + mat.m44*self.m43,
+            mat.m41*self.m14 + mat.m42*self.m24 + mat.m43*self.m34 + mat.m44*self.m44
+        )
+    }
+
+    pub fn invert(&self) -> TypedMatrix4D<T, Dst, Src> {
         let det = self.determinant();
 
         if det == Zero::zero() {
-            return Matrix4D::identity();
+            return TypedMatrix4D::identity();
         }
 
         // todo(gw): this could be made faster by special casing
         // for simpler matrix types.
-        let m = Matrix4D::new(
+        let m = TypedMatrix4D::new(
             self.m23*self.m34*self.m42 - self.m24*self.m33*self.m42 +
             self.m24*self.m32*self.m43 - self.m22*self.m34*self.m43 -
             self.m23*self.m32*self.m44 + self.m22*self.m33*self.m44,
@@ -250,75 +284,73 @@ impl <T:Add<T, Output=T> +
         self.m11 * self.m22 * self.m33 * self.m44
     }
 
-    pub fn mul_s(&self, x: T) -> Matrix4D<T> {
-        Matrix4D::new(self.m11 * x, self.m12 * x, self.m13 * x, self.m14 * x,
-                     self.m21 * x, self.m22 * x, self.m23 * x, self.m24 * x,
-                     self.m31 * x, self.m32 * x, self.m33 * x, self.m34 * x,
-                     self.m41 * x, self.m42 * x, self.m43 * x, self.m44 * x)
+    pub fn mul_s(&self, x: T) -> TypedMatrix4D<T, Src, Dst> {
+        TypedMatrix4D::new(
+            self.m11 * x, self.m12 * x, self.m13 * x, self.m14 * x,
+            self.m21 * x, self.m22 * x, self.m23 * x, self.m24 * x,
+            self.m31 * x, self.m32 * x, self.m33 * x, self.m34 * x,
+            self.m41 * x, self.m42 * x, self.m43 * x, self.m44 * x
+        )
     }
 
-    pub fn scale(&self, x: T, y: T, z: T) -> Matrix4D<T> {
-        Matrix4D::new(self.m11 * x, self.m12,     self.m13,     self.m14,
-                     self.m21    , self.m22 * y, self.m23,     self.m24,
-                     self.m31    , self.m32,     self.m33 * z, self.m34,
-                     self.m41    , self.m42,     self.m43,     self.m44)
+    pub fn from_scale_factor(scale: ScaleFactor<T, Src, Dst>) -> TypedMatrix4D<T, Src, Dst> {
+        TypedMatrix4D::create_scale(scale.get(), scale.get(), scale.get())
+    }
+
+    pub fn scale(&self, x: T, y: T, z: T) -> TypedMatrix4D<T, Src, Dst> {
+        TypedMatrix4D::new(
+            self.m11 * x, self.m12,     self.m13,     self.m14,
+            self.m21    , self.m22 * y, self.m23,     self.m24,
+            self.m31    , self.m32,     self.m33 * z, self.m34,
+            self.m41    , self.m42,     self.m43,     self.m44
+        )
     }
 
     /// Returns the given point transformed by this matrix.
     #[inline]
-    pub fn transform_point(&self, p: &Point2D<T>) -> Point2D<T> {
-        Point2D::new(p.x * self.m11 + p.y * self.m21 + self.m41,
-                     p.x * self.m12 + p.y * self.m22 + self.m42)
+    pub fn transform_point(&self, p: &TypedPoint2D<T, Src>) -> TypedPoint2D<T, Dst> {
+        TypedPoint2D::new(p.x * self.m11 + p.y * self.m21 + self.m41,
+                          p.x * self.m12 + p.y * self.m22 + self.m42)
     }
 
     #[inline]
-    pub fn transform_point4d(&self, p: &Point4D<T>) -> Point4D<T> {
+    pub fn transform_point4d(&self, p: &TypedPoint4D<T, Src>) -> TypedPoint4D<T, Dst> {
         let x = p.x * self.m11 + p.y * self.m21 + p.z * self.m31 + self.m41;
         let y = p.x * self.m12 + p.y * self.m22 + p.z * self.m32 + self.m42;
         let z = p.x * self.m13 + p.y * self.m23 + p.z * self.m33 + self.m43;
         let w = p.x * self.m14 + p.y * self.m24 + p.z * self.m34 + self.m44;
-        Point4D::new(x, y, z, w)
+        TypedPoint4D::new(x, y, z, w)
     }
 
-    pub fn to_array(&self) -> [T; 16] {
-        [
-            self.m11, self.m12, self.m13, self.m14,
-            self.m21, self.m22, self.m23, self.m24,
-            self.m31, self.m32, self.m33, self.m34,
-            self.m41, self.m42, self.m43, self.m44
-        ]
-    }
-
-    pub fn translate(&self, x: T, y: T, z: T) -> Matrix4D<T> {
-        let (_0, _1): (T, T) = (Zero::zero(), One::one());
-        let matrix = Matrix4D::new(_1, _0, _0, _0,
-                                   _0, _1, _0, _0,
-                                   _0, _0, _1, _0,
-                                    x,  y,  z, _1);
-        self.mul(&matrix)
+    pub fn translate(&self, x: T, y: T, z: T) -> TypedMatrix4D<T, Src, Dst> {
+        self.mul(&TypedMatrix4D::create_translation(x, y, z))
     }
 
     /// Create a 3d translation matrix
-    pub fn create_translation(x: T, y: T, z: T) -> Matrix4D<T> {
+    pub fn create_translation(x: T, y: T, z: T) -> TypedMatrix4D<T, Src, Dst> {
         let (_0, _1): (T, T) = (Zero::zero(), One::one());
-        Matrix4D::new(_1, _0, _0, _0,
-                      _0, _1, _0, _0,
-                      _0, _0, _1, _0,
-                       x,  y,  z, _1)
+        TypedMatrix4D::new(
+            _1, _0, _0, _0,
+            _0, _1, _0, _0,
+            _0, _0, _1, _0,
+             x,  y,  z, _1
+        )
     }
 
     /// Create a 3d scale matrix
-    pub fn create_scale(x: T, y: T, z: T) -> Matrix4D<T> {
+    pub fn create_scale(x: T, y: T, z: T) -> TypedMatrix4D<T, Src, Dst> {
         let (_0, _1): (T, T) = (Zero::zero(), One::one());
-        Matrix4D::new( x, _0, _0, _0,
-                      _0,  y, _0, _0,
-                      _0, _0,  z, _0,
-                      _0, _0, _0, _1)
+        TypedMatrix4D::new(
+             x, _0, _0, _0,
+            _0,  y, _0, _0,
+            _0, _0,  z, _0,
+            _0, _0, _0, _1
+        )
     }
 
     /// Create a 3d rotation matrix from an angle / axis.
     /// The supplied axis must be normalized.
-    pub fn create_rotation(x: T, y: T, z: T, theta: T) -> Matrix4D<T> {
+    pub fn create_rotation(x: T, y: T, z: T, theta: T) -> TypedMatrix4D<T, Src, Dst> {
         let (_0, _1): (T, T) = (Zero::zero(), One::one());
         let _2 = _1 + _1;
 
@@ -330,7 +362,7 @@ impl <T:Add<T, Output=T> +
         let sc = half_theta.sin() * half_theta.cos();
         let sq = half_theta.sin() * half_theta.sin();
 
-        Matrix4D::new(
+        TypedMatrix4D::new(
             _1 - _2 * (yy + zz) * sq,
             _2 * (x * y * sq - z * sc),
             _2 * (x * z * sq + y * sc),
@@ -355,32 +387,56 @@ impl <T:Add<T, Output=T> +
 
     /// Create a 2d skew matrix.
     /// https://drafts.csswg.org/css-transforms/#funcdef-skew
-    pub fn create_skew(alpha: T, beta: T) -> Matrix4D<T> {
+    pub fn create_skew(alpha: T, beta: T) -> TypedMatrix4D<T, Src, Dst> {
         let (_0, _1): (T, T) = (Zero::zero(), One::one());
         let (sx, sy) = (beta.tan(), alpha.tan());
-        Matrix4D::new(_1, sx, _0, _0,
+        TypedMatrix4D::new(_1, sx, _0, _0,
                       sy, _1, _0, _0,
                       _0, _0, _1, _0,
                       _0, _0, _0, _1)
     }
 
     /// Create a simple perspective projection matrix
-    pub fn create_perspective(d: T) -> Matrix4D<T> {
+    pub fn create_perspective(d: T) -> TypedMatrix4D<T, Src, Dst> {
         let (_0, _1): (T, T) = (Zero::zero(), One::one());
-        Matrix4D::new(_1, _0, _0, _0,
+        TypedMatrix4D::new(_1, _0, _0, _0,
                       _0, _1, _0, _0,
                       _0, _0, _1, -_1 / d,
                       _0, _0, _0, _1)
     }
 }
 
+impl<T: Copy, Src, Dst> TypedMatrix4D<T, Src, Dst> {
+    pub fn to_array(&self) -> [T; 16] {
+        [
+            self.m11, self.m12, self.m13, self.m14,
+            self.m21, self.m22, self.m23, self.m24,
+            self.m31, self.m32, self.m33, self.m34,
+            self.m41, self.m42, self.m43, self.m44
+        ]
+    }
+}
 
+impl<T: Copy + fmt::Debug, Src, Dst> fmt::Debug for TypedMatrix4D<T, Src, Dst> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.to_array().fmt(f)
+    }
+}
+
+impl<T: PartialEq, Src, Dst> PartialEq for TypedMatrix4D<T, Src, Dst> {
+    fn eq(&self, other: &Self) -> bool {
+        self.m11 == other.m11 && self.m12 == other.m12 && self.m13 == other.m13 && self.m14 == other.m14 &&
+        self.m21 == other.m21 && self.m22 == other.m22 && self.m23 == other.m23 && self.m24 == other.m24 &&
+        self.m31 == other.m31 && self.m32 == other.m32 && self.m33 == other.m33 && self.m34 == other.m34 &&
+        self.m41 == other.m41 && self.m42 == other.m42 && self.m43 == other.m43 && self.m44 == other.m44
+    }
+}
 
 #[cfg(test)]
 mod tests {
-    use point::{Point2D};
+    use point::Point2D;
     use super::*;
-    
+
     type Mf32 = Matrix4D<f32>;
 
     #[test]

--- a/src/point.rs
+++ b/src/point.rs
@@ -7,261 +7,357 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use length::Length;
-use size::Size2D;
+use length::{Length, UnknownUnit};
+use scale_factor::ScaleFactor;
+use size::TypedSize2D;
 use num::Zero;
 
 use num_traits::{Float, NumCast};
 use std::fmt;
 use std::ops::{Add, Neg, Mul, Sub, Div};
+use std::marker::PhantomData;
+use std::cmp::{PartialEq, Eq};
+use std::hash::{Hash, Hasher};
 
-define_matrix! {
+define_vector! {
     #[derive(RustcDecodable, RustcEncodable)]
-    pub struct Point2D<T> {
+    pub struct TypedPoint2D<T, U> {
         pub x: T,
         pub y: T,
     }
 }
 
-impl<T: Zero> Point2D<T> {
-    pub fn zero() -> Point2D<T> {
-        Point2D { x: Zero::zero(), y: Zero::zero() }
+pub type Point2D<T> = TypedPoint2D<T, UnknownUnit>;
+
+impl<T: Copy, U> Copy for TypedPoint2D<T, U> {}
+
+impl<T: Clone, U> Clone for TypedPoint2D<T, U> {
+    fn clone(&self) -> TypedPoint2D<T, U> {
+        TypedPoint2D::new(self.x.clone(), self.y.clone())
     }
 }
 
-impl<T: fmt::Debug> fmt::Debug for Point2D<T> {
+impl<T: PartialEq, U> PartialEq<TypedPoint2D<T, U>> for TypedPoint2D<T, U> {
+    fn eq(&self, other: &TypedPoint2D<T, U>) -> bool {
+        self.x.eq(&other.x) && self.y.eq(&other.y)
+    }
+}
+
+impl<T: Eq, U> Eq for TypedPoint2D<T, U> {}
+
+impl<T: Hash, U> Hash for TypedPoint2D<T, U> {
+    fn hash<H: Hasher>(&self, h: &mut H) {
+        self.x.hash(h);
+        self.y.hash(h);
+    }
+}
+
+impl<T: Zero, U> TypedPoint2D<T, U> {
+    pub fn zero() -> TypedPoint2D<T, U> {
+        TypedPoint2D::new(Zero::zero(), Zero::zero())
+    }
+}
+
+impl<T: fmt::Debug, U> fmt::Debug for TypedPoint2D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "({:?},{:?})", self.x, self.y)
     }
 }
 
-impl<T: fmt::Display> fmt::Display for Point2D<T> {
+impl<T: fmt::Display, U> fmt::Display for TypedPoint2D<T, U> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(formatter, "({},{})", self.x, self.y)
     }
 }
 
-impl<T> Point2D<T> {
-    pub fn new(x: T, y: T) -> Point2D<T> {
-        Point2D {x: x, y: y}
+impl<T, U> TypedPoint2D<T, U> {
+    pub fn new(x: T, y: T) -> TypedPoint2D<T, U> {
+        TypedPoint2D { x: x, y: y, _unit: PhantomData }
     }
 }
 
-impl<T: Mul<T, Output=T> +
-        Add<T, Output=T> +
-        Sub<T, Output=T> +
-        Copy> Point2D<T> {
+impl<T: Clone, U> TypedPoint2D<T, U> {
+    pub fn from_lengths(x: Length<T, U>, y: Length<T, U>) -> TypedPoint2D<T, U> {
+        TypedPoint2D::new(x.get(), y.get())
+    }
+}
+
+impl<T: Clone, U> TypedPoint2D<T, U> {
+    pub fn x_typed(&self) -> Length<T, U> { Length::new(self.x.clone()) }
+    pub fn y_typed(&self) -> Length<T, U> { Length::new(self.y.clone()) }
+}
+
+impl<T, U> TypedPoint2D<T, U>
+where T: Copy + Mul<T, Output=T> + Add<T, Output=T> + Sub<T, Output=T> {
     #[inline]
-    pub fn dot(self, other: Point2D<T>) -> T {
-        self.x * other.x +
-        self.y * other.y
+    pub fn dot(self, other: TypedPoint2D<T, U>) -> T {
+        self.x * other.x + self.y * other.y
     }
 
     #[inline]
-    pub fn cross(self, other: Point2D<T>) -> T {
+    pub fn cross(self, other: TypedPoint2D<T, U>) -> T {
         self.x * other.y - self.y * other.x
     }
 }
 
-impl<T:Clone + Add<T, Output=T>> Add for Point2D<T> {
-    type Output = Point2D<T>;
-    fn add(self, other: Point2D<T>) -> Point2D<T> {
-        Point2D::new(self.x + other.x, self.y + other.y)
+impl<T: Clone + Add<T, Output=T>, U> Add for TypedPoint2D<T, U> {
+    type Output = TypedPoint2D<T, U>;
+    fn add(self, other: TypedPoint2D<T, U>) -> TypedPoint2D<T, U> {
+        TypedPoint2D::new(self.x + other.x, self.y + other.y)
     }
 }
 
-impl<T:Clone + Add<T, Output=T>> Add<Size2D<T>> for Point2D<T> {
-    type Output = Point2D<T>;
-    fn add(self, other: Size2D<T>) -> Point2D<T> {
-        Point2D::new(self.x + other.width, self.y + other.height)
+impl<T: Clone + Add<T, Output=T>, U> Add<TypedSize2D<T, U>> for TypedPoint2D<T, U> {
+    type Output = TypedPoint2D<T, U>;
+    fn add(self, other: TypedSize2D<T, U>) -> TypedPoint2D<T, U> {
+        TypedPoint2D::new(self.x + other.width, self.y + other.height)
     }
 }
 
-impl<T: Copy + Add<T, Output=T>> Point2D<T> {
-    pub fn add_size(&self, other: &Size2D<T>) -> Point2D<T> {
-        Point2D { x: self.x + other.width, y: self.y + other.height }
+impl<T: Copy + Add<T, Output=T>, U> TypedPoint2D<T, U> {
+    pub fn add_size(&self, other: &TypedSize2D<T, U>) -> TypedPoint2D<T, U> {
+        TypedPoint2D::new(self.x + other.width, self.y + other.height)
     }
 }
 
-impl<T:Clone + Sub<T, Output=T>> Sub for Point2D<T> {
-    type Output = Point2D<T>;
-    fn sub(self, other: Point2D<T>) -> Point2D<T> {
-        Point2D::new(self.x - other.x, self.y - other.y)
+impl<T: Clone + Sub<T, Output=T>, U> Sub for TypedPoint2D<T, U> {
+    type Output = TypedPoint2D<T, U>;
+    fn sub(self, other: TypedPoint2D<T, U>) -> TypedPoint2D<T, U> {
+        TypedPoint2D::new(self.x - other.x, self.y - other.y)
     }
 }
 
-impl <T:Clone + Neg<Output=T>> Neg for Point2D<T> {
-    type Output = Point2D<T>;
+impl <T: Clone + Neg<Output=T>, U> Neg for TypedPoint2D<T, U> {
+    type Output = TypedPoint2D<T, U>;
     #[inline]
-    fn neg(self) -> Point2D<T> {
-        Point2D::new(-self.x, -self.y)
+    fn neg(self) -> TypedPoint2D<T, U> {
+        TypedPoint2D::new(-self.x, -self.y)
     }
 }
 
-impl<T: Float> Point2D<T> {
-    pub fn min(self, other: Point2D<T>) -> Point2D<T> {
-         Point2D::new(self.x.min(other.x), self.y.min(other.y))
+impl<T: Float, U> TypedPoint2D<T, U> {
+    pub fn min(self, other: TypedPoint2D<T, U>) -> TypedPoint2D<T, U> {
+         TypedPoint2D::new(self.x.min(other.x), self.y.min(other.y))
     }
 
-    pub fn max(self, other: Point2D<T>) -> Point2D<T> {
-        Point2D::new(self.x.max(other.x), self.y.max(other.y))
+    pub fn max(self, other: TypedPoint2D<T, U>) -> TypedPoint2D<T, U> {
+        TypedPoint2D::new(self.x.max(other.x), self.y.max(other.y))
     }
 }
 
-impl<Scale: Copy, T0: Mul<Scale, Output=T1>, T1: Clone> Mul<Scale> for Point2D<T0> {
-    type Output = Point2D<T1>;
+impl<T: Copy + Mul<T, Output=T>, U> Mul<T> for TypedPoint2D<T, U> {
+    type Output = TypedPoint2D<T, U>;
     #[inline]
-    fn mul(self, scale: Scale) -> Point2D<T1> {
-        Point2D::new(self.x * scale, self.y * scale)
+    fn mul(self, scale: T) -> TypedPoint2D<T, U> {
+        TypedPoint2D::new(self.x * scale, self.y * scale)
     }
 }
 
-impl<Scale: Copy, T0: Div<Scale, Output=T1>, T1: Clone> Div<Scale> for Point2D<T0> {
-    type Output = Point2D<T1>;
+impl<T: Copy + Div<T, Output=T>, U> Div<T> for TypedPoint2D<T, U> {
+    type Output = TypedPoint2D<T, U>;
     #[inline]
-    fn div(self, scale: Scale) -> Point2D<T1> {
-        Point2D::new(self.x / scale, self.y / scale)
+    fn div(self, scale: T) -> TypedPoint2D<T, U> {
+        TypedPoint2D::new(self.x / scale, self.y / scale)
     }
 }
 
-// Convenient aliases for Point2D with typed units
-
-pub type TypedPoint2D<Unit, T> = Point2D<Length<Unit, T>>;
-
-impl<Unit, T: Clone> TypedPoint2D<Unit, T> {
-    pub fn typed(x: T, y: T) -> TypedPoint2D<Unit, T> {
-        Point2D::new(Length::new(x), Length::new(y))
+impl<T: Copy + Mul<T, Output=T>, U1, U2> Mul<ScaleFactor<T, U1, U2>> for TypedPoint2D<T, U1> {
+    type Output = TypedPoint2D<T, U2>;
+    #[inline]
+    fn mul(self, scale: ScaleFactor<T, U1, U2>) -> TypedPoint2D<T, U2> {
+        TypedPoint2D::new(self.x * scale.get(), self.y * scale.get())
     }
+}
 
+impl<T: Copy + Div<T, Output=T>, U1, U2> Div<ScaleFactor<T, U1, U2>> for TypedPoint2D<T, U2> {
+    type Output = TypedPoint2D<T, U1>;
+    #[inline]
+    fn div(self, scale: ScaleFactor<T, U1, U2>) -> TypedPoint2D<T, U1> {
+        TypedPoint2D::new(self.x / scale.get(), self.y / scale.get())
+    }
+}
+
+// Convenient aliases for TypedPoint2D with typed units
+
+impl<T: Clone, U> TypedPoint2D<T, U> {
     /// Drop the units, preserving only the numeric value.
     pub fn to_untyped(&self) -> Point2D<T> {
-        Point2D::new(self.x.get(), self.y.get())
+        TypedPoint2D::new(self.x.clone(), self.y.clone())
     }
 
     /// Tag a unitless value with units.
-    pub fn from_untyped(p: &Point2D<T>) -> TypedPoint2D<Unit, T> {
-        Point2D::new(Length::new(p.x.clone()), Length::new(p.y.clone()))
+    pub fn from_untyped(p: &Point2D<T>) -> TypedPoint2D<T, U> {
+        TypedPoint2D::new(p.x.clone(), p.y.clone())
     }
 }
 
-impl<Unit, T0: NumCast + Clone> Point2D<Length<Unit, T0>> {
+impl<T0: NumCast + Clone, U> TypedPoint2D<T0, U> {
     /// Cast from one numeric representation to another, preserving the units.
-    pub fn cast<T1: NumCast + Clone>(&self) -> Option<Point2D<Length<Unit, T1>>> {
-        match (self.x.cast(), self.y.cast()) {
-            (Some(x), Some(y)) => Some(Point2D::new(x, y)),
+    pub fn cast<T1: NumCast + Clone>(&self) -> Option<TypedPoint2D<T1, U>> {
+        match (NumCast::from(self.x.clone()), NumCast::from(self.y.clone())) {
+            (Some(x), Some(y)) => Some(TypedPoint2D::new(x, y)),
             _ => None
         }
     }
 }
 
 // Convenience functions for common casts
-impl<Unit, T: NumCast + Clone> Point2D<Length<Unit, T>> {
-    pub fn as_f32(&self) -> Point2D<Length<Unit, f32>> {
+impl<T: NumCast + Clone, U> TypedPoint2D<T, U> {
+    pub fn as_f32(&self) -> TypedPoint2D<f32, U> {
         self.cast().unwrap()
     }
 
-    pub fn as_uint(&self) -> Point2D<Length<Unit, usize>> {
+    pub fn as_uint(&self) -> TypedPoint2D<usize, U> {
         self.cast().unwrap()
     }
 }
 
-define_matrix! {
+define_vector! {
     #[derive(RustcDecodable, RustcEncodable)]
-    pub struct Point3D<T> {
+    pub struct TypedPoint3D<T, U> {
         pub x: T,
         pub y: T,
         pub z: T,
     }
 }
 
-impl<T: Zero> Point3D<T> {
-    #[inline]
-    pub fn zero() -> Point3D<T> {
-        Point3D { x: Zero::zero(), y: Zero::zero(), z: Zero::zero() }
+pub type Point3D<T> = TypedPoint3D<T, UnknownUnit>;
+
+impl<T: Hash, U> Hash for TypedPoint3D<T, U> {
+    fn hash<H: Hasher>(&self, h: &mut H) {
+        self.x.hash(h);
+        self.y.hash(h);
+        self.z.hash(h);
     }
 }
 
-impl<T: fmt::Debug> fmt::Debug for Point3D<T> {
+impl<T: Zero, U> TypedPoint3D<T, U> {
+    #[inline]
+    pub fn zero() -> TypedPoint3D<T, U> {
+        TypedPoint3D::new(Zero::zero(), Zero::zero(), Zero::zero())
+    }
+}
+
+impl<T: Copy, U> Copy for TypedPoint3D<T, U> {}
+
+impl<T: Clone, U> Clone for TypedPoint3D<T, U> {
+    fn clone(&self) -> TypedPoint3D<T, U> {
+        TypedPoint3D::new(self.x.clone(), self.y.clone(), self.z.clone())
+    }
+}
+
+impl<T: PartialEq, U> PartialEq<TypedPoint3D<T, U>> for TypedPoint3D<T, U> {
+    fn eq(&self, other: &TypedPoint3D<T, U>) -> bool {
+        self.x.eq(&other.x) && self.y.eq(&other.y) && self.z.eq(&other.z)
+    }
+}
+
+impl<T: Eq, U> Eq for TypedPoint3D<T, U> {}
+
+impl<T: fmt::Debug, U> fmt::Debug for TypedPoint3D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "({:?},{:?},{:?})", self.x, self.y, self.z)
     }
 }
 
-impl<T: fmt::Display> fmt::Display for Point3D<T> {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "({},{},{})", self.x, self.y, self.z)
+impl<T: fmt::Display, U> fmt::Display for TypedPoint3D<T, U> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({},{},{})", self.x, self.y, self.z)
     }
 }
 
-impl<T> Point3D<T> {
+impl<T, U> TypedPoint3D<T, U> {
     #[inline]
-    pub fn new(x: T, y: T, z: T) -> Point3D<T> {
-        Point3D {x: x, y: y, z: z}
+    pub fn new(x: T, y: T, z: T) -> TypedPoint3D<T, U> {
+        TypedPoint3D { x: x, y: y, z: z, _unit: PhantomData }
     }
+}
+
+impl<T: Clone, U> TypedPoint3D<T, U> {
+    pub fn from_lengths(x: Length<T, U>, y: Length<T, U>, z: Length<T, U>) -> TypedPoint3D<T, U> {
+        TypedPoint3D::new(x.get(), y.get(), z.get())
+    }
+}
+
+impl<T: Clone, U> TypedPoint3D<T, U> {
+    pub fn x_typed(&self) -> Length<T, U> { Length::new(self.x.clone()) }
+    pub fn y_typed(&self) -> Length<T, U> { Length::new(self.y.clone()) }
+    pub fn z_typed(&self) -> Length<T, U> { Length::new(self.z.clone()) }
 }
 
 impl<T: Mul<T, Output=T> +
         Add<T, Output=T> +
         Sub<T, Output=T> +
-        Copy> Point3D<T> {
+        Copy, U> TypedPoint3D<T, U> {
     #[inline]
-    pub fn dot(self, other: Point3D<T>) -> T {
+    pub fn dot(self, other: TypedPoint3D<T, U>) -> T {
         self.x * other.x +
         self.y * other.y +
         self.z * other.z
     }
 
     #[inline]
-    pub fn cross(self, other: Point3D<T>) -> Point3D<T> {
-        Point3D {
-            x: self.y * other.z - self.z * other.y,
-            y: self.z * other.x - self.x * other.z,
-            z: self.x * other.y - self.y * other.x,
-        }
+    pub fn cross(self, other: TypedPoint3D<T, U>) -> TypedPoint3D<T, U> {
+        TypedPoint3D::new(self.y * other.z - self.z * other.y,
+                          self.z * other.x - self.x * other.z,
+                          self.x * other.y - self.y * other.x)
     }
 }
 
-impl<T:Clone + Add<T, Output=T>> Add for Point3D<T> {
-    type Output = Point3D<T>;
-    fn add(self, other: Point3D<T>) -> Point3D<T> {
-        Point3D::new(self.x + other.x,
-                     self.y + other.y,
-                     self.z + other.z)
+impl<T: Clone + Add<T, Output=T>, U> Add for TypedPoint3D<T, U> {
+    type Output = TypedPoint3D<T, U>;
+    fn add(self, other: TypedPoint3D<T, U>) -> TypedPoint3D<T, U> {
+        TypedPoint3D::new(self.x + other.x,
+                          self.y + other.y,
+                          self.z + other.z)
     }
 }
 
-impl<T:Clone + Sub<T, Output=T>> Sub for Point3D<T> {
-    type Output = Point3D<T>;
-    fn sub(self, other: Point3D<T>) -> Point3D<T> {
-        Point3D::new(self.x - other.x,
-                     self.y - other.y,
-                     self.z - other.z)
+impl<T: Clone + Sub<T, Output=T>, U> Sub for TypedPoint3D<T, U> {
+    type Output = TypedPoint3D<T, U>;
+    fn sub(self, other: TypedPoint3D<T, U>) -> TypedPoint3D<T, U> {
+        TypedPoint3D::new(self.x - other.x,
+                          self.y - other.y,
+                          self.z - other.z)
     }
 }
 
-impl <T:Clone + Neg<Output=T>> Neg for Point3D<T> {
-    type Output = Point3D<T>;
+impl <T: Clone + Neg<Output=T>, U> Neg for TypedPoint3D<T, U> {
+    type Output = TypedPoint3D<T, U>;
     #[inline]
-    fn neg(self) -> Point3D<T> {
-        Point3D::new(-self.x, -self.y, -self.z)
+    fn neg(self) -> TypedPoint3D<T, U> {
+        TypedPoint3D::new(-self.x, -self.y, -self.z)
     }
 }
 
-impl<T: Float> Point3D<T> {
-    pub fn min(self, other: Point3D<T>) -> Point3D<T> {
-         Point3D::new(self.x.min(other.x), self.y.min(other.y),
-                      self.z.min(other.z))
+impl<T: Float, U> TypedPoint3D<T, U> {
+    pub fn min(self, other: TypedPoint3D<T, U>) -> TypedPoint3D<T, U> {
+         TypedPoint3D::new(self.x.min(other.x),
+                           self.y.min(other.y),
+                           self.z.min(other.z))
     }
 
-    pub fn max(self, other: Point3D<T>) -> Point3D<T> {
-        Point3D::new(self.x.max(other.x), self.y.max(other.y),
+    pub fn max(self, other: TypedPoint3D<T, U>) -> TypedPoint3D<T, U> {
+        TypedPoint3D::new(self.x.max(other.x), self.y.max(other.y),
                      self.z.max(other.z))
     }
 }
 
-define_matrix! {
+impl<T: Clone, U> TypedPoint3D<T, U> {
+    /// Drop the units, preserving only the numeric value.
+    pub fn to_untyped(&self) -> Point3D<T> {
+        TypedPoint3D::new(self.x.clone(), self.y.clone(), self.z.clone())
+    }
+
+    /// Tag a unitless value with units.
+    pub fn from_untyped(p: &Point3D<T>) -> TypedPoint3D<T, U> {
+        TypedPoint3D::new(p.x.clone(), p.y.clone(), p.z.clone())
+    }
+}
+
+define_vector! {
     #[derive(RustcDecodable, RustcEncodable)]
-    pub struct Point4D<T> {
+    pub struct TypedPoint4D<T, U> {
         pub x: T,
         pub y: T,
         pub z: T,
@@ -269,77 +365,129 @@ define_matrix! {
     }
 }
 
-impl<T: Zero> Point4D<T> {
-    #[inline]
-    pub fn zero() -> Point4D<T> {
-        Point4D {
-            x: Zero::zero(),
-            y: Zero::zero(),
-            z: Zero::zero(),
-            w: Zero::zero()
-        }
+pub type Point4D<T> = TypedPoint4D<T, UnknownUnit>;
+
+impl<T: Copy, U> Copy for TypedPoint4D<T, U> {}
+
+impl<T: Clone, U> Clone for TypedPoint4D<T, U> {
+    fn clone(&self) -> TypedPoint4D<T, U> {
+        TypedPoint4D::new(self.x.clone(),
+                          self.y.clone(),
+                          self.z.clone(),
+                          self.w.clone())
     }
 }
 
-impl<T: fmt::Debug> fmt::Debug for Point4D<T> {
+impl<T: PartialEq, U> PartialEq<TypedPoint4D<T, U>> for TypedPoint4D<T, U> {
+    fn eq(&self, other: &TypedPoint4D<T, U>) -> bool {
+        self.x.eq(&other.x) && self.y.eq(&other.y) && self.z.eq(&other.z) && self.w.eq(&other.w)
+    }
+}
+
+impl<T: Eq, U> Eq for TypedPoint4D<T, U> {}
+
+impl<T: Hash, U> Hash for TypedPoint4D<T, U> {
+    fn hash<H: Hasher>(&self, h: &mut H) {
+        self.x.hash(h);
+        self.y.hash(h);
+        self.z.hash(h);
+        self.w.hash(h);
+    }
+}
+
+impl<T: Zero, U> TypedPoint4D<T, U> {
+    #[inline]
+    pub fn zero() -> TypedPoint4D<T, U> {
+        TypedPoint4D::new(Zero::zero(), Zero::zero(), Zero::zero(), Zero::zero())
+    }
+}
+
+impl<T: fmt::Debug, U> fmt::Debug for TypedPoint4D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "({:?},{:?},{:?},{:?})", self.x, self.y, self.z, self.w)
     }
 }
 
-impl<T: fmt::Display> fmt::Display for Point4D<T> {
+impl<T: fmt::Display, U> fmt::Display for TypedPoint4D<T, U> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(formatter, "({},{},{},{})", self.x, self.y, self.z, self.w)
     }
 }
 
-impl<T> Point4D<T> {
+impl<T, U> TypedPoint4D<T, U> {
     #[inline]
-    pub fn new(x: T, y: T, z: T, w: T) -> Point4D<T> {
-        Point4D {x: x, y: y, z: z, w: w}
+    pub fn new(x: T, y: T, z: T, w: T) -> TypedPoint4D<T, U> {
+        TypedPoint4D { x: x, y: y, z: z, w: w, _unit: PhantomData }
     }
 }
 
-impl<T:Clone + Add<T, Output=T>> Add for Point4D<T> {
-    type Output = Point4D<T>;
-    fn add(self, other: Point4D<T>) -> Point4D<T> {
-        Point4D::new(self.x + other.x,
-                     self.y + other.y,
-                     self.z + other.z,
-                     self.w + other.w)
+impl<T: Clone, U> TypedPoint4D<T, U> {
+    pub fn from_lengths(x: Length<T, U>,
+                        y: Length<T, U>,
+                        z: Length<T, U>,
+                        w: Length<T, U>) -> TypedPoint4D<T, U> {
+        TypedPoint4D::new(x.get(), y.get(), z.get(), w.get())
     }
 }
 
-impl<T:Clone + Sub<T, Output=T>> Sub for Point4D<T> {
-    type Output = Point4D<T>;
-    fn sub(self, other: Point4D<T>) -> Point4D<T> {
-        Point4D::new(self.x - other.x,
-                     self.y - other.y,
-                     self.z - other.z,
-                     self.w - other.w)
+impl<T: Clone, U> TypedPoint4D<T, U> {
+    pub fn x_typed(&self) -> Length<T, U> { Length::new(self.x.clone()) }
+    pub fn y_typed(&self) -> Length<T, U> { Length::new(self.y.clone()) }
+    pub fn z_typed(&self) -> Length<T, U> { Length::new(self.z.clone()) }
+    pub fn w_typed(&self) -> Length<T, U> { Length::new(self.w.clone()) }
+}
+
+impl<T: Clone + Add<T, Output=T>, U> Add for TypedPoint4D<T, U> {
+    type Output = TypedPoint4D<T, U>;
+    fn add(self, other: TypedPoint4D<T, U>) -> TypedPoint4D<T, U> {
+        TypedPoint4D::new(self.x + other.x,
+                          self.y + other.y,
+                          self.z + other.z,
+                          self.w + other.w)
     }
 }
 
-impl <T:Clone + Neg<Output=T>> Neg for Point4D<T> {
-    type Output = Point4D<T>;
+impl<T: Clone + Sub<T, Output=T>, U> Sub for TypedPoint4D<T, U> {
+    type Output = TypedPoint4D<T, U>;
+    fn sub(self, other: TypedPoint4D<T, U>) -> TypedPoint4D<T, U> {
+        TypedPoint4D::new(self.x - other.x,
+                          self.y - other.y,
+                          self.z - other.z,
+                          self.w - other.w)
+    }
+}
+
+impl <T: Clone + Neg<Output=T>, U> Neg for TypedPoint4D<T, U> {
+    type Output = TypedPoint4D<T, U>;
     #[inline]
-    fn neg(self) -> Point4D<T> {
-        Point4D::new(-self.x, -self.y, -self.z, -self.w)
+    fn neg(self) -> TypedPoint4D<T, U> {
+        TypedPoint4D::new(-self.x, -self.y, -self.z, -self.w)
     }
 }
 
-impl<T: Float> Point4D<T> {
-    pub fn min(self, other: Point4D<T>) -> Point4D<T> {
-         Point4D::new(self.x.min(other.x), self.y.min(other.y),
-                      self.z.min(other.z), self.w.min(other.w))
+impl<T: Float, U> TypedPoint4D<T, U> {
+    pub fn min(self, other: TypedPoint4D<T, U>) -> TypedPoint4D<T, U> {
+         TypedPoint4D::new(self.x.min(other.x), self.y.min(other.y),
+                           self.z.min(other.z), self.w.min(other.w))
     }
 
-    pub fn max(self, other: Point4D<T>) -> Point4D<T> {
-        Point4D::new(self.x.max(other.x), self.y.max(other.y),
-                     self.z.max(other.z), self.w.max(other.w))
+    pub fn max(self, other: TypedPoint4D<T, U>) -> TypedPoint4D<T, U> {
+        TypedPoint4D::new(self.x.max(other.x), self.y.max(other.y),
+                          self.z.max(other.z), self.w.max(other.w))
     }
 }
 
+impl<T: Clone, U> TypedPoint4D<T, U> {
+    /// Drop the units, preserving only the numeric value.
+    pub fn to_untyped(&self) -> Point4D<T> {
+        TypedPoint4D::new(self.x.clone(), self.y.clone(), self.z.clone(), self.w.clone())
+    }
+
+    /// Tag a unitless value with units.
+    pub fn from_untyped(p: &Point4D<T>) -> TypedPoint4D<T, U> {
+        TypedPoint4D::new(p.x.clone(), p.y.clone(), p.z.clone(), p.w.clone())
+    }
+}
 
 #[cfg(test)]
 mod point2d {
@@ -347,7 +495,7 @@ mod point2d {
 
     #[test]
     pub fn test_scalar_mul() {
-        let p1 = Point2D::new(3.0, 5.0);
+        let p1: Point2D<f32> = Point2D::new(3.0, 5.0);
 
         let result = p1 * 5.0;
 
@@ -356,15 +504,15 @@ mod point2d {
 
     #[test]
     pub fn test_dot() {
-        let p1 = Point2D::new(2.0, 7.0);
-        let p2 = Point2D::new(13.0, 11.0);
+        let p1: Point2D<f32> = Point2D::new(2.0, 7.0);
+        let p2: Point2D<f32> = Point2D::new(13.0, 11.0);
         assert_eq!(p1.dot(p2), 103.0);
     }
 
     #[test]
     pub fn test_cross() {
-        let p1 = Point2D::new(4.0, 7.0);
-        let p2 = Point2D::new(13.0, 8.0);
+        let p1: Point2D<f32> = Point2D::new(4.0, 7.0);
+        let p2: Point2D<f32> = Point2D::new(13.0, 8.0);
         let r = p1.cross(p2);
         assert_eq!(r, -59.0);
     }
@@ -400,27 +548,27 @@ mod typedpoint2d {
     #[derive(Debug, Copy, Clone)]
     pub enum Cm {}
 
-    pub type Point2DMm<T> = TypedPoint2D<Mm, T>;
-    pub type Point2DCm<T> = TypedPoint2D<Cm, T>;
+    pub type Point2DMm<T> = TypedPoint2D<T, Mm>;
+    pub type Point2DCm<T> = TypedPoint2D<T, Cm>;
 
     #[test]
     pub fn test_add() {
-        let p1 = Point2DMm::typed(1.0, 2.0);
-        let p2 = Point2DMm::typed(3.0, 4.0);
+        let p1 = Point2DMm::new(1.0, 2.0);
+        let p2 = Point2DMm::new(3.0, 4.0);
 
         let result = p1 + p2;
 
-        assert_eq!(result, Point2DMm::typed(4.0, 6.0));
+        assert_eq!(result, Point2DMm::new(4.0, 6.0));
     }
 
     #[test]
     pub fn test_scalar_mul() {
-        let p1 = Point2DMm::typed(1.0, 2.0);
-        let cm_per_mm: ScaleFactor<Mm, Cm, f32> = ScaleFactor::new(0.1);
+        let p1 = Point2DMm::new(1.0, 2.0);
+        let cm_per_mm: ScaleFactor<f32, Mm, Cm> = ScaleFactor::new(0.1);
 
         let result = p1 * cm_per_mm;
 
-        assert_eq!(result, Point2DCm::typed(0.1, 0.2));
+        assert_eq!(result, Point2DCm::new(0.1, 0.2));
     }
 }
 

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -7,10 +7,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use length::Length;
+use length::{Length, UnknownUnit};
+use scale_factor::ScaleFactor;
 use num::Zero;
-use point::Point2D;
-use size::Size2D;
+use point::TypedPoint2D;
+use size::TypedSize2D;
 
 use heapsize::HeapSizeOf;
 use num_traits::NumCast;
@@ -19,31 +20,30 @@ use std::cmp::PartialOrd;
 use std::fmt;
 use std::ops::{Add, Sub, Mul, Div};
 
-#[derive(Clone, Copy, Eq, RustcDecodable, RustcEncodable, PartialEq)]
-pub struct Rect<T> {
-    pub origin: Point2D<T>,
-    pub size: Size2D<T>,
+#[derive(RustcDecodable, RustcEncodable)]
+pub struct TypedRect<T, U = UnknownUnit> {
+    pub origin: TypedPoint2D<T, U>,
+    pub size: TypedSize2D<T, U>,
 }
 
-impl<T: HeapSizeOf> HeapSizeOf for Rect<T> {
+pub type Rect<T> = TypedRect<T, UnknownUnit>;
+
+impl<T: HeapSizeOf, U> HeapSizeOf for TypedRect<T, U> {
     fn heap_size_of_children(&self) -> usize {
         self.origin.heap_size_of_children() + self.size.heap_size_of_children()
     }
 }
 
-impl<T: Clone + Deserialize> Deserialize for Rect<T> {
+impl<T: Clone + Deserialize, U> Deserialize for TypedRect<T, U> {
     fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
         where D: Deserializer
     {
         let (origin, size) = try!(Deserialize::deserialize(deserializer));
-        Ok(Rect {
-            origin: origin,
-            size: size,
-        })
+        Ok(TypedRect::new(origin, size))
     }
 }
 
-impl<T: Serialize> Serialize for Rect<T> {
+impl<T: Serialize, U> Serialize for TypedRect<T, U> {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: Serializer
     {
@@ -51,30 +51,47 @@ impl<T: Serialize> Serialize for Rect<T> {
     }
 }
 
-impl<T: fmt::Debug> fmt::Debug for Rect<T> {
-   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Rect({:?} at {:?})", self.size, self.origin)
+impl<T: Copy, U> Copy for TypedRect<T, U> {}
+
+impl<T: Clone, U> Clone for TypedRect<T, U> {
+    fn clone(&self) -> TypedRect<T, U> {
+        TypedRect::new(self.origin.clone(), self.size.clone())
     }
 }
 
-impl<T: fmt::Display> fmt::Display for Rect<T> {
+impl<T: PartialEq, U> PartialEq<TypedRect<T, U>> for TypedRect<T, U> {
+    fn eq(&self, other: &TypedRect<T, U>) -> bool {
+        self.origin.eq(&other.origin) && self.size.eq(&other.size)
+    }
+}
+
+impl<T: Eq, U> Eq for TypedRect<T, U> {}
+
+impl<T: fmt::Debug, U> fmt::Debug for TypedRect<T, U> {
+   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "TypedRect({:?} at {:?})", self.size, self.origin)
+    }
+}
+
+impl<T: fmt::Display, U> fmt::Display for TypedRect<T, U> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(formatter, "Rect({} at {})", self.size, self.origin)
     }
 }
 
-impl<T: Clone> Rect<T> {
-    pub fn new(origin: Point2D<T>, size: Size2D<T>) -> Rect<T> {
-        Rect {
+impl<T, U> TypedRect<T, U> {
+    pub fn new(origin: TypedPoint2D<T, U>, size: TypedSize2D<T, U>) -> TypedRect<T, U> {
+        TypedRect {
             origin: origin,
-            size: size
+            size: size,
         }
     }
 }
 
-impl<T: Copy + Clone + PartialOrd + Add<T, Output=T> + Sub<T, Output=T>> Rect<T> {
+impl<T, U> TypedRect<T, U>
+where T: Copy + Clone + PartialOrd + Add<T, Output=T> + Sub<T, Output=T> {
     #[inline]
-    pub fn intersects(&self, other: &Rect<T>) -> bool {
+    pub fn intersects(&self, other: &TypedRect<T, U>) -> bool {
         self.origin.x < other.origin.x + other.size.width &&
        other.origin.x <  self.origin.x + self.size.width &&
         self.origin.y < other.origin.y + other.size.height &&
@@ -102,103 +119,128 @@ impl<T: Copy + Clone + PartialOrd + Add<T, Output=T> + Sub<T, Output=T>> Rect<T>
     }
 
     #[inline]
-    pub fn intersection(&self, other: &Rect<T>) -> Option<Rect<T>> {
+    pub fn max_x_typed(&self) -> Length<T, U> {
+        Length::new(self.max_x())
+    }
+
+    #[inline]
+    pub fn min_x_typed(&self) -> Length<T, U> {
+        Length::new(self.min_x())
+    }
+
+    #[inline]
+    pub fn max_y_typed(&self) -> Length<T, U> {
+        Length::new(self.max_y())
+    }
+
+    #[inline]
+    pub fn min_y_typed(&self) -> Length<T, U> {
+        Length::new(self.min_y())
+    }
+
+    #[inline]
+    pub fn intersection(&self, other: &TypedRect<T, U>) -> Option<TypedRect<T, U>> {
         if !self.intersects(other) {
             return None;
         }
 
-        let upper_left = Point2D::new(max(self.min_x(), other.min_x()),
+        let upper_left = TypedPoint2D::new(max(self.min_x(), other.min_x()),
                                       max(self.min_y(), other.min_y()));
-        let lower_right = Point2D::new(min(self.max_x(), other.max_x()),
-                                       min(self.max_y(), other.max_y()));
+        let lower_right_x = min(self.max_x(), other.max_x());
+        let lower_right_y = min(self.max_y(), other.max_y());
 
-        Some(Rect::new(upper_left, Size2D::new(lower_right.x - upper_left.x,
-                                               lower_right.y - upper_left.y)))
+        Some(TypedRect::new(upper_left.clone(), TypedSize2D::new(lower_right_x - upper_left.x,
+                                                            lower_right_y - upper_left.y)))
     }
 
     #[inline]
-    pub fn translate(&self, other: &Point2D<T>) -> Rect<T> {
-        Rect {
-            origin: Point2D::new(self.origin.x + other.x, self.origin.y + other.y),
-            size: self.size
-        }
+    pub fn translate(&self, other: &TypedPoint2D<T, U>) -> TypedRect<T, U> {
+        TypedRect::new(
+            TypedPoint2D::new(self.origin.x + other.x, self.origin.y + other.y),
+            self.size
+        )
     }
 
     #[inline]
-    pub fn contains(&self, other: &Point2D<T>) -> bool {
+    pub fn contains(&self, other: &TypedPoint2D<T, U>) -> bool {
         self.origin.x <= other.x && other.x < self.origin.x + self.size.width &&
         self.origin.y <= other.y && other.y < self.origin.y + self.size.height
     }
 
     #[inline]
-    pub fn inflate(&self, width: T, height: T) -> Rect<T> {
-        Rect {
-            origin: Point2D::new(self.origin.x - width, self.origin.y - height),
-            size: Size2D::new(self.size.width + width + width, self.size.height + height + height),
-        }
+    pub fn inflate(&self, width: T, height: T) -> TypedRect<T, U> {
+        TypedRect::new(
+            TypedPoint2D::new(self.origin.x - width, self.origin.y - height),
+            TypedSize2D::new(self.size.width + width + width, self.size.height + height + height),
+        )
     }
 
     #[inline]
-    pub fn top_right(&self) -> Point2D<T> {
-        Point2D::new(self.max_x(), self.origin.y)
+    pub fn inflate_typed(&self, width: Length<T, U>, height: Length<T, U>) -> TypedRect<T, U> {
+        self.inflate(width.get(), height.get())
     }
 
     #[inline]
-    pub fn bottom_left(&self) -> Point2D<T> {
-        Point2D::new(self.origin.x, self.max_y())
+    pub fn top_right(&self) -> TypedPoint2D<T, U> {
+        TypedPoint2D::new(self.max_x(), self.origin.y)
     }
 
     #[inline]
-    pub fn bottom_right(&self) -> Point2D<T> {
-        Point2D::new(self.max_x(), self.max_y())
+    pub fn bottom_left(&self) -> TypedPoint2D<T, U> {
+        TypedPoint2D::new(self.origin.x.clone(), self.max_y())
     }
 
     #[inline]
-    pub fn translate_by_size(&self, size: &Size2D<T>) -> Rect<T> {
-        self.translate(&Point2D::new(size.width, size.height))
+    pub fn bottom_right(&self) -> TypedPoint2D<T, U> {
+        TypedPoint2D::new(self.max_x(), self.max_y())
+    }
+
+    #[inline]
+    pub fn translate_by_size(&self, size: &TypedSize2D<T, U>) -> TypedRect<T, U> {
+        self.translate(&TypedPoint2D::new(size.width, size.height))
     }
 }
 
-impl<T: Copy + Clone + PartialOrd + Add<T, Output=T> + Sub<T, Output=T> + Zero> Rect<T> {
+impl<T: Copy + Clone + PartialOrd + Add<T, Output=T> + Sub<T, Output=T> + Zero, U> TypedRect<T, U> {
     #[inline]
-    pub fn union(&self, other: &Rect<T>) -> Rect<T> {
+    pub fn union(&self, other: &TypedRect<T, U>) -> TypedRect<T, U> {
         if self.size == Zero::zero() {
-            return *other
+            return other.clone();
         }
         if other.size == Zero::zero() {
-            return *self
+            return self.clone();
         }
 
-        let upper_left = Point2D::new(min(self.min_x(), other.min_x()),
+        let upper_left = TypedPoint2D::new(min(self.min_x(), other.min_x()),
                                       min(self.min_y(), other.min_y()));
 
-        let lower_right = Point2D::new(max(self.max_x(), other.max_x()),
-                                       max(self.max_y(), other.max_y()));
+        let lower_right_x = max(self.max_x(), other.max_x());
+        let lower_right_y = max(self.max_y(), other.max_y());
 
-        Rect {
-            origin: upper_left,
-            size: Size2D::new(lower_right.x - upper_left.x, lower_right.y - upper_left.y)
-        }
+        TypedRect::new(
+            upper_left,
+            TypedSize2D::new(lower_right_x - upper_left.x, lower_right_y - upper_left.y)
+        )
     }
 }
 
-impl<T> Rect<T> {
+impl<T, U> TypedRect<T, U> {
     #[inline]
-    pub fn scale<Scale: Copy>(&self, x: Scale, y: Scale) -> Rect<T>
+    pub fn scale<Scale: Copy>(&self, x: Scale, y: Scale) -> TypedRect<T, U>
         where T: Copy + Clone + Mul<Scale, Output=T> {
-        Rect {
-            origin: Point2D { x: self.origin.x * x, y: self.origin.y * y},
-            size: Size2D { width: self.size.width * x, height: self.size.height * y}
-        }
+        TypedRect::new(
+            TypedPoint2D::new(self.origin.x * x, self.origin.y * y),
+            TypedSize2D::new(self.size.width * x, self.size.height * y)
+        )
     }
 }
 
-impl<T: PartialEq + Zero> Rect<T> {
-    pub fn zero() -> Rect<T> {
-        Rect {
-            origin: Point2D::zero(),
-            size: Size2D::zero(),
-        }
+impl<T: PartialEq + Zero, U> TypedRect<T, U> {
+    pub fn zero() -> TypedRect<T, U> {
+        TypedRect::new(
+            TypedPoint2D::zero(),
+            TypedSize2D::zero(),
+        )
     }
 
     pub fn is_empty(&self) -> bool {
@@ -207,62 +249,75 @@ impl<T: PartialEq + Zero> Rect<T> {
 }
 
 
-pub fn min<T:Clone + PartialOrd>(x: T, y: T) -> T {
+pub fn min<T: Clone + PartialOrd>(x: T, y: T) -> T {
     if x <= y { x } else { y }
 }
 
-pub fn max<T:Clone + PartialOrd>(x: T, y: T) -> T {
+pub fn max<T: Clone + PartialOrd>(x: T, y: T) -> T {
     if x >= y { x } else { y }
 }
 
-impl<Scale: Copy, T0: Mul<Scale, Output=T1>, T1: Clone> Mul<Scale> for Rect<T0> {
-    type Output = Rect<T1>;
+impl<T: Copy + Mul<T, Output=T>, U> Mul<T> for TypedRect<T, U> {
+    type Output = TypedRect<T, U>;
     #[inline]
-    fn mul(self, scale: Scale) -> Rect<T1> {
-        Rect::new(self.origin * scale, self.size * scale)
+    fn mul(self, scale: T) -> TypedRect<T, U> {
+        TypedRect::new(self.origin * scale, self.size * scale)
     }
 }
 
-impl<Scale: Copy, T0: Div<Scale, Output=T1>, T1: Clone> Div<Scale> for Rect<T0> {
-    type Output = Rect<T1>;
+impl<T: Copy + Div<T, Output=T>, U> Div<T> for TypedRect<T, U> {
+    type Output = TypedRect<T, U>;
     #[inline]
-    fn div(self, scale: Scale) -> Rect<T1> {
-        Rect::new(self.origin / scale, self.size / scale)
+    fn div(self, scale: T) -> TypedRect<T, U> {
+        TypedRect::new(self.origin / scale, self.size / scale)
     }
 }
 
-// Convenient aliases for Rect with typed units
-pub type TypedRect<Unit, T> = Rect<Length<Unit, T>>;
+impl<T: Copy + Mul<T, Output=T>, U1, U2> Mul<ScaleFactor<T, U1, U2>> for TypedRect<T, U1> {
+    type Output = TypedRect<T, U2>;
+    #[inline]
+    fn mul(self, scale: ScaleFactor<T, U1, U2>) -> TypedRect<T, U2> {
+        TypedRect::new(self.origin * scale.clone(), self.size * scale.clone())
+    }
+}
 
-impl<Unit, T: Clone> Rect<Length<Unit, T>> {
+impl<T: Copy + Div<T, Output=T>, U1, U2> Div<ScaleFactor<T, U1, U2>> for TypedRect<T, U2> {
+    type Output = TypedRect<T, U1>;
+    #[inline]
+    fn div(self, scale: ScaleFactor<T, U1, U2>) -> TypedRect<T, U1> {
+        TypedRect::new(self.origin / scale.clone(), self.size / scale.clone())
+    }
+}
+
+impl<T: Clone, Unit> TypedRect<T, Unit> {
     /// Drop the units, preserving only the numeric value.
     pub fn to_untyped(&self) -> Rect<T> {
-        Rect::new(self.origin.to_untyped(), self.size.to_untyped())
+        TypedRect::new(self.origin.to_untyped(), self.size.to_untyped())
     }
 
     /// Tag a unitless value with units.
-    pub fn from_untyped(r: &Rect<T>) -> TypedRect<Unit, T> {
-        Rect::new(Point2D::from_untyped(&r.origin), Size2D::from_untyped(&r.size))
+    pub fn from_untyped(r: &Rect<T>) -> TypedRect<T, Unit> {
+        TypedRect::new(TypedPoint2D::from_untyped(&r.origin), TypedSize2D::from_untyped(&r.size))
     }
 }
 
-impl<Unit, T0: NumCast + Clone> Rect<Length<Unit, T0>> {
+impl<T0: NumCast + Clone, Unit> TypedRect<T0, Unit> {
     /// Cast from one numeric representation to another, preserving the units.
-    pub fn cast<T1: NumCast + Clone>(&self) -> Option<Rect<Length<Unit, T1>>> {
+    pub fn cast<T1: NumCast + Clone>(&self) -> Option<TypedRect<T1, Unit>> {
         match (self.origin.cast(), self.size.cast()) {
-            (Some(origin), Some(size)) => Some(Rect::new(origin, size)),
+            (Some(origin), Some(size)) => Some(TypedRect::new(origin, size)),
             _ => None
         }
     }
 }
 
 // Convenience functions for common casts
-impl<Unit, T: NumCast + Clone> Rect<Length<Unit, T>> {
-    pub fn as_f32(&self) -> Rect<Length<Unit, f32>> {
+impl<T: NumCast + Clone, Unit> TypedRect<T, Unit> {
+    pub fn as_f32(&self) -> TypedRect<f32, Unit> {
         self.cast().unwrap()
     }
 
-    pub fn as_uint(&self) -> Rect<Length<Unit, usize>> {
+    pub fn as_uint(&self) -> TypedRect<usize, Unit> {
         self.cast().unwrap()
     }
 }

--- a/src/scale_factor.rs
+++ b/src/scale_factor.rs
@@ -30,86 +30,86 @@ use std::marker::PhantomData;
 /// enum Mm {};
 /// enum Inch {};
 ///
-/// let mm_per_inch: ScaleFactor<Inch, Mm, f32> = ScaleFactor::new(25.4);
+/// let mm_per_inch: ScaleFactor<f32, Inch, Mm> = ScaleFactor::new(25.4);
 ///
-/// let one_foot: Length<Inch, f32> = Length::new(12.0);
-/// let one_foot_in_mm: Length<Mm, f32> = one_foot * mm_per_inch;
+/// let one_foot: Length<f32, Inch> = Length::new(12.0);
+/// let one_foot_in_mm: Length<f32, Mm> = one_foot * mm_per_inch;
 /// ```
 // Uncomment the derive, and remove the macro call, once heapsize gets
 // PhantomData<T> support.
 #[derive(Copy, RustcDecodable, RustcEncodable, Debug)]
-pub struct ScaleFactor<Src, Dst, T>(pub T, PhantomData<(Src, Dst)>);
+pub struct ScaleFactor<T, Src, Dst>(pub T, PhantomData<(Src, Dst)>);
 
-impl<Src, Dst, T: HeapSizeOf> HeapSizeOf for ScaleFactor<Src, Dst, T> {
+impl<T: HeapSizeOf, Src, Dst> HeapSizeOf for ScaleFactor<T, Src, Dst> {
     fn heap_size_of_children(&self) -> usize {
         self.0.heap_size_of_children()
     }
 }
 
-impl<Src, Dst, T> Deserialize for ScaleFactor<Src, Dst, T> where T: Deserialize {
-    fn deserialize<D>(deserializer: &mut D) -> Result<ScaleFactor<Src,Dst,T>,D::Error>
+impl<T, Src, Dst> Deserialize for ScaleFactor<T, Src, Dst> where T: Deserialize {
+    fn deserialize<D>(deserializer: &mut D) -> Result<ScaleFactor<T, Src, Dst>, D::Error>
                       where D: Deserializer {
         Ok(ScaleFactor(try!(Deserialize::deserialize(deserializer)), PhantomData))
     }
 }
 
-impl<Src, Dst, T> Serialize for ScaleFactor<Src, Dst, T> where T: Serialize {
+impl<T, Src, Dst> Serialize for ScaleFactor<T, Src, Dst> where T: Serialize {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(),S::Error> where S: Serializer {
         self.0.serialize(serializer)
     }
 }
 
-impl<Src, Dst, T> ScaleFactor<Src, Dst, T> {
-    pub fn new(x: T) -> ScaleFactor<Src, Dst, T> {
+impl<T, Src, Dst> ScaleFactor<T, Src, Dst> {
+    pub fn new(x: T) -> ScaleFactor<T, Src, Dst> {
         ScaleFactor(x, PhantomData)
     }
 }
 
-impl<Src, Dst, T: Clone> ScaleFactor<Src, Dst, T> {
+impl<T: Clone, Src, Dst> ScaleFactor<T, Src, Dst> {
     pub fn get(&self) -> T {
         self.0.clone()
     }
 }
 
-impl<Src, Dst, T: Clone + One + Div<T, Output=T>> ScaleFactor<Src, Dst, T> {
+impl<T: Clone + One + Div<T, Output=T>, Src, Dst> ScaleFactor<T, Src, Dst> {
     /// The inverse ScaleFactor (1.0 / self).
-    pub fn inv(&self) -> ScaleFactor<Dst, Src, T> {
+    pub fn inv(&self) -> ScaleFactor<T, Dst, Src> {
         let one: T = One::one();
         ScaleFactor::new(one / self.get())
     }
 }
 
 // scale0 * scale1
-impl<A, B, C, T: Clone + Mul<T, Output=T>>
-Mul<ScaleFactor<B, C, T>> for ScaleFactor<A, B, T> {
-    type Output = ScaleFactor<A, C, T>;
+impl<T: Clone + Mul<T, Output=T>, A, B, C>
+Mul<ScaleFactor<T, B, C>> for ScaleFactor<T, A, B> {
+    type Output = ScaleFactor<T, A, C>;
     #[inline]
-    fn mul(self, other: ScaleFactor<B, C, T>) -> ScaleFactor<A, C, T> {
+    fn mul(self, other: ScaleFactor<T, B, C>) -> ScaleFactor<T, A, C> {
         ScaleFactor::new(self.get() * other.get())
     }
 }
 
 // scale0 + scale1
-impl<Src, Dst, T: Clone + Add<T, Output=T>> Add for ScaleFactor<Src, Dst, T> {
-    type Output = ScaleFactor<Src, Dst, T>;
+impl<T: Clone + Add<T, Output=T>, Src, Dst> Add for ScaleFactor<T, Src, Dst> {
+    type Output = ScaleFactor<T, Src, Dst>;
     #[inline]
-    fn add(self, other: ScaleFactor<Src, Dst, T>) -> ScaleFactor<Src, Dst, T> {
+    fn add(self, other: ScaleFactor<T, Src, Dst>) -> ScaleFactor<T, Src, Dst> {
         ScaleFactor::new(self.get() + other.get())
     }
 }
 
 // scale0 - scale1
-impl<Src, Dst, T: Clone + Sub<T, Output=T>> Sub for ScaleFactor<Src, Dst, T> {
-    type Output = ScaleFactor<Src, Dst, T>;
+impl<T: Clone + Sub<T, Output=T>, Src, Dst> Sub for ScaleFactor<T, Src, Dst> {
+    type Output = ScaleFactor<T, Src, Dst>;
     #[inline]
-    fn sub(self, other: ScaleFactor<Src, Dst, T>) -> ScaleFactor<Src, Dst, T> {
+    fn sub(self, other: ScaleFactor<T, Src, Dst>) -> ScaleFactor<T, Src, Dst> {
         ScaleFactor::new(self.get() - other.get())
     }
 }
 
-impl<Src, Dst, T0: NumCast + Clone> ScaleFactor<Src, Dst, T0> {
+impl<T: NumCast + Clone, Src, Dst0> ScaleFactor<T, Src, Dst0> {
     /// Cast from one numeric representation to another, preserving the units.
-    pub fn cast<T1: NumCast + Clone>(&self) -> Option<ScaleFactor<Src, Dst, T1>> {
+    pub fn cast<T1: NumCast + Clone>(&self) -> Option<ScaleFactor<T1, Src, Dst0>> {
         NumCast::from(self.get()).map(ScaleFactor::new)
     }
 }
@@ -117,14 +117,14 @@ impl<Src, Dst, T0: NumCast + Clone> ScaleFactor<Src, Dst, T0> {
 // FIXME: Switch to `derive(PartialEq, Clone)` after this Rust issue is fixed:
 // https://github.com/mozilla/rust/issues/7671
 
-impl<Src, Dst, T: Clone + PartialEq> PartialEq for ScaleFactor<Src, Dst, T> {
-    fn eq(&self, other: &ScaleFactor<Src, Dst, T>) -> bool {
+impl<T: Clone + PartialEq, Src, Dst> PartialEq for ScaleFactor<T, Src, Dst> {
+    fn eq(&self, other: &ScaleFactor<T, Src, Dst>) -> bool {
         self.get().eq(&other.get())
     }
 }
 
-impl<Src, Dst, T: Clone> Clone for ScaleFactor<Src, Dst, T> {
-    fn clone(&self) -> ScaleFactor<Src, Dst, T> {
+impl<T: Clone, Src, Dst> Clone for ScaleFactor<T, Src, Dst> {
+    fn clone(&self) -> ScaleFactor<T, Src, Dst> {
         ScaleFactor::new(self.get())
     }
 }
@@ -142,17 +142,17 @@ mod tests {
 
     #[test]
     fn test_scale_factor() {
-        let mm_per_inch: ScaleFactor<Inch, Mm, f32> = ScaleFactor::new(25.4);
-        let cm_per_mm: ScaleFactor<Mm, Cm, f32> = ScaleFactor::new(0.1);
+        let mm_per_inch: ScaleFactor<f32, Inch, Mm> = ScaleFactor::new(25.4);
+        let cm_per_mm: ScaleFactor<f32, Mm, Cm> = ScaleFactor::new(0.1);
 
-        let mm_per_cm: ScaleFactor<Cm, Mm, f32> = cm_per_mm.inv();
+        let mm_per_cm: ScaleFactor<f32, Cm, Mm> = cm_per_mm.inv();
         assert_eq!(mm_per_cm.get(), 10.0);
 
-        let cm_per_inch: ScaleFactor<Inch, Cm, f32> = mm_per_inch * cm_per_mm;
+        let cm_per_inch: ScaleFactor<f32, Inch, Cm> = mm_per_inch * cm_per_mm;
         assert_eq!(cm_per_inch, ScaleFactor::new(2.54));
 
-        let a: ScaleFactor<Inch, Inch, isize> = ScaleFactor::new(2);
-        let b: ScaleFactor<Inch, Inch, isize> = ScaleFactor::new(3);
+        let a: ScaleFactor<isize, Inch, Inch> = ScaleFactor::new(2);
+        let b: ScaleFactor<isize, Inch, Inch> = ScaleFactor::new(3);
         assert!(a != b);
         assert_eq!(a, a.clone());
         assert_eq!(a.clone() + b.clone(), ScaleFactor::new(5));

--- a/src/size.rs
+++ b/src/size.rs
@@ -7,117 +7,154 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use length::Length;
+use length::{Length, UnknownUnit};
+use scale_factor::ScaleFactor;
 use num::Zero;
 
 use num_traits::NumCast;
 use std::fmt;
 use std::ops::{Mul, Div};
+use std::marker::PhantomData;
 
-define_matrix! {
+define_vector! {
     #[derive(RustcDecodable, RustcEncodable)]
-    pub struct Size2D<T> {
+    pub struct TypedSize2D<T, U> {
         pub width: T,
         pub height: T,
     }
 }
 
-impl<T: fmt::Debug> fmt::Debug for Size2D<T> {
+pub type Size2D<T> = TypedSize2D<T, UnknownUnit>;
+
+impl<T: Copy, U> Copy for TypedSize2D<T, U> {}
+
+impl<T: Clone, U> Clone for TypedSize2D<T, U> {
+    fn clone(&self) -> TypedSize2D<T, U> {
+        TypedSize2D::new(self.width.clone(), self.height.clone())
+    }
+}
+
+impl<T: PartialEq, U> PartialEq<TypedSize2D<T, U>> for TypedSize2D<T, U> {
+    fn eq(&self, other: &TypedSize2D<T, U>) -> bool {
+        self.width.eq(&other.width) && self.height.eq(&other.height)
+    }
+}
+
+impl<T: Eq, U> Eq for TypedSize2D<T, U> {}
+
+impl<T: fmt::Debug, U> fmt::Debug for TypedSize2D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}×{:?}", self.width, self.height)
     }
 }
 
-impl<T: fmt::Display> fmt::Display for Size2D<T> {
+impl<T: fmt::Display, U> fmt::Display for TypedSize2D<T, U> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(formatter, "({}x{})", self.width, self.height)
     }
 }
 
-impl<T: Clone> Size2D<T> {
-    pub fn new(width: T, height: T) -> Size2D<T> {
-        Size2D {
+impl<T, U> TypedSize2D<T, U> {
+    pub fn new(width: T, height: T) -> TypedSize2D<T, U> {
+        TypedSize2D {
             width: width,
-            height: height
+            height: height,
+            _unit: PhantomData,
         }
     }
 }
 
-impl<T:Copy + Clone + Mul<T, Output=U>, U> Size2D<T> {
+impl<T: Clone, U> TypedSize2D<T, U> {
+    pub fn from_lengths(width: Length<T, U>, height: Length<T, U>) -> TypedSize2D<T, U> {
+        TypedSize2D::new(width.get(), height.get())
+    }
+}
+
+impl<T: Copy + Clone + Mul<T, Output=U>, U> TypedSize2D<T, U> {
     pub fn area(&self) -> U { self.width * self.height }
 }
 
-impl<T: Zero> Size2D<T> {
-    pub fn zero() -> Size2D<T> {
-        Size2D {
-            width: Zero::zero(),
-            height: Zero::zero(),
-        }
+impl<T: Zero, U> TypedSize2D<T, U> {
+    pub fn zero() -> TypedSize2D<T, U> {
+        TypedSize2D::new(
+            Zero::zero(),
+            Zero::zero(),
+        )
     }
 }
 
-impl<T: Zero> Zero for Size2D<T> {
-    fn zero() -> Size2D<T> {
-        Size2D {
-            width: Zero::zero(),
-            height: Zero::zero(),
-        }
+impl<T: Zero, U> Zero for TypedSize2D<T, U> {
+    fn zero() -> TypedSize2D<T, U> {
+        TypedSize2D::new(
+            Zero::zero(),
+            Zero::zero(),
+        )
     }
 }
 
-impl<Scale: Copy, T0: Mul<Scale, Output=T1>, T1: Clone> Mul<Scale> for Size2D<T0> {
-    type Output = Size2D<T1>;
+impl<T: Copy + Mul<T, Output=T>, U> Mul<T> for TypedSize2D<T, U> {
+    type Output = TypedSize2D<T, U>;
     #[inline]
-    fn mul(self, scale: Scale) -> Size2D<T1> {
-        Size2D::new(self.width * scale, self.height * scale)
+    fn mul(self, scale: T) -> TypedSize2D<T, U> {
+        TypedSize2D::new(self.width * scale, self.height * scale)
     }
 }
 
-impl<Scale: Copy, T0: Div<Scale, Output=T1>, T1: Clone> Div<Scale> for Size2D<T0> {
-    type Output = Size2D<T1>;
+impl<T: Copy + Div<T, Output=T>, U> Div<T> for TypedSize2D<T, U> {
+    type Output = TypedSize2D<T, U>;
     #[inline]
-    fn div(self, scale: Scale) -> Size2D<T1> {
-        Size2D::new(self.width / scale, self.height / scale)
+    fn div(self, scale: T) -> TypedSize2D<T, U> {
+        TypedSize2D::new(self.width / scale, self.height / scale)
     }
 }
 
-// Convenient aliases for Size2D with typed units
-
-pub type TypedSize2D<Unit, T> = Size2D<Length<Unit, T>>;
-
-impl<Unit, T: Clone> Size2D<Length<Unit, T>> {
-    pub fn typed(width: T, height: T) -> TypedSize2D<Unit, T> {
-        Size2D::new(Length::new(width), Length::new(height))
+impl<T: Copy + Mul<T, Output=T>, U1, U2> Mul<ScaleFactor<T, U1, U2>> for TypedSize2D<T, U1> {
+    type Output = TypedSize2D<T, U2>;
+    #[inline]
+    fn mul(self, scale: ScaleFactor<T, U1, U2>) -> TypedSize2D<T, U2> {
+        TypedSize2D::new(self.width * scale.get(), self.height * scale.get())
     }
+}
 
+impl<T: Copy + Div<T, Output=T>, U1, U2> Div<ScaleFactor<T, U1, U2>> for TypedSize2D<T, U2> {
+    type Output = TypedSize2D<T, U1>;
+    #[inline]
+    fn div(self, scale: ScaleFactor<T, U1, U2>) -> TypedSize2D<T, U1> {
+        TypedSize2D::new(self.width / scale.get(), self.height / scale.get())
+    }
+}
+
+// Convenient aliases for TypedSize2D with typed units
+
+impl<Unit, T: Clone> TypedSize2D<T, Unit> {
     /// Drop the units, preserving only the numeric value.
     pub fn to_untyped(&self) -> Size2D<T> {
-        Size2D::new(self.width.get(), self.height.get())
+        TypedSize2D::new(self.width.clone(), self.height.clone())
     }
 
     /// Tag a unitless value with units.
-    pub fn from_untyped(p: &Size2D<T>) -> TypedSize2D<Unit, T> {
-        Size2D::new(Length::new(p.width.clone()), Length::new(p.height.clone()))
+    pub fn from_untyped(p: &Size2D<T>) -> TypedSize2D<T, Unit> {
+        TypedSize2D::new(p.width.clone(), p.height.clone())
     }
 }
 
-impl<Unit, T0: NumCast + Clone> Size2D<Length<Unit, T0>> {
+impl<Unit, T0: NumCast + Clone> TypedSize2D<T0, Unit> {
     /// Cast from one numeric representation to another, preserving the units.
-    pub fn cast<T1: NumCast + Clone>(&self) -> Option<Size2D<Length<Unit, T1>>> {
-        match (self.width.cast(), self.height.cast()) {
-            (Some(w), Some(h)) => Some(Size2D::new(w, h)),
+    pub fn cast<T1: NumCast + Clone>(&self) -> Option<TypedSize2D<T1, Unit>> {
+        match (NumCast::from(self.width.clone()), NumCast::from(self.height.clone())) {
+            (Some(w), Some(h)) => Some(TypedSize2D::new(w, h)),
             _ => None
         }
     }
 }
 
 // Convenience functions for common casts
-impl<Unit, T: NumCast + Clone> Size2D<Length<Unit, T>> {
-    pub fn as_f32(&self) -> Size2D<Length<Unit, f32>> {
+impl<Unit, T: NumCast + Clone> TypedSize2D<T, Unit> {
+    pub fn as_f32(&self) -> TypedSize2D<f32, Unit> {
         self.cast().unwrap()
     }
 
-    pub fn as_uint(&self) -> Size2D<Length<Unit, usize>> {
+    pub fn as_uint(&self) -> TypedSize2D<usize, Unit> {
         self.cast().unwrap()
     }
 }


### PR DESCRIPTION
Here is the implementation of the units system from issue #144.

Other than changing how units are expressed, I took the liberty to change the convention ```Typed<Unit, ScalarType>``` into ```Typed<SalarType, Unit>```. This is to be able to use default generic parameters for the units. Default generics in rust are not quite where they should be yet, so the library does not take full advantage of it. When the language issues get resolved, there are some simplifications that can be made to the library (for instance not need both a TypedPoint2D and a Point2D alias).

Member access (```foo.x```) provides scalars (like f32) by default, and there are a few ```_typed``` convenience methods to access members as a Length (```foo.x_typed()```). converting rust-layers to this system, I haven't come across places where the members were accessed without unwrapping the Length right away, which tends to confirm that scalar member access should be what is convenient to write by default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/148)
<!-- Reviewable:end -->
