### PR TITLE
Associativity issue because w is not multiplied

### DIFF
--- a/src/point.rs
+++ b/src/point.rs
@@ -8,11 +8,11 @@
 // except according to those terms.
 
 use super::UnknownUnit;
+use approxeq::ApproxEq;
 use length::Length;
 use scale_factor::ScaleFactor;
 use size::TypedSize2D;
 use num::*;
-use approxeq::ApproxEq;
 use num_traits::{Float, NumCast};
 use std::fmt;
 use std::ops::{Add, Neg, Mul, Sub, Div};
@@ -728,6 +728,23 @@ impl<T: NumCast + Copy, U> TypedPoint4D<T, U> {
     /// conversion behavior.
     pub fn to_i64(&self) -> TypedPoint4D<i64, U> {
         self.cast().unwrap()
+    }
+}
+
+impl<T: ApproxEq<T>, U> ApproxEq<T> for TypedPoint4D<T, U> {
+    fn approx_epsilon() -> T {
+        T::approx_epsilon()
+    }
+
+    fn approx_eq_eps(&self, other: &Self, approx_epsilon: &T) -> bool {
+        self.x.approx_eq_eps(&other.x, approx_epsilon)
+        && self.y.approx_eq_eps(&other.y, approx_epsilon)
+        && self.z.approx_eq_eps(&other.z, approx_epsilon)
+        && self.w.approx_eq_eps(&other.w, approx_epsilon)
+    }
+
+    fn approx_eq(&self, other: &Self) -> bool {
+        self.approx_eq_eps(&other, &Self::approx_epsilon())
     }
 }
 


### PR DESCRIPTION
Transforming a point by two matrices in sequence should be the same as premultiplying the matrices and performing one transformation.

The issue appears to be because the `w` field of the point is assumed to be always 1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/157)
<!-- Reviewable:end -->
