### PR TITLE
Some small changes to get Servo compiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["The Servo Project Developers"]
 description = "Geometry primitives"
 documentation = "http://doc.servo.org/euclid/"

--- a/src/length.rs
+++ b/src/length.rs
@@ -20,7 +20,7 @@ use std::ops::{AddAssign, SubAssign};
 use std::marker::PhantomData;
 use std::fmt;
 
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Clone, Copy, RustcDecodable, RustcEncodable)]
 pub struct UnknownUnit;
 
 /// A one-dimensional distance, with value represented by `T` and unit of measurement `Unit`.
@@ -36,7 +36,7 @@ pub struct UnknownUnit;
 /// another. See the `ScaleFactor` docs for an example.
 // Uncomment the derive, and remove the macro call, once heapsize gets
 // PhantomData<T> support.
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Clone, Copy, RustcDecodable, RustcEncodable)]
 pub struct Length<T, Unit>(pub T, PhantomData<Unit>);
 
 impl<Unit, T: HeapSizeOf> HeapSizeOf for Length<T, Unit> {
@@ -63,8 +63,6 @@ impl<T, Unit> Length<T, Unit> {
         Length(x, PhantomData)
     }
 }
-
-impl<T: Copy, Unit> Copy for Length<T, Unit> {}
 
 impl<Unit, T: Clone> Length<T, Unit> {
     pub fn get(&self) -> T {
@@ -154,15 +152,6 @@ impl<Unit, T0: NumCast + Clone> Length<T0, Unit> {
     /// Cast from one numeric representation to another, preserving the units.
     pub fn cast<T1: NumCast + Clone>(&self) -> Option<Length<T1, Unit>> {
         NumCast::from(self.get()).map(Length::new)
-    }
-}
-
-// FIXME: Switch to `derive(Clone, PartialEq, PartialOrd, Zero)` after this Rust issue is fixed:
-// https://github.com/mozilla/rust/issues/7671
-
-impl<Unit, T: Clone> Clone for Length<T, Unit> {
-    fn clone(&self) -> Length<T, Unit> {
-        Length::new(self.get())
     }
 }
 

--- a/src/matrix2d.rs
+++ b/src/matrix2d.rs
@@ -16,6 +16,7 @@ use std::ops::{Add, Mul, Sub};
 use std::marker::PhantomData;
 
 define_matrix! {
+    #[derive(Clone, Copy, Eq, Hash, PartialEq)]
     pub struct TypedMatrix2D<T, Src, Dst> {
         pub m11: T, pub m12: T,
         pub m21: T, pub m22: T,

--- a/src/side_offsets.rs
+++ b/src/side_offsets.rs
@@ -21,7 +21,7 @@ use heapsize::HeapSizeOf;
 /// A group of side offsets, which correspond to top/left/bottom/right for borders, padding,
 /// and margins in CSS.
 define_vector! {
-    #[derive(Debug)]
+    #[derive(Clone, Debug)]
     pub struct TypedSideOffsets2D<T, U> {
         pub top: T,
         pub right: T,


### PR DESCRIPTION
This was mostly a matter of missing traits. The _unit member of all
typed structs is exposed to allow static initialization. Ideally there
will be a better way to do this in the future.

A similar change will also be pushed to the master branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/152)
<!-- Reviewable:end -->
