### PR TITLE
Have TypedSideOffsets2D derive PartialEq and Copy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["The Servo Project Developers"]
 description = "Geometry primitives"
 documentation = "http://doc.servo.org/euclid/"

--- a/src/length.rs
+++ b/src/length.rs
@@ -20,7 +20,7 @@ use std::ops::{AddAssign, SubAssign};
 use std::marker::PhantomData;
 use std::fmt;
 
-#[derive(Clone, Copy, RustcDecodable, RustcEncodable)]
+#[derive(Clone, Copy, RustcDecodable, RustcEncodable, PartialEq)]
 pub struct UnknownUnit;
 
 /// A one-dimensional distance, with value represented by `T` and unit of measurement `Unit`.

--- a/src/side_offsets.rs
+++ b/src/side_offsets.rs
@@ -21,7 +21,7 @@ use heapsize::HeapSizeOf;
 /// A group of side offsets, which correspond to top/left/bottom/right for borders, padding,
 /// and margins in CSS.
 define_vector! {
-    #[derive(Clone, Debug)]
+    #[derive(Clone, Copy, Debug, PartialEq)]
     pub struct TypedSideOffsets2D<T, U> {
         pub top: T,
         pub right: T,


### PR DESCRIPTION
This is necessary to get Servo unit tests compiling and running. Also
bump the version so this change can be propagated to crates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/154)
<!-- Reviewable:end -->
