### PR TITLE
Separate Point and Vector types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,8 +74,12 @@ pub use transform3d::{Transform3D, TypedTransform3D};
 pub use point::{
     Point2D, TypedPoint2D,
     Point3D, TypedPoint3D,
-    Point4D, TypedPoint4D,
 };
+pub use vector::{
+    Vector2D, TypedVector2D,
+    Vector3D, TypedVector3D,
+};
+
 pub use rect::{Rect, TypedRect};
 pub use side_offsets::{SideOffsets2D, TypedSideOffsets2D};
 #[cfg(feature = "unstable")] pub use side_offsets::SideOffsets2DSimdI32;
@@ -94,6 +98,7 @@ pub mod scale_factor;
 pub mod side_offsets;
 pub mod size;
 pub mod trig;
+pub mod vector;
 
 /// The default unit.
 #[derive(Clone, Copy)]

--- a/src/point.rs
+++ b/src/point.rs
@@ -14,8 +14,9 @@ use scale_factor::ScaleFactor;
 use size::TypedSize2D;
 use num::*;
 use num_traits::{Float, NumCast};
+use vector::{TypedVector2D, TypedVector3D, vec2, vec3};
 use std::fmt;
-use std::ops::{Add, Neg, Mul, Sub, Div, AddAssign};
+use std::ops::{Add, Mul, Sub, Div, AddAssign, SubAssign, MulAssign, DivAssign};
 use std::marker::PhantomData;
 
 define_matrix! {
@@ -34,14 +35,19 @@ pub type Point2D<T> = TypedPoint2D<T, UnknownUnit>;
 impl<T: Copy + Zero, U> TypedPoint2D<T, U> {
     /// Constructor, setting all components to zero.
     #[inline]
-    pub fn zero() -> TypedPoint2D<T, U> {
-        TypedPoint2D::new(Zero::zero(), Zero::zero())
+    pub fn origin() -> Self {
+        point2(Zero::zero(), Zero::zero())
+    }
+
+    #[inline]
+    pub fn zero() -> Self {
+        Self::origin()
     }
 
     /// Convert into a 3d point.
     #[inline]
     pub fn to_3d(&self) -> TypedPoint3D<T, U> {
-        TypedPoint3D::new(self.x, self.y, Zero::zero())
+        point3(self.x, self.y, Zero::zero())
     }
 }
 
@@ -60,14 +66,22 @@ impl<T: fmt::Display, U> fmt::Display for TypedPoint2D<T, U> {
 impl<T: Copy, U> TypedPoint2D<T, U> {
     /// Constructor taking scalar values directly.
     #[inline]
-    pub fn new(x: T, y: T) -> TypedPoint2D<T, U> {
+    pub fn new(x: T, y: T) -> Self {
         TypedPoint2D { x: x, y: y, _unit: PhantomData }
     }
 
     /// Constructor taking properly typed Lengths instead of scalar values.
     #[inline]
-    pub fn from_lengths(x: Length<T, U>, y: Length<T, U>) -> TypedPoint2D<T, U> {
-        TypedPoint2D::new(x.0, y.0)
+    pub fn from_lengths(x: Length<T, U>, y: Length<T, U>) -> Self {
+        point2(x.0, y.0)
+    }
+
+    /// Cast this point into a vector.
+    ///
+    /// Equivalent to substracting the origin to this point.
+    #[inline]
+    pub fn to_vector(&self) -> TypedVector2D<T, U> {
+        vec2(self.x, self.y)
     }
 
     /// Returns self.x as a Length carrying the unit.
@@ -81,13 +95,13 @@ impl<T: Copy, U> TypedPoint2D<T, U> {
     /// Drop the units, preserving only the numeric value.
     #[inline]
     pub fn to_untyped(&self) -> Point2D<T> {
-        TypedPoint2D::new(self.x, self.y)
+        point2(self.x, self.y)
     }
 
     /// Tag a unitless value with units.
     #[inline]
-    pub fn from_untyped(p: &Point2D<T>) -> TypedPoint2D<T, U> {
-        TypedPoint2D::new(p.x, p.y)
+    pub fn from_untyped(p: &Point2D<T>) -> Self {
+        point2(p.x, p.y)
     }
 
     #[inline]
@@ -96,95 +110,98 @@ impl<T: Copy, U> TypedPoint2D<T, U> {
     }
 }
 
-impl<T, U> TypedPoint2D<T, U>
-where T: Copy + Mul<T, Output=T> + Add<T, Output=T> + Sub<T, Output=T> {
-    /// Dot product.
+impl<T: Copy + Add<T, Output=T>, U> TypedPoint2D<T, U> {
     #[inline]
-    pub fn dot(self, other: TypedPoint2D<T, U>) -> T {
-        self.x * other.x + self.y * other.y
-    }
-
-    /// Returns the norm of the cross product [self.x, self.y, 0] x [other.x, other.y, 0]..
-    #[inline]
-    pub fn cross(self, other: TypedPoint2D<T, U>) -> T {
-        self.x * other.y - self.y * other.x
-    }
-
-    #[inline]
-    pub fn normalize(self) -> Self where T: Float + ApproxEq<T> {
-        let dot = self.dot(self);
-        if dot.approx_eq(&T::zero()) {
-            self
-        } else {
-            self / dot.sqrt()
-        }
-    }
-}
-
-impl<T: Copy + Add<T, Output=T>, U> Add for TypedPoint2D<T, U> {
-    type Output = TypedPoint2D<T, U>;
-    fn add(self, other: TypedPoint2D<T, U>) -> TypedPoint2D<T, U> {
-        TypedPoint2D::new(self.x + other.x, self.y + other.y)
-    }
-}
-
-impl<T: Copy + Add<T, Output=T>, U> AddAssign for TypedPoint2D<T, U> {
-    fn add_assign(&mut self, other: TypedPoint2D<T, U>){
-        *self = *self + other
+    pub fn add_size(&self, other: &TypedSize2D<T, U>) -> Self {
+        point2(self.x + other.width, self.y + other.height)
     }
 }
 
 impl<T: Copy + Add<T, Output=T>, U> Add<TypedSize2D<T, U>> for TypedPoint2D<T, U> {
     type Output = TypedPoint2D<T, U>;
-    fn add(self, other: TypedSize2D<T, U>) -> TypedPoint2D<T, U> {
-        TypedPoint2D::new(self.x + other.width, self.y + other.height)
+    #[inline]
+    fn add(self, other: TypedSize2D<T, U>) -> Self {
+        point2(self.x + other.width, self.y + other.height)
     }
 }
 
-impl<T: Copy + Add<T, Output=T>, U> TypedPoint2D<T, U> {
-    pub fn add_size(&self, other: &TypedSize2D<T, U>) -> TypedPoint2D<T, U> {
-        TypedPoint2D::new(self.x + other.width, self.y + other.height)
+impl<T: Copy + Add<T, Output=T>, U> AddAssign<TypedVector2D<T, U>> for TypedPoint2D<T, U> {
+    #[inline]
+    fn add_assign(&mut self, other: TypedVector2D<T, U>) {
+        *self = *self + other
+    }
+}
+
+impl<T: Copy + Sub<T, Output=T>, U> SubAssign<TypedVector2D<T, U>> for TypedPoint2D<T, U> {
+    #[inline]
+    fn sub_assign(&mut self, other: TypedVector2D<T, U>) {
+        *self = *self - other
+    }
+}
+
+impl<T: Copy + Add<T, Output=T>, U> Add<TypedVector2D<T, U>> for TypedPoint2D<T, U> {
+    type Output = TypedPoint2D<T, U>;
+    #[inline]
+    fn add(self, other: TypedVector2D<T, U>) -> Self {
+        point2(self.x + other.x, self.y + other.y)
     }
 }
 
 impl<T: Copy + Sub<T, Output=T>, U> Sub for TypedPoint2D<T, U> {
-    type Output = TypedPoint2D<T, U>;
-    fn sub(self, other: TypedPoint2D<T, U>) -> TypedPoint2D<T, U> {
-        TypedPoint2D::new(self.x - other.x, self.y - other.y)
+    type Output = TypedVector2D<T, U>;
+    #[inline]
+    fn sub(self, other: TypedPoint2D<T, U>) -> TypedVector2D<T, U> {
+        vec2(self.x - other.x, self.y - other.y)
     }
 }
 
-impl <T: Copy + Neg<Output=T>, U> Neg for TypedPoint2D<T, U> {
-    type Output = TypedPoint2D<T, U>;
+impl<T: Copy + Sub<T, Output=T>, U> Sub<TypedVector2D<T, U>> for TypedPoint2D<T, U> {
+    type Output = Self;
     #[inline]
-    fn neg(self) -> TypedPoint2D<T, U> {
-        TypedPoint2D::new(-self.x, -self.y)
+    fn sub(self, other: TypedVector2D<T, U>) -> Self {
+        point2(self.x - other.x, self.y - other.y)
     }
 }
 
 impl<T: Float, U> TypedPoint2D<T, U> {
-    pub fn min(self, other: TypedPoint2D<T, U>) -> TypedPoint2D<T, U> {
-         TypedPoint2D::new(self.x.min(other.x), self.y.min(other.y))
+    #[inline]
+    pub fn min(self, other: TypedPoint2D<T, U>) -> Self {
+         point2(self.x.min(other.x), self.y.min(other.y))
     }
 
-    pub fn max(self, other: TypedPoint2D<T, U>) -> TypedPoint2D<T, U> {
-        TypedPoint2D::new(self.x.max(other.x), self.y.max(other.y))
+    #[inline]
+    pub fn max(self, other: TypedPoint2D<T, U>) -> Self {
+        point2(self.x.max(other.x), self.y.max(other.y))
     }
 }
 
 impl<T: Copy + Mul<T, Output=T>, U> Mul<T> for TypedPoint2D<T, U> {
-    type Output = TypedPoint2D<T, U>;
+    type Output = Self;
     #[inline]
-    fn mul(self, scale: T) -> TypedPoint2D<T, U> {
-        TypedPoint2D::new(self.x * scale, self.y * scale)
+    fn mul(self, scale: T) -> Self {
+        point2(self.x * scale, self.y * scale)
+    }
+}
+
+impl<T: Copy + Mul<T, Output=T>, U> MulAssign<T> for TypedPoint2D<T, U> {
+    #[inline]
+    fn mul_assign(&mut self, scale: T) {
+        *self = *self * scale
     }
 }
 
 impl<T: Copy + Div<T, Output=T>, U> Div<T> for TypedPoint2D<T, U> {
-    type Output = TypedPoint2D<T, U>;
+    type Output = Self;
     #[inline]
-    fn div(self, scale: T) -> TypedPoint2D<T, U> {
-        TypedPoint2D::new(self.x / scale, self.y / scale)
+    fn div(self, scale: T) -> Self {
+        point2(self.x / scale, self.y / scale)
+    }
+}
+
+impl<T: Copy + Div<T, Output=T>, U> DivAssign<T> for TypedPoint2D<T, U> {
+    #[inline]
+    fn div_assign(&mut self, scale: T) {
+        *self = *self / scale
     }
 }
 
@@ -192,7 +209,7 @@ impl<T: Copy + Mul<T, Output=T>, U1, U2> Mul<ScaleFactor<T, U1, U2>> for TypedPo
     type Output = TypedPoint2D<T, U2>;
     #[inline]
     fn mul(self, scale: ScaleFactor<T, U1, U2>) -> TypedPoint2D<T, U2> {
-        TypedPoint2D::new(self.x * scale.get(), self.y * scale.get())
+        point2(self.x * scale.get(), self.y * scale.get())
     }
 }
 
@@ -200,7 +217,7 @@ impl<T: Copy + Div<T, Output=T>, U1, U2> Div<ScaleFactor<T, U1, U2>> for TypedPo
     type Output = TypedPoint2D<T, U1>;
     #[inline]
     fn div(self, scale: ScaleFactor<T, U1, U2>) -> TypedPoint2D<T, U1> {
-        TypedPoint2D::new(self.x / scale.get(), self.y / scale.get())
+        point2(self.x / scale.get(), self.y / scale.get())
     }
 }
 
@@ -209,8 +226,9 @@ impl<T: Round, U> TypedPoint2D<T, U> {
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
     /// For example `{ -0.1, -0.8 }.round() == { 0.0, -1.0 }`.
+    #[inline]
     pub fn round(&self) -> Self {
-        TypedPoint2D::new(self.x.round(), self.y.round())
+        point2(self.x.round(), self.y.round())
     }
 }
 
@@ -219,8 +237,9 @@ impl<T: Ceil, U> TypedPoint2D<T, U> {
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
     /// For example `{ -0.1, -0.8 }.ceil() == { 0.0, 0.0 }`.
+    #[inline]
     pub fn ceil(&self) -> Self {
-        TypedPoint2D::new(self.x.ceil(), self.y.ceil())
+        point2(self.x.ceil(), self.y.ceil())
     }
 }
 
@@ -229,8 +248,9 @@ impl<T: Floor, U> TypedPoint2D<T, U> {
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
     /// For example `{ -0.1, -0.8 }.floor() == { -1.0, -1.0 }`.
+    #[inline]
     pub fn floor(&self) -> Self {
-        TypedPoint2D::new(self.x.floor(), self.y.floor())
+        point2(self.x.floor(), self.y.floor())
     }
 }
 
@@ -240,9 +260,10 @@ impl<T: NumCast + Copy, U> TypedPoint2D<T, U> {
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
+    #[inline]
     pub fn cast<NewT: NumCast + Copy>(&self) -> Option<TypedPoint2D<NewT, U>> {
         match (NumCast::from(self.x), NumCast::from(self.y)) {
-            (Some(x), Some(y)) => Some(TypedPoint2D::new(x, y)),
+            (Some(x), Some(y)) => Some(point2(x, y)),
             _ => None
         }
     }
@@ -250,6 +271,7 @@ impl<T: NumCast + Copy, U> TypedPoint2D<T, U> {
     // Convenience functions for common casts
 
     /// Cast into an `f32` point.
+    #[inline]
     pub fn to_f32(&self) -> TypedPoint2D<f32, U> {
         self.cast().unwrap()
     }
@@ -259,6 +281,7 @@ impl<T: NumCast + Copy, U> TypedPoint2D<T, U> {
     /// When casting from floating point points, it is worth considering whether
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
+    #[inline]
     pub fn to_usize(&self) -> TypedPoint2D<usize, U> {
         self.cast().unwrap()
     }
@@ -268,6 +291,7 @@ impl<T: NumCast + Copy, U> TypedPoint2D<T, U> {
     /// When casting from floating point points, it is worth considering whether
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
+    #[inline]
     pub fn to_i32(&self) -> TypedPoint2D<i32, U> {
         self.cast().unwrap()
     }
@@ -277,15 +301,16 @@ impl<T: NumCast + Copy, U> TypedPoint2D<T, U> {
     /// When casting from floating point points, it is worth considering whether
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
+    #[inline]
     pub fn to_i64(&self) -> TypedPoint2D<i64, U> {
         self.cast().unwrap()
     }
 }
 
-impl<T: Copy+ApproxEq<T>, U> ApproxEq<TypedPoint2D<T, U>> for TypedPoint2D<T, U> {
+impl<T: Copy+ApproxEq<T>, U> ApproxEq<Self> for TypedPoint2D<T, U> {
     #[inline]
     fn approx_epsilon() -> Self {
-        TypedPoint2D::new(T::approx_epsilon(), T::approx_epsilon())
+        point2(T::approx_epsilon(), T::approx_epsilon())
     }
 
     #[inline]
@@ -316,8 +341,15 @@ pub type Point3D<T> = TypedPoint3D<T, UnknownUnit>;
 impl<T: Copy + Zero, U> TypedPoint3D<T, U> {
     /// Constructor, setting all copmonents to zero.
     #[inline]
-    pub fn zero() -> TypedPoint3D<T, U> {
-        TypedPoint3D::new(Zero::zero(), Zero::zero(), Zero::zero())
+    pub fn origin() -> Self {
+        point3(Zero::zero(), Zero::zero(), Zero::zero())
+    }
+}
+
+impl<T: Copy + One, U> TypedPoint3D<T, U> {
+    #[inline]
+    pub fn to_array_4d(&self) -> [T; 4] {
+        [self.x, self.y, self.z, One::one()]
     }
 }
 
@@ -336,14 +368,22 @@ impl<T: fmt::Display, U> fmt::Display for TypedPoint3D<T, U> {
 impl<T: Copy, U> TypedPoint3D<T, U> {
     /// Constructor taking scalar values directly.
     #[inline]
-    pub fn new(x: T, y: T, z: T) -> TypedPoint3D<T, U> {
+    pub fn new(x: T, y: T, z: T) -> Self {
         TypedPoint3D { x: x, y: y, z: z, _unit: PhantomData }
     }
 
     /// Constructor taking properly typed Lengths instead of scalar values.
     #[inline]
-    pub fn from_lengths(x: Length<T, U>, y: Length<T, U>, z: Length<T, U>) -> TypedPoint3D<T, U> {
-        TypedPoint3D::new(x.0, y.0, z.0)
+    pub fn from_lengths(x: Length<T, U>, y: Length<T, U>, z: Length<T, U>) -> Self {
+        point3(x.0, y.0, z.0)
+    }
+
+    /// Cast this point into a vector.
+    ///
+    /// Equivalent to substracting the origin to this point.
+    #[inline]
+    pub fn to_vector(&self) -> TypedVector3D<T, U> {
+        vec3(self.x, self.y, self.y)
     }
 
     /// Returns self.x as a Length carrying the unit.
@@ -364,77 +404,57 @@ impl<T: Copy, U> TypedPoint3D<T, U> {
     /// Drop the units, preserving only the numeric value.
     #[inline]
     pub fn to_untyped(&self) -> Point3D<T> {
-        TypedPoint3D::new(self.x, self.y, self.z)
+        point3(self.x, self.y, self.z)
     }
 
     /// Tag a unitless value with units.
     #[inline]
-    pub fn from_untyped(p: &Point3D<T>) -> TypedPoint3D<T, U> {
-        TypedPoint3D::new(p.x, p.y, p.z)
+    pub fn from_untyped(p: &Point3D<T>) -> Self {
+        point3(p.x, p.y, p.z)
     }
 
     /// Convert into a 2d point.
     #[inline]
     pub fn to_2d(&self) -> TypedPoint2D<T, U> {
-        TypedPoint2D::new(self.x, self.y)
+        point2(self.x, self.y)
     }
 }
 
-impl<T: Mul<T, Output=T> +
-        Add<T, Output=T> +
-        Sub<T, Output=T> +
-        Copy, U> TypedPoint3D<T, U> {
-
-    // Dot product.
+impl<T: Copy + Add<T, Output=T>, U> AddAssign<TypedVector3D<T, U>> for TypedPoint3D<T, U> {
     #[inline]
-    pub fn dot(self, other: TypedPoint3D<T, U>) -> T {
-        self.x * other.x +
-        self.y * other.y +
-        self.z * other.z
-    }
-
-    // Cross product.
-    #[inline]
-    pub fn cross(self, other: TypedPoint3D<T, U>) -> TypedPoint3D<T, U> {
-        TypedPoint3D::new(self.y * other.z - self.z * other.y,
-                          self.z * other.x - self.x * other.z,
-                          self.x * other.y - self.y * other.x)
-    }
-
-    #[inline]
-    pub fn normalize(self) -> Self where T: Float + ApproxEq<T> {
-        let dot = self.dot(self);
-        if dot.approx_eq(&T::zero()) {
-            self
-        } else {
-            self / dot.sqrt()
-        }
+    fn add_assign(&mut self, other: TypedVector3D<T, U>) {
+        *self = *self + other
     }
 }
 
-impl<T: Copy + Add<T, Output=T>, U> Add for TypedPoint3D<T, U> {
-    type Output = TypedPoint3D<T, U>;
-    fn add(self, other: TypedPoint3D<T, U>) -> TypedPoint3D<T, U> {
-        TypedPoint3D::new(self.x + other.x,
-                          self.y + other.y,
-                          self.z + other.z)
+impl<T: Copy + Sub<T, Output=T>, U> SubAssign<TypedVector3D<T, U>> for TypedPoint3D<T, U> {
+    #[inline]
+    fn sub_assign(&mut self, other: TypedVector3D<T, U>) {
+        *self = *self - other
+    }
+}
+
+impl<T: Copy + Add<T, Output=T>, U> Add<TypedVector3D<T, U>> for TypedPoint3D<T, U> {
+    type Output = Self;
+    #[inline]
+    fn add(self, other: TypedVector3D<T, U>) -> Self {
+        point3(self.x + other.x, self.y + other.y, self.z + other.z)
     }
 }
 
 impl<T: Copy + Sub<T, Output=T>, U> Sub for TypedPoint3D<T, U> {
-    type Output = TypedPoint3D<T, U>;
-    fn sub(self, other: TypedPoint3D<T, U>) -> TypedPoint3D<T, U> {
-        TypedPoint3D::new(self.x - other.x,
-                          self.y - other.y,
-                          self.z - other.z)
+    type Output = TypedVector3D<T, U>;
+    #[inline]
+    fn sub(self, other: Self) -> TypedVector3D<T, U> {
+        vec3(self.x - other.x, self.y - other.y, self.z - other.z)
     }
 }
 
-impl <T: Copy + Neg<Output=T>, U> Neg for TypedPoint3D<T, U> {
-    type Output = TypedPoint3D<T, U>;
+impl<T: Copy + Sub<T, Output=T>, U> Sub<TypedVector3D<T, U>> for TypedPoint3D<T, U> {
+    type Output = Self;
     #[inline]
-    fn neg(self) -> TypedPoint3D<T, U> {
-        TypedPoint3D::new(-self.x, -self.y, -self.z)
+    fn sub(self, other: TypedVector3D<T, U>) -> Self {
+        point3(self.x - other.x, self.y - other.y, self.z - other.z)
     }
 }
 
@@ -442,7 +462,7 @@ impl<T: Copy + Mul<T, Output=T>, U> Mul<T> for TypedPoint3D<T, U> {
     type Output = Self;
     #[inline]
     fn mul(self, scale: T) -> Self {
-        Self::new(self.x * scale, self.y * scale, self.z * scale)
+        point3(self.x * scale, self.y * scale, self.z * scale)
     }
 }
 
@@ -450,20 +470,19 @@ impl<T: Copy + Div<T, Output=T>, U> Div<T> for TypedPoint3D<T, U> {
     type Output = Self;
     #[inline]
     fn div(self, scale: T) -> Self {
-        Self::new(self.x / scale, self.y / scale, self.z / scale)
+        point3(self.x / scale, self.y / scale, self.z / scale)
     }
 }
 
 impl<T: Float, U> TypedPoint3D<T, U> {
-    pub fn min(self, other: TypedPoint3D<T, U>) -> TypedPoint3D<T, U> {
-         TypedPoint3D::new(self.x.min(other.x),
-                           self.y.min(other.y),
-                           self.z.min(other.z))
+    #[inline]
+    pub fn min(self, other: Self) -> Self {
+         point3(self.x.min(other.x), self.y.min(other.y), self.z.min(other.z))
     }
 
-    pub fn max(self, other: TypedPoint3D<T, U>) -> TypedPoint3D<T, U> {
-        TypedPoint3D::new(self.x.max(other.x), self.y.max(other.y),
-                     self.z.max(other.z))
+    #[inline]
+    pub fn max(self, other: Self) -> Self {
+        point3(self.x.max(other.x), self.y.max(other.y), self.z.max(other.z))
     }
 }
 
@@ -471,8 +490,9 @@ impl<T: Round, U> TypedPoint3D<T, U> {
     /// Rounds each component to the nearest integer value.
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
+    #[inline]
     pub fn round(&self) -> Self {
-        TypedPoint3D::new(self.x.round(), self.y.round(), self.z.round())
+        point3(self.x.round(), self.y.round(), self.z.round())
     }
 }
 
@@ -480,8 +500,9 @@ impl<T: Ceil, U> TypedPoint3D<T, U> {
     /// Rounds each component to the smallest integer equal or greater than the original value.
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
+    #[inline]
     pub fn ceil(&self) -> Self {
-        TypedPoint3D::new(self.x.ceil(), self.y.ceil(), self.z.ceil())
+        point3(self.x.ceil(), self.y.ceil(), self.z.ceil())
     }
 }
 
@@ -489,8 +510,9 @@ impl<T: Floor, U> TypedPoint3D<T, U> {
     /// Rounds each component to the biggest integer equal or lower than the original value.
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
+    #[inline]
     pub fn floor(&self) -> Self {
-        TypedPoint3D::new(self.x.floor(), self.y.floor(), self.z.floor())
+        point3(self.x.floor(), self.y.floor(), self.z.floor())
     }
 }
 
@@ -500,11 +522,12 @@ impl<T: NumCast + Copy, U> TypedPoint3D<T, U> {
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using round(), ceil or floor() before casting.
+    #[inline]
     pub fn cast<NewT: NumCast + Copy>(&self) -> Option<TypedPoint3D<NewT, U>> {
         match (NumCast::from(self.x),
                NumCast::from(self.y),
                NumCast::from(self.z)) {
-            (Some(x), Some(y), Some(z)) => Some(TypedPoint3D::new(x, y, z)),
+            (Some(x), Some(y), Some(z)) => Some(point3(x, y, z)),
             _ => None
         }
     }
@@ -512,6 +535,7 @@ impl<T: NumCast + Copy, U> TypedPoint3D<T, U> {
     // Convenience functions for common casts
 
     /// Cast into an `f32` point.
+    #[inline]
     pub fn to_f32(&self) -> TypedPoint3D<f32, U> {
         self.cast().unwrap()
     }
@@ -521,6 +545,7 @@ impl<T: NumCast + Copy, U> TypedPoint3D<T, U> {
     /// When casting from floating point points, it is worth considering whether
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
+    #[inline]
     pub fn to_usize(&self) -> TypedPoint3D<usize, U> {
         self.cast().unwrap()
     }
@@ -530,6 +555,7 @@ impl<T: NumCast + Copy, U> TypedPoint3D<T, U> {
     /// When casting from floating point points, it is worth considering whether
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
+    #[inline]
     pub fn to_i32(&self) -> TypedPoint3D<i32, U> {
         self.cast().unwrap()
     }
@@ -539,15 +565,16 @@ impl<T: NumCast + Copy, U> TypedPoint3D<T, U> {
     /// When casting from floating point points, it is worth considering whether
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
+    #[inline]
     pub fn to_i64(&self) -> TypedPoint3D<i64, U> {
         self.cast().unwrap()
     }
 }
 
-impl<T: Copy+ApproxEq<T>, U> ApproxEq<TypedPoint3D<T, U>> for TypedPoint3D<T, U> {
+impl<T: Copy+ApproxEq<T>, U> ApproxEq<Self> for TypedPoint3D<T, U> {
     #[inline]
     fn approx_epsilon() -> Self {
-        TypedPoint3D::new(T::approx_epsilon(), T::approx_epsilon(), T::approx_epsilon())
+        point3(T::approx_epsilon(), T::approx_epsilon(), T::approx_epsilon())
     }
 
     #[inline]
@@ -565,239 +592,6 @@ impl<T: Copy+ApproxEq<T>, U> ApproxEq<TypedPoint3D<T, U>> for TypedPoint3D<T, U>
     }
 }
 
-define_matrix! {
-    /// A 4d Point tagged with a unit.
-    pub struct TypedPoint4D<T, U> {
-        pub x: T,
-        pub y: T,
-        pub z: T,
-        pub w: T,
-    }
-}
-
-/// Default 4d point with no unit.
-///
-/// `Point4D` provides the same methods as `TypedPoint4D`.
-pub type Point4D<T> = TypedPoint4D<T, UnknownUnit>;
-
-impl<T: Copy + Zero, U> TypedPoint4D<T, U> {
-    /// Constructor, setting all copmonents to zero.
-    #[inline]
-    pub fn zero() -> TypedPoint4D<T, U> {
-        TypedPoint4D::new(Zero::zero(), Zero::zero(), Zero::zero(), Zero::zero())
-    }
-}
-
-impl<T: fmt::Debug, U> fmt::Debug for TypedPoint4D<T, U> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "({:?},{:?},{:?},{:?})", self.x, self.y, self.z, self.w)
-    }
-}
-
-impl<T: fmt::Display, U> fmt::Display for TypedPoint4D<T, U> {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "({},{},{},{})", self.x, self.y, self.z, self.w)
-    }
-}
-
-impl<T: Copy, U> TypedPoint4D<T, U> {
-    /// Constructor taking scalar values directly.
-    #[inline]
-    pub fn new(x: T, y: T, z: T, w: T) -> TypedPoint4D<T, U> {
-        TypedPoint4D { x: x, y: y, z: z, w: w, _unit: PhantomData }
-    }
-
-    /// Constructor taking properly typed Lengths instead of scalar values.
-    #[inline]
-    pub fn from_lengths(x: Length<T, U>,
-                        y: Length<T, U>,
-                        z: Length<T, U>,
-                        w: Length<T, U>) -> TypedPoint4D<T, U> {
-        TypedPoint4D::new(x.0, y.0, z.0, w.0)
-    }
-
-    /// Returns self.x as a Length carrying the unit.
-    #[inline]
-    pub fn x_typed(&self) -> Length<T, U> { Length::new(self.x) }
-
-    /// Returns self.y as a Length carrying the unit.
-    #[inline]
-    pub fn y_typed(&self) -> Length<T, U> { Length::new(self.y) }
-
-    /// Returns self.z as a Length carrying the unit.
-    #[inline]
-    pub fn z_typed(&self) -> Length<T, U> { Length::new(self.z) }
-
-    /// Returns self.w as a Length carrying the unit.
-    #[inline]
-    pub fn w_typed(&self) -> Length<T, U> { Length::new(self.w) }
-
-    /// Drop the units, preserving only the numeric value.
-    #[inline]
-    pub fn to_untyped(&self) -> Point4D<T> {
-        TypedPoint4D::new(self.x, self.y, self.z, self.w)
-    }
-
-    /// Tag a unitless value with units.
-    #[inline]
-    pub fn from_untyped(p: &Point4D<T>) -> TypedPoint4D<T, U> {
-        TypedPoint4D::new(p.x, p.y, p.z, p.w)
-    }
-
-    #[inline]
-    pub fn to_array(&self) -> [T; 4] {
-        [self.x, self.y, self.z, self.w]
-    }
-}
-
-impl<T: Copy + Div<T, Output=T>, U> TypedPoint4D<T, U> {
-    /// Convert into a 2d point.
-    #[inline]
-    pub fn to_2d(self) -> TypedPoint2D<T, U> {
-        TypedPoint2D::new(self.x / self.w, self.y / self.w)
-    }
-
-    /// Convert into a 3d point.
-    #[inline]
-    pub fn to_3d(self) -> TypedPoint3D<T, U> {
-        TypedPoint3D::new(self.x / self.w, self.y / self.w, self.z / self.w)
-    }
-}
-
-impl<T: Copy + Add<T, Output=T>, U> Add for TypedPoint4D<T, U> {
-    type Output = TypedPoint4D<T, U>;
-    fn add(self, other: TypedPoint4D<T, U>) -> TypedPoint4D<T, U> {
-        TypedPoint4D::new(self.x + other.x,
-                          self.y + other.y,
-                          self.z + other.z,
-                          self.w + other.w)
-    }
-}
-
-impl<T: Copy + Sub<T, Output=T>, U> Sub for TypedPoint4D<T, U> {
-    type Output = TypedPoint4D<T, U>;
-    fn sub(self, other: TypedPoint4D<T, U>) -> TypedPoint4D<T, U> {
-        TypedPoint4D::new(self.x - other.x,
-                          self.y - other.y,
-                          self.z - other.z,
-                          self.w - other.w)
-    }
-}
-
-impl <T: Copy + Neg<Output=T>, U> Neg for TypedPoint4D<T, U> {
-    type Output = TypedPoint4D<T, U>;
-    #[inline]
-    fn neg(self) -> TypedPoint4D<T, U> {
-        TypedPoint4D::new(-self.x, -self.y, -self.z, -self.w)
-    }
-}
-
-impl<T: Float, U> TypedPoint4D<T, U> {
-    pub fn min(self, other: TypedPoint4D<T, U>) -> TypedPoint4D<T, U> {
-         TypedPoint4D::new(self.x.min(other.x), self.y.min(other.y),
-                           self.z.min(other.z), self.w.min(other.w))
-    }
-
-    pub fn max(self, other: TypedPoint4D<T, U>) -> TypedPoint4D<T, U> {
-        TypedPoint4D::new(self.x.max(other.x), self.y.max(other.y),
-                          self.z.max(other.z), self.w.max(other.w))
-    }
-}
-
-impl<T: Round, U> TypedPoint4D<T, U> {
-    /// Rounds each component to the nearest integer value.
-    ///
-    /// This behavior is preserved for negative values (unlike the basic cast).
-    pub fn round(&self) -> Self {
-        TypedPoint4D::new(self.x.round(), self.y.round(), self.z.round(), self.w.round())
-    }
-}
-
-impl<T: Ceil, U> TypedPoint4D<T, U> {
-    /// Rounds each component to the smallest integer equal or greater than the original value.
-    ///
-    /// This behavior is preserved for negative values (unlike the basic cast).
-    pub fn ceil(&self) -> Self {
-        TypedPoint4D::new(self.x.ceil(), self.y.ceil(), self.z.ceil(), self.w.ceil())
-    }
-}
-
-impl<T: Floor, U> TypedPoint4D<T, U> {
-    /// Rounds each component to the biggest integer equal or lower than the original value.
-    ///
-    /// This behavior is preserved for negative values (unlike the basic cast).
-    pub fn floor(&self) -> Self {
-        TypedPoint4D::new(self.x.floor(), self.y.floor(), self.z.floor(), self.w.floor())
-    }
-}
-
-impl<T: NumCast + Copy, U> TypedPoint4D<T, U> {
-    /// Cast from one numeric representation to another, preserving the units.
-    ///
-    /// When casting from floating point to integer coordinates, the decimals are truncated
-    /// as one would expect from a simple cast, but this behavior does not always make sense
-    /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
-    pub fn cast<NewT: NumCast + Copy>(&self) -> Option<TypedPoint4D<NewT, U>> {
-        match (NumCast::from(self.x),
-               NumCast::from(self.y),
-               NumCast::from(self.z),
-               NumCast::from(self.w)) {
-            (Some(x), Some(y), Some(z), Some(w)) => Some(TypedPoint4D::new(x, y, z, w)),
-            _ => None
-        }
-    }
-
-    // Convenience functions for common casts
-
-    /// Cast into an `f32` point.
-    pub fn to_f32(&self) -> TypedPoint4D<f32, U> {
-        self.cast().unwrap()
-    }
-
-    /// Cast into an `usize` point, truncating decimals if any.
-    ///
-    /// When casting from floating point points, it is worth considering whether
-    /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
-    /// the desired conversion behavior.
-    pub fn to_usize(&self) -> TypedPoint4D<usize, U> {
-        self.cast().unwrap()
-    }
-
-    /// Cast into an `i32` point, truncating decimals if any.
-    ///
-    /// When casting from floating point points, it is worth considering whether
-    /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
-    /// the desired conversion behavior.
-    pub fn to_i32(&self) -> TypedPoint4D<i32, U> {
-        self.cast().unwrap()
-    }
-
-    /// Cast into an `i64` point, truncating decimals if any.
-    ///
-    /// When casting from floating point points, it is worth considering whether
-    /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
-    /// the desired conversion behavior.
-    pub fn to_i64(&self) -> TypedPoint4D<i64, U> {
-        self.cast().unwrap()
-    }
-}
-
-impl<T: ApproxEq<T>, U> ApproxEq<T> for TypedPoint4D<T, U> {
-    fn approx_epsilon() -> T {
-        T::approx_epsilon()
-    }
-
-    fn approx_eq_eps(&self, other: &Self, approx_epsilon: &T) -> bool {
-        self.x.approx_eq_eps(&other.x, approx_epsilon)
-        && self.y.approx_eq_eps(&other.y, approx_epsilon)
-        && self.z.approx_eq_eps(&other.z, approx_epsilon)
-        && self.w.approx_eq_eps(&other.w, approx_epsilon)
-    }
-
-    fn approx_eq(&self, other: &Self) -> bool {
-        self.approx_eq_eps(&other, &Self::approx_epsilon())
-    }
-}
 
 pub fn point2<T: Copy, U>(x: T, y: T) -> TypedPoint2D<T, U> {
     TypedPoint2D::new(x, y)
@@ -805,10 +599,6 @@ pub fn point2<T: Copy, U>(x: T, y: T) -> TypedPoint2D<T, U> {
 
 pub fn point3<T: Copy, U>(x: T, y: T, z: T) -> TypedPoint3D<T, U> {
     TypedPoint3D::new(x, y, z)
-}
-
-pub fn point4<T: Copy, U>(x: T, y: T, z: T, w: T) -> TypedPoint4D<T, U> {
-    TypedPoint4D::new(x, y, z, w)
 }
 
 #[cfg(test)]
@@ -822,31 +612,6 @@ mod point2d {
         let result = p1 * 5.0;
 
         assert_eq!(result, Point2D::new(15.0, 25.0));
-    }
-
-    #[test]
-    pub fn test_dot() {
-        let p1: Point2D<f32> = Point2D::new(2.0, 7.0);
-        let p2: Point2D<f32> = Point2D::new(13.0, 11.0);
-        assert_eq!(p1.dot(p2), 103.0);
-    }
-
-    #[test]
-    pub fn test_cross() {
-        let p1: Point2D<f32> = Point2D::new(4.0, 7.0);
-        let p2: Point2D<f32> = Point2D::new(13.0, 8.0);
-        let r = p1.cross(p2);
-        assert_eq!(r, -59.0);
-    }
-
-    #[test]
-    pub fn test_normalize() {
-        let p0: Point2D<f32> = Point2D::zero();
-        let p1: Point2D<f32> = Point2D::new(4.0, 0.0);
-        let p2: Point2D<f32> = Point2D::new(3.0, -4.0);
-        assert_eq!(p0.normalize(), p0);
-        assert_eq!(p1.normalize(), Point2D::new(1.0, 0.0));
-        assert_eq!(p2.normalize(), Point2D::new(0.6, -0.8));
     }
 
     #[test]
@@ -874,6 +639,7 @@ mod point2d {
 mod typedpoint2d {
     use super::TypedPoint2D;
     use scale_factor::ScaleFactor;
+    use vector::vec2;
 
     pub enum Mm {}
     pub enum Cm {}
@@ -884,7 +650,7 @@ mod typedpoint2d {
     #[test]
     pub fn test_add() {
         let p1 = Point2DMm::new(1.0, 2.0);
-        let p2 = Point2DMm::new(3.0, 4.0);
+        let p2 = vec2(3.0, 4.0);
 
         let result = p1 + p2;
 
@@ -894,7 +660,7 @@ mod typedpoint2d {
     #[test]
     pub fn test_add_assign() {
         let mut p1 = Point2DMm::new(1.0, 2.0);
-        p1 += Point2DMm::new(3.0, 4.0);
+        p1 += vec2(3.0, 4.0);
 
         assert_eq!(p1, Point2DMm::new(4.0, 6.0));
     }
@@ -915,31 +681,6 @@ mod point3d {
     use super::Point3D;
 
     #[test]
-    pub fn test_dot() {
-        let p1 = Point3D::new(7.0, 21.0, 32.0);
-        let p2 = Point3D::new(43.0, 5.0, 16.0);
-        assert_eq!(p1.dot(p2), 918.0);
-    }
-
-    #[test]
-    pub fn test_cross() {
-        let p1 = Point3D::new(4.0, 7.0, 9.0);
-        let p2 = Point3D::new(13.0, 8.0, 3.0);
-        let p3 = p1.cross(p2);
-        assert_eq!(p3, Point3D::new(-51.0, 105.0, -59.0));
-    }
-
-    #[test]
-    pub fn test_normalize() {
-        let p0: Point3D<f32> = Point3D::zero();
-        let p1: Point3D<f32> = Point3D::new(0.0, -6.0, 0.0);
-        let p2: Point3D<f32> = Point3D::new(1.0, 2.0, -2.0);
-        assert_eq!(p0.normalize(), p0);
-        assert_eq!(p1.normalize(), Point3D::new(0.0, -1.0, 0.0));
-        assert_eq!(p2.normalize(), Point3D::new(1.0/3.0, 2.0/3.0, -2.0/3.0));
-    }
-
-    #[test]
     pub fn test_min() {
         let p1 = Point3D::new(1.0, 3.0, 5.0);
         let p2 = Point3D::new(2.0, 2.0, -1.0);
@@ -957,50 +698,5 @@ mod point3d {
         let result = p1.max(p2);
 
         assert_eq!(result, Point3D::new(2.0, 3.0, 5.0));
-    }
-}
-
-#[cfg(test)]
-mod point4d {
-    use super::Point4D;
-
-    #[test]
-    pub fn test_add() {
-        let p1 = Point4D::new(7.0, 21.0, 32.0, 1.0);
-        let p2 = Point4D::new(43.0, 5.0, 16.0, 2.0);
-
-        let result = p1 + p2;
-
-        assert_eq!(result, Point4D::new(50.0, 26.0, 48.0, 3.0));
-    }
-
-    #[test]
-    pub fn test_sub() {
-        let p1 = Point4D::new(7.0, 21.0, 32.0, 1.0);
-        let p2 = Point4D::new(43.0, 5.0, 16.0, 2.0);
-
-        let result = p1 - p2;
-
-        assert_eq!(result, Point4D::new(-36.0, 16.0, 16.0, -1.0));
-    }
-
-    #[test]
-    pub fn test_min() {
-        let p1 = Point4D::new(1.0, 3.0, 5.0, 7.0);
-        let p2 = Point4D::new(2.0, 2.0, -1.0, 10.0);
-
-        let result = p1.min(p2);
-
-        assert_eq!(result, Point4D::new(1.0, 2.0, -1.0, 7.0));
-    }
-
-    #[test]
-    pub fn test_max() {
-        let p1 = Point4D::new(1.0, 3.0, 5.0, 7.0);
-        let p2 = Point4D::new(2.0, 2.0, -1.0, 10.0);
-
-        let result = p1.max(p2);
-
-        assert_eq!(result, Point4D::new(2.0, 3.0, 5.0, 10.0));
     }
 }

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -12,6 +12,7 @@ use length::Length;
 use scale_factor::ScaleFactor;
 use num::*;
 use point::TypedPoint2D;
+use vector::TypedVector2D;
 use size::TypedSize2D;
 
 use heapsize::HeapSizeOf;
@@ -154,13 +155,10 @@ where T: Copy + Clone + Zero + PartialOrd + PartialEq + Add<T, Output=T> + Sub<T
                                                     lower_right_y - upper_left.y)))
     }
 
-    /// Translates the rect by a vector.
+    /// Returns the same rectangle, translated by a vector.
     #[inline]
-    pub fn translate(&self, other: &TypedPoint2D<T, U>) -> TypedRect<T, U> {
-        TypedRect::new(
-            TypedPoint2D::new(self.origin.x + other.x, self.origin.y + other.y),
-            self.size
-        )
+    pub fn translate(&self, by: &TypedVector2D<T, U>) -> TypedRect<T, U> {
+        Self::new(self.origin + *by, self.size)
     }
 
     /// Returns true if this rectangle contains the point. Points are considered
@@ -212,7 +210,7 @@ where T: Copy + Clone + Zero + PartialOrd + PartialEq + Add<T, Output=T> + Sub<T
 
     #[inline]
     pub fn translate_by_size(&self, size: &TypedSize2D<T, U>) -> TypedRect<T, U> {
-        self.translate(&TypedPoint2D::new(size.width, size.height))
+        self.translate(&size.to_vector())
     }
 
     /// Returns the smallest rectangle containing the four points.
@@ -280,7 +278,7 @@ impl<T: Copy + PartialEq + Zero, U> TypedRect<T, U> {
     /// Constructor, setting all sides to zero.
     pub fn zero() -> TypedRect<T, U> {
         TypedRect::new(
-            TypedPoint2D::zero(),
+            TypedPoint2D::origin(),
             TypedSize2D::zero(),
         )
     }
@@ -434,6 +432,7 @@ pub fn rect<T: Copy, U>(x: T, y: T, w: T, h: T) -> TypedRect<T, U> {
 #[cfg(test)]
 mod tests {
     use point::Point2D;
+    use vector::vec2;
     use size::Size2D;
     use super::*;
 
@@ -449,7 +448,7 @@ mod tests {
     #[test]
     fn test_translate() {
         let p = Rect::new(Point2D::new(0u32, 0u32), Size2D::new(50u32, 40u32));
-        let pp = p.translate(&Point2D::new(10,15));
+        let pp = p.translate(&vec2(10,15));
 
         assert!(pp.size.width == 50);
         assert!(pp.size.height == 40);
@@ -458,7 +457,7 @@ mod tests {
 
 
         let r = Rect::new(Point2D::new(-10, -5), Size2D::new(50, 40));
-        let rr = r.translate(&Point2D::new(0,-10));
+        let rr = r.translate(&vec2(0,-10));
 
         assert!(rr.size.width == 50);
         assert!(rr.size.height == 40);
@@ -561,10 +560,10 @@ mod tests {
 
         let r = Rect::new(Point2D::new(-20.0, 15.0), Size2D::new(100.0, 200.0));
         assert!(r.contains_rect(&r));
-        assert!(!r.contains_rect(&r.translate(&Point2D::new( 0.1,  0.0))));
-        assert!(!r.contains_rect(&r.translate(&Point2D::new(-0.1,  0.0))));
-        assert!(!r.contains_rect(&r.translate(&Point2D::new( 0.0,  0.1))));
-        assert!(!r.contains_rect(&r.translate(&Point2D::new( 0.0, -0.1))));
+        assert!(!r.contains_rect(&r.translate(&vec2( 0.1,  0.0))));
+        assert!(!r.contains_rect(&r.translate(&vec2(-0.1,  0.0))));
+        assert!(!r.contains_rect(&r.translate(&vec2( 0.0,  0.1))));
+        assert!(!r.contains_rect(&r.translate(&vec2( 0.0, -0.1))));
         // Empty rectangles are always considered as contained in other rectangles,
         // even if their origin is not.
         let p = Point2D::new(1.0, 1.0);

--- a/src/size.rs
+++ b/src/size.rs
@@ -10,6 +10,7 @@
 use super::UnknownUnit;
 use length::Length;
 use scale_factor::ScaleFactor;
+use vector::{TypedVector2D, vec2};
 use num::*;
 
 use num_traits::NumCast;
@@ -166,6 +167,9 @@ impl<T: Copy, U> TypedSize2D<T, U> {
 
     #[inline]
     pub fn to_array(&self) -> [T; 2] { [self.width, self.height] }
+
+    #[inline]
+    pub fn to_vector(&self) -> TypedVector2D<T, U> { vec2(self.width, self.height) }
 
     /// Drop the units, preserving only the numeric value.
     pub fn to_untyped(&self) -> Size2D<T> {

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -10,7 +10,8 @@
 use super::{UnknownUnit, Radians};
 use approxeq::ApproxEq;
 use trig::Trig;
-use point::{TypedPoint2D, TypedPoint3D, TypedPoint4D};
+use point::{TypedPoint2D, TypedPoint3D, point2, point3};
+use vector::{TypedVector2D, TypedVector3D, vec2, vec3};
 use rect::TypedRect;
 use transform2d::TypedTransform2D;
 use scale_factor::ScaleFactor;
@@ -24,8 +25,8 @@ define_matrix! {
     ///
     /// Transforms can be parametrized over the source and destination units, to describe a
     /// transformation from a space to another.
-    /// For example, `TypedTransform3D<f32, WordSpace, ScreenSpace>::transform_point4d`
-    /// takes a `TypedPoint4D<f32, WordSpace>` and returns a `TypedPoint4D<f32, ScreenSpace>`.
+    /// For example, `TypedTransform3D<f32, WordSpace, ScreenSpace>::transform_point3d`
+    /// takes a `TypedPoint3D<f32, WordSpace>` and returns a `TypedPoint3D<f32, ScreenSpace>`.
     ///
     /// Transforms expose a set of convenience methods for pre- and post-transformations.
     /// A pre-transformation corresponds to adding an operation that is applied before
@@ -387,8 +388,24 @@ where T: Copy + Clone +
     ///
     /// The input point must be use the unit Src, and the returned point has the unit Dst.
     #[inline]
-    pub fn transform_point(&self, p: &TypedPoint2D<T, Src>) -> TypedPoint2D<T, Dst> {
-        self.transform_point4d(&TypedPoint4D::new(p.x, p.y, Zero::zero(), One::one())).to_2d()
+    pub fn transform_point2d(&self, p: &TypedPoint2D<T, Src>) -> TypedPoint2D<T, Dst> {
+        let x = p.x * self.m11 + p.y * self.m21 + self.m41;
+        let y = p.x * self.m12 + p.y * self.m22 + self.m42;
+
+        let w = p.x * self.m14 + p.y * self.m24 + self.m44;
+
+        point2(x/w, y/w)
+    }
+
+    /// Returns the given 2d vector transformed by this matrix.
+    ///
+    /// The input point must be use the unit Src, and the returned point has the unit Dst.
+    #[inline]
+    pub fn transform_vector2d(&self, v: &TypedVector2D<T, Src>) -> TypedVector2D<T, Dst> {
+        vec2(
+            v.x * self.m11 + v.y * self.m21,
+            v.x * self.m12 + v.y * self.m22,
+        )
     }
 
     /// Returns the given 3d point transformed by this transform.
@@ -396,29 +413,34 @@ where T: Copy + Clone +
     /// The input point must be use the unit Src, and the returned point has the unit Dst.
     #[inline]
     pub fn transform_point3d(&self, p: &TypedPoint3D<T, Src>) -> TypedPoint3D<T, Dst> {
-        self.transform_point4d(&TypedPoint4D::new(p.x, p.y, p.z, One::one())).to_3d()
+        let x = p.x * self.m11 + p.y * self.m21 + p.z * self.m31 + self.m41;
+        let y = p.x * self.m12 + p.y * self.m22 + p.z * self.m32 + self.m42;
+        let z = p.x * self.m13 + p.y * self.m23 + p.z * self.m33 + self.m43;
+        let w = p.x * self.m14 + p.y * self.m24 + p.z * self.m34 + self.m44;
+
+        point3(x/w, y/w, z/w)
     }
 
-    /// Returns the given 4d point transformed by this transform.
+    /// Returns the given 3d vector transformed by this matrix.
     ///
     /// The input point must be use the unit Src, and the returned point has the unit Dst.
     #[inline]
-    pub fn transform_point4d(&self, p: &TypedPoint4D<T, Src>) -> TypedPoint4D<T, Dst> {
-        let x = p.x * self.m11 + p.y * self.m21 + p.z * self.m31 + p.w * self.m41;
-        let y = p.x * self.m12 + p.y * self.m22 + p.z * self.m32 + p.w * self.m42;
-        let z = p.x * self.m13 + p.y * self.m23 + p.z * self.m33 + p.w * self.m43;
-        let w = p.x * self.m14 + p.y * self.m24 + p.z * self.m34 + p.w * self.m44;
-        TypedPoint4D::new(x, y, z, w)
+    pub fn transform_vector3d(&self, v: &TypedVector3D<T, Src>) -> TypedVector3D<T, Dst> {
+        vec3(
+            v.x * self.m11 + v.y * self.m21 + v.z * self.m31,
+            v.x * self.m12 + v.y * self.m22 + v.z * self.m32,
+            v.x * self.m13 + v.y * self.m23 + v.z * self.m33,
+        )
     }
 
     /// Returns a rectangle that encompasses the result of transforming the given rectangle by this
     /// transform.
     pub fn transform_rect(&self, rect: &TypedRect<T, Src>) -> TypedRect<T, Dst> {
         TypedRect::from_points(&[
-            self.transform_point(&rect.origin),
-            self.transform_point(&rect.top_right()),
-            self.transform_point(&rect.bottom_left()),
-            self.transform_point(&rect.bottom_right()),
+            self.transform_point2d(&rect.origin),
+            self.transform_point2d(&rect.top_right()),
+            self.transform_point2d(&rect.bottom_left()),
+            self.transform_point2d(&rect.bottom_right()),
         ])
     }
 
@@ -434,13 +456,13 @@ where T: Copy + Clone +
     }
 
     /// Returns a transform with a translation applied before self's transformation.
-    pub fn pre_translated(&self, x: T, y: T, z: T) -> TypedTransform3D<T, Src, Dst> {
-        self.pre_mul(&TypedTransform3D::create_translation(x, y, z))
+    pub fn pre_translated(&self, v: TypedVector3D<T, Dst>) -> TypedTransform3D<T, Src, Dst> {
+        self.pre_mul(&TypedTransform3D::create_translation(v.x, v.y, v.z))
     }
 
     /// Returns a transform with a translation applied after self's transformation.
-    pub fn post_translated(&self, x: T, y: T, z: T) -> TypedTransform3D<T, Src, Dst> {
-        self.post_mul(&TypedTransform3D::create_translation(x, y, z))
+    pub fn post_translated(&self, v: TypedVector3D<T, Dst>) -> TypedTransform3D<T, Src, Dst> {
+        self.post_mul(&TypedTransform3D::create_translation(v.x, v.y, v.z))
     }
 
     /// Create a 3d scale transform
@@ -608,7 +630,7 @@ where T: Copy + fmt::Debug +
 mod tests {
     use approxeq::ApproxEq;
     use transform2d::Transform2D;
-    use point::{Point2D, Point3D, Point4D};
+    use point::{Point2D, Point3D};
     use Radians;
     use super::*;
 
@@ -622,13 +644,13 @@ mod tests {
     #[test]
     pub fn test_translation() {
         let t1 = Mf32::create_translation(1.0, 2.0, 3.0);
-        let t2 = Mf32::identity().pre_translated(1.0, 2.0, 3.0);
-        let t3 = Mf32::identity().post_translated(1.0, 2.0, 3.0);
+        let t2 = Mf32::identity().pre_translated(vec3(1.0, 2.0, 3.0));
+        let t3 = Mf32::identity().post_translated(vec3(1.0, 2.0, 3.0));
         assert_eq!(t1, t2);
         assert_eq!(t1, t3);
 
         assert_eq!(t1.transform_point3d(&Point3D::new(1.0, 1.0, 1.0)), Point3D::new(2.0, 3.0, 4.0));
-        assert_eq!(t1.transform_point(&Point2D::new(1.0, 1.0)), Point2D::new(2.0, 3.0));
+        assert_eq!(t1.transform_point2d(&Point2D::new(1.0, 1.0)), Point2D::new(2.0, 3.0));
 
         assert_eq!(t1.post_mul(&t1), Mf32::create_translation(2.0, 4.0, 6.0));
 
@@ -645,7 +667,7 @@ mod tests {
         assert_eq!(r1, r3);
 
         assert!(r1.transform_point3d(&Point3D::new(1.0, 2.0, 3.0)).approx_eq(&Point3D::new(2.0, -1.0, 3.0)));
-        assert!(r1.transform_point(&Point2D::new(1.0, 2.0)).approx_eq(&Point2D::new(2.0, -1.0)));
+        assert!(r1.transform_point2d(&Point2D::new(1.0, 2.0)).approx_eq(&Point2D::new(2.0, -1.0)));
 
         assert!(r1.post_mul(&r1).approx_eq(&Mf32::create_rotation(0.0, 0.0, 1.0, rad(FRAC_PI_2*2.0))));
 
@@ -662,7 +684,7 @@ mod tests {
         assert_eq!(s1, s3);
 
         assert!(s1.transform_point3d(&Point3D::new(2.0, 2.0, 2.0)).approx_eq(&Point3D::new(4.0, 6.0, 8.0)));
-        assert!(s1.transform_point(&Point2D::new(2.0, 2.0)).approx_eq(&Point2D::new(4.0, 6.0)));
+        assert!(s1.transform_point2d(&Point2D::new(2.0, 2.0)).approx_eq(&Point2D::new(4.0, 6.0)));
 
         assert_eq!(s1.post_mul(&s1), Mf32::create_scale(4.0, 9.0, 16.0));
 
@@ -757,10 +779,10 @@ mod tests {
         assert!(m1.pre_mul(&m2).approx_eq(&Mf32::identity()));
 
         let p1 = Point2D::new(1000.0, 2000.0);
-        let p2 = m1.transform_point(&p1);
+        let p2 = m1.transform_point2d(&p1);
         assert!(p2.eq(&Point2D::new(1100.0, 2200.0)));
 
-        let p3 = m2.transform_point(&p2);
+        let p3 = m2.transform_point2d(&p2);
         assert!(p3.eq(&p1));
     }
 
@@ -772,8 +794,8 @@ mod tests {
 
     #[test]
     pub fn test_pre_post() {
-        let m1 = Transform3D::identity().post_scaled(1.0, 2.0, 3.0).post_translated(1.0, 2.0, 3.0);
-        let m2 = Transform3D::identity().pre_translated(1.0, 2.0, 3.0).pre_scaled(1.0, 2.0, 3.0);
+        let m1 = Transform3D::identity().post_scaled(1.0, 2.0, 3.0).post_translated(vec3(1.0, 2.0, 3.0));
+        let m2 = Transform3D::identity().pre_translated(vec3(1.0, 2.0, 3.0)).pre_scaled(1.0, 2.0, 3.0);
         assert!(m1.approx_eq(&m2));
 
         let r = Mf32::create_rotation(0.0, 0.0, 1.0, rad(FRAC_PI_2));
@@ -808,9 +830,9 @@ mod tests {
                                  1.5, -2.0, 6.0, 0.0,
                                  -2.5, 6.0, 1.0, 1.0);
 
-        let p = Point4D::new(1.0, 3.0, 5.0, 1.0);
-        let p1 = m2.pre_mul(&m1).transform_point4d(&p);
-        let p2 = m2.transform_point4d(&m1.transform_point4d(&p));
+        let p = Point3D::new(1.0, 3.0, 5.0);
+        let p1 = m2.pre_mul(&m1).transform_point3d(&p);
+        let p2 = m2.transform_point3d(&m1.transform_point3d(&p));
         assert!(p1.approx_eq(&p2));
     }
 
@@ -818,7 +840,22 @@ mod tests {
     pub fn test_is_identity() {
         let m1 = Transform3D::identity();
         assert!(m1.is_identity());
-        let m2 = m1.post_translated(0.1, 0.0, 0.0);
+        let m2 = m1.post_translated(vec3(0.1, 0.0, 0.0));
         assert!(!m2.is_identity());
+    }
+
+    #[test]
+    pub fn test_transform_vector() {
+        // Translation does not apply to vectors.
+        let m = Mf32::create_translation(1.0, 2.0, 3.0);
+        let v1 = vec3(10.0, -10.0, 3.0);
+        assert_eq!(v1, m.transform_vector3d(&v1));
+        // While it does apply to points.
+        assert!(v1.to_point() != m.transform_point3d(&v1.to_point()));
+
+        // same thing with 2d vectors/points
+        let v2 = vec2(10.0, -5.0);
+        assert_eq!(v2, m.transform_vector2d(&v2));
+        assert!(v2.to_point() != m.transform_point2d(&v2.to_point()));
     }
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,0 +1,833 @@
+// Copyright 2013 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use super::UnknownUnit;
+use approxeq::ApproxEq;
+use length::Length;
+use point::{TypedPoint2D, TypedPoint3D, point2, point3};
+use size::{TypedSize2D, size2};
+use scale_factor::ScaleFactor;
+use num::*;
+use num_traits::{Float, NumCast};
+use std::fmt;
+use std::ops::{Add, Neg, Mul, Sub, Div, AddAssign, SubAssign, MulAssign, DivAssign};
+use std::marker::PhantomData;
+
+define_matrix! {
+    /// A 2d Vector tagged with a unit.
+    pub struct TypedVector2D<T, U> {
+        pub x: T,
+        pub y: T,
+    }
+}
+
+/// Default 2d vector type with no unit.
+///
+/// `Vector2D` provides the same methods as `TypedVector2D`.
+pub type Vector2D<T> = TypedVector2D<T, UnknownUnit>;
+
+impl<T: Copy + Zero, U> TypedVector2D<T, U> {
+    /// Constructor, setting all components to zero.
+    #[inline]
+    pub fn zero() -> Self {
+        TypedVector2D::new(Zero::zero(), Zero::zero())
+    }
+
+    /// Convert into a 3d vector.
+    #[inline]
+    pub fn to_3d(&self) -> TypedVector3D<T, U> {
+        vec3(self.x, self.y, Zero::zero())
+    }
+}
+
+impl<T: fmt::Debug, U> fmt::Debug for TypedVector2D<T, U> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({:?},{:?})", self.x, self.y)
+    }
+}
+
+impl<T: fmt::Display, U> fmt::Display for TypedVector2D<T, U> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "({},{})", self.x, self.y)
+    }
+}
+
+impl<T: Copy, U> TypedVector2D<T, U> {
+    /// Constructor taking scalar values directly.
+    #[inline]
+    pub fn new(x: T, y: T) -> Self {
+        TypedVector2D { x: x, y: y, _unit: PhantomData }
+    }
+
+    /// Constructor taking properly typed Lengths instead of scalar values.
+    #[inline]
+    pub fn from_lengths(x: Length<T, U>, y: Length<T, U>) -> Self {
+        vec2(x.0, y.0)
+    }
+
+    /// Cast this vector into a point.
+    ///
+    /// Equivalent to adding this vector to the origin.
+    #[inline]
+    pub fn to_point(&self) -> TypedPoint2D<T, U> {
+        point2(self.x, self.y)
+    }
+
+    /// Cast this vector into a size.
+    #[inline]
+    pub fn to_size(&self) -> TypedSize2D<T, U> {
+        size2(self.x, self.y)
+    }
+
+
+    /// Returns self.x as a Length carrying the unit.
+    #[inline]
+    pub fn x_typed(&self) -> Length<T, U> { Length::new(self.x) }
+
+    /// Returns self.y as a Length carrying the unit.
+    #[inline]
+    pub fn y_typed(&self) -> Length<T, U> { Length::new(self.y) }
+
+    /// Drop the units, preserving only the numeric value.
+    #[inline]
+    pub fn to_untyped(&self) -> Vector2D<T> {
+        vec2(self.x, self.y)
+    }
+
+    /// Tag a unitless value with units.
+    #[inline]
+    pub fn from_untyped(p: &Vector2D<T>) -> Self {
+        vec2(p.x, p.y)
+    }
+
+    #[inline]
+    pub fn to_array(&self) -> [T; 2] {
+        [self.x, self.y]
+    }
+}
+
+impl<T, U> TypedVector2D<T, U>
+where T: Copy + Mul<T, Output=T> + Add<T, Output=T> + Sub<T, Output=T> {
+    /// Dot product.
+    #[inline]
+    pub fn dot(self, other: Self) -> T {
+        self.x * other.x + self.y * other.y
+    }
+
+    /// Returns the norm of the cross product [self.x, self.y, 0] x [other.x, other.y, 0]..
+    #[inline]
+    pub fn cross(self, other: Self) -> T {
+        self.x * other.y - self.y * other.x
+    }
+
+    #[inline]
+    pub fn normalize(self) -> Self where T: Float + ApproxEq<T> {
+        let dot = self.dot(self);
+        if dot.approx_eq(&T::zero()) {
+            self
+        } else {
+            self / dot.sqrt()
+        }
+    }
+
+    #[inline]
+    pub fn square_length(&self) -> T {
+        self.x * self.x + self.y * self.y
+    }
+
+    #[inline]
+    pub fn length(&self) -> T where T: Float + ApproxEq<T> {
+        self.square_length().sqrt()
+    }
+}
+
+impl<T: Copy + Add<T, Output=T>, U> Add for TypedVector2D<T, U> {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        TypedVector2D::new(self.x + other.x, self.y + other.y)
+    }
+}
+
+impl<T: Copy + Add<T, Output=T>, U> AddAssign for TypedVector2D<T, U> {
+    #[inline]
+    fn add_assign(&mut self, other: Self) {
+        *self = *self + other
+    }
+}
+
+impl<T: Copy + Sub<T, Output=T>, U> SubAssign<TypedVector2D<T, U>> for TypedVector2D<T, U> {
+    #[inline]
+    fn sub_assign(&mut self, other: Self) {
+        *self = *self - other
+    }
+}
+
+impl<T: Copy + Sub<T, Output=T>, U> Sub for TypedVector2D<T, U> {
+    type Output = Self;
+    #[inline]
+    fn sub(self, other: TypedVector2D<T, U>) -> Self {
+        vec2(self.x - other.x, self.y - other.y)
+    }
+}
+
+impl <T: Copy + Neg<Output=T>, U> Neg for TypedVector2D<T, U> {
+    type Output = Self;
+    #[inline]
+    fn neg(self) -> Self {
+        vec2(-self.x, -self.y)
+    }
+}
+
+impl<T: Float, U> TypedVector2D<T, U> {
+    #[inline]
+    pub fn min(self, other: TypedVector2D<T, U>) -> Self {
+         vec2(self.x.min(other.x), self.y.min(other.y))
+    }
+
+    #[inline]
+    pub fn max(self, other: TypedVector2D<T, U>) -> Self {
+        vec2(self.x.max(other.x), self.y.max(other.y))
+    }
+}
+
+impl<T: Copy + Mul<T, Output=T>, U> Mul<T> for TypedVector2D<T, U> {
+    type Output = Self;
+    #[inline]
+    fn mul(self, scale: T) -> Self {
+        vec2(self.x * scale, self.y * scale)
+    }
+}
+
+impl<T: Copy + Div<T, Output=T>, U> Div<T> for TypedVector2D<T, U> {
+    type Output = Self;
+    #[inline]
+    fn div(self, scale: T) -> Self {
+        vec2(self.x / scale, self.y / scale)
+    }
+}
+
+impl<T: Copy + Mul<T, Output=T>, U> MulAssign<T> for TypedVector2D<T, U> {
+    #[inline]
+    fn mul_assign(&mut self, scale: T) {
+        *self = *self * scale
+    }
+}
+
+impl<T: Copy + Div<T, Output=T>, U> DivAssign<T> for TypedVector2D<T, U> {
+    #[inline]
+    fn div_assign(&mut self, scale: T) {
+        *self = *self / scale
+    }
+}
+
+impl<T: Copy + Mul<T, Output=T>, U1, U2> Mul<ScaleFactor<T, U1, U2>> for TypedVector2D<T, U1> {
+    type Output = TypedVector2D<T, U2>;
+    #[inline]
+    fn mul(self, scale: ScaleFactor<T, U1, U2>) -> TypedVector2D<T, U2> {
+        vec2(self.x * scale.get(), self.y * scale.get())
+    }
+}
+
+impl<T: Copy + Div<T, Output=T>, U1, U2> Div<ScaleFactor<T, U1, U2>> for TypedVector2D<T, U2> {
+    type Output = TypedVector2D<T, U1>;
+    #[inline]
+    fn div(self, scale: ScaleFactor<T, U1, U2>) -> TypedVector2D<T, U1> {
+        vec2(self.x / scale.get(), self.y / scale.get())
+    }
+}
+
+impl<T: Round, U> TypedVector2D<T, U> {
+    /// Rounds each component to the nearest integer value.
+    ///
+    /// This behavior is preserved for negative values (unlike the basic cast).
+    /// For example `{ -0.1, -0.8 }.round() == { 0.0, -1.0 }`.
+    #[inline]
+    pub fn round(&self) -> Self {
+        vec2(self.x.round(), self.y.round())
+    }
+}
+
+impl<T: Ceil, U> TypedVector2D<T, U> {
+    /// Rounds each component to the smallest integer equal or greater than the original value.
+    ///
+    /// This behavior is preserved for negative values (unlike the basic cast).
+    /// For example `{ -0.1, -0.8 }.ceil() == { 0.0, 0.0 }`.
+    #[inline]
+    pub fn ceil(&self) -> Self {
+        vec2(self.x.ceil(), self.y.ceil())
+    }
+}
+
+impl<T: Floor, U> TypedVector2D<T, U> {
+    /// Rounds each component to the biggest integer equal or lower than the original value.
+    ///
+    /// This behavior is preserved for negative values (unlike the basic cast).
+    /// For example `{ -0.1, -0.8 }.floor() == { -1.0, -1.0 }`.
+    #[inline]
+    pub fn floor(&self) -> Self {
+        vec2(self.x.floor(), self.y.floor())
+    }
+}
+
+impl<T: NumCast + Copy, U> TypedVector2D<T, U> {
+    /// Cast from one numeric representation to another, preserving the units.
+    ///
+    /// When casting from floating vector to integer coordinates, the decimals are truncated
+    /// as one would expect from a simple cast, but this behavior does not always make sense
+    /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
+    #[inline]
+    pub fn cast<NewT: NumCast + Copy>(&self) -> Option<TypedVector2D<NewT, U>> {
+        match (NumCast::from(self.x), NumCast::from(self.y)) {
+            (Some(x), Some(y)) => Some(TypedVector2D::new(x, y)),
+            _ => None
+        }
+    }
+
+    // Convenience functions for common casts
+
+    /// Cast into an `f32` vector.
+    #[inline]
+    pub fn to_f32(&self) -> TypedVector2D<f32, U> {
+        self.cast().unwrap()
+    }
+
+    /// Cast into an `usize` vector, truncating decimals if any.
+    ///
+    /// When casting from floating vector vectors, it is worth considering whether
+    /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
+    /// the desired conversion behavior.
+    #[inline]
+    pub fn to_usize(&self) -> TypedVector2D<usize, U> {
+        self.cast().unwrap()
+    }
+
+    /// Cast into an i32 vector, truncating decimals if any.
+    ///
+    /// When casting from floating vector vectors, it is worth considering whether
+    /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
+    /// the desired conversion behavior.
+    #[inline]
+    pub fn to_i32(&self) -> TypedVector2D<i32, U> {
+        self.cast().unwrap()
+    }
+
+    /// Cast into an i64 vector, truncating decimals if any.
+    ///
+    /// When casting from floating vector vectors, it is worth considering whether
+    /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
+    /// the desired conversion behavior.
+    #[inline]
+    pub fn to_i64(&self) -> TypedVector2D<i64, U> {
+        self.cast().unwrap()
+    }
+}
+
+impl<T: Copy+ApproxEq<T>, U> ApproxEq<TypedVector2D<T, U>> for TypedVector2D<T, U> {
+    #[inline]
+    fn approx_epsilon() -> Self {
+        vec2(T::approx_epsilon(), T::approx_epsilon())
+    }
+
+    #[inline]
+    fn approx_eq(&self, other: &Self) -> bool {
+        self.x.approx_eq(&other.x) && self.y.approx_eq(&other.y)
+    }
+
+    #[inline]
+    fn approx_eq_eps(&self, other: &Self, eps: &Self) -> bool {
+        self.x.approx_eq_eps(&other.x, &eps.x) && self.y.approx_eq_eps(&other.y, &eps.y)
+    }
+}
+
+define_matrix! {
+    /// A 3d Vector tagged with a unit.
+    pub struct TypedVector3D<T, U> {
+        pub x: T,
+        pub y: T,
+        pub z: T,
+    }
+}
+
+/// Default 3d vector type with no unit.
+///
+/// `Vector3D` provides the same methods as `TypedVector3D`.
+pub type Vector3D<T> = TypedVector3D<T, UnknownUnit>;
+
+impl<T: Copy + Zero, U> TypedVector3D<T, U> {
+    /// Constructor, setting all copmonents to zero.
+    #[inline]
+    pub fn zero() -> Self {
+        vec3(Zero::zero(), Zero::zero(), Zero::zero())
+    }
+
+    #[inline]
+    pub fn to_array_4d(&self) -> [T; 4] {
+        [self.x, self.y, self.z, Zero::zero()]
+    }
+}
+
+impl<T: fmt::Debug, U> fmt::Debug for TypedVector3D<T, U> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({:?},{:?},{:?})", self.x, self.y, self.z)
+    }
+}
+
+impl<T: fmt::Display, U> fmt::Display for TypedVector3D<T, U> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({},{},{})", self.x, self.y, self.z)
+    }
+}
+
+impl<T: Copy, U> TypedVector3D<T, U> {
+    /// Constructor taking scalar values directly.
+    #[inline]
+    pub fn new(x: T, y: T, z: T) -> Self {
+        TypedVector3D { x: x, y: y, z: z, _unit: PhantomData }
+    }
+
+    /// Constructor taking properly typed Lengths instead of scalar values.
+    #[inline]
+    pub fn from_lengths(x: Length<T, U>, y: Length<T, U>, z: Length<T, U>) -> TypedVector3D<T, U> {
+        vec3(x.0, y.0, z.0)
+    }
+
+    /// Cast this vector into a point.
+    ///
+    /// Equivalent to adding this vector to the origin.
+    #[inline]
+    pub fn to_point(&self) -> TypedPoint3D<T, U> {
+        point3(self.x, self.y, self.z)
+    }
+
+    /// Returns self.x as a Length carrying the unit.
+    #[inline]
+    pub fn x_typed(&self) -> Length<T, U> { Length::new(self.x) }
+
+    /// Returns self.y as a Length carrying the unit.
+    #[inline]
+    pub fn y_typed(&self) -> Length<T, U> { Length::new(self.y) }
+
+    /// Returns self.z as a Length carrying the unit.
+    #[inline]
+    pub fn z_typed(&self) -> Length<T, U> { Length::new(self.z) }
+
+    #[inline]
+    pub fn to_array(&self) -> [T; 3] { [self.x, self.y, self.z] }
+
+    /// Drop the units, preserving only the numeric value.
+    #[inline]
+    pub fn to_untyped(&self) -> Vector3D<T> {
+        vec3(self.x, self.y, self.z)
+    }
+
+    /// Tag a unitless value with units.
+    #[inline]
+    pub fn from_untyped(p: &Vector3D<T>) -> Self {
+        vec3(p.x, p.y, p.z)
+    }
+
+    /// Convert into a 2d vector.
+    #[inline]
+    pub fn to_2d(&self) -> TypedVector2D<T, U> {
+        vec2(self.x, self.y)
+    }
+}
+
+impl<T: Mul<T, Output=T> +
+        Add<T, Output=T> +
+        Sub<T, Output=T> +
+        Copy, U> TypedVector3D<T, U> {
+
+    // Dot product.
+    #[inline]
+    pub fn dot(self, other: Self) -> T {
+        self.x * other.x +
+        self.y * other.y +
+        self.z * other.z
+    }
+
+    // Cross product.
+    #[inline]
+    pub fn cross(self, other: TypedVector3D<T, U>) -> Self {
+        vec3(
+            self.y * other.z - self.z * other.y,
+            self.z * other.x - self.x * other.z,
+            self.x * other.y - self.y * other.x
+        )
+    }
+
+    #[inline]
+    pub fn normalize(self) -> Self where T: Float + ApproxEq<T> {
+        let dot = self.dot(self);
+        if dot.approx_eq(&T::zero()) {
+            self
+        } else {
+            self / dot.sqrt()
+        }
+    }
+
+    #[inline]
+    pub fn square_length(&self) -> T {
+        self.x * self.x + self.y * self.y + self.z * self.z
+    }
+
+    #[inline]
+    pub fn length(&self) -> T where T: Float + ApproxEq<T> {
+        self.square_length().sqrt()
+    }
+}
+
+impl<T: Copy + Add<T, Output=T>, U> Add for TypedVector3D<T, U> {
+    type Output = TypedVector3D<T, U>;
+    #[inline]
+    fn add(self, other: TypedVector3D<T, U>) -> Self {
+        vec3(self.x + other.x, self.y + other.y, self.z + other.z)
+    }
+}
+
+impl<T: Copy + Sub<T, Output=T>, U> Sub for TypedVector3D<T, U> {
+    type Output = TypedVector3D<T, U>;
+    #[inline]
+    fn sub(self, other: TypedVector3D<T, U>) -> Self {
+        vec3(self.x - other.x, self.y - other.y, self.z - other.z)
+    }
+}
+
+impl<T: Copy + Add<T, Output=T>, U> AddAssign for TypedVector3D<T, U> {
+    #[inline]
+    fn add_assign(&mut self, other: Self) {
+        *self = *self + other
+    }
+}
+
+impl<T: Copy + Sub<T, Output=T>, U> SubAssign<TypedVector3D<T, U>> for TypedVector3D<T, U> {
+    #[inline]
+    fn sub_assign(&mut self, other: Self) {
+        *self = *self - other
+    }
+}
+
+impl <T: Copy + Neg<Output=T>, U> Neg for TypedVector3D<T, U> {
+    type Output = Self;
+    #[inline]
+    fn neg(self) -> Self {
+        vec3(-self.x, -self.y, -self.z)
+    }
+}
+
+impl<T: Copy + Mul<T, Output=T>, U> Mul<T> for TypedVector3D<T, U> {
+    type Output = Self;
+    #[inline]
+    fn mul(self, scale: T) -> Self {
+        Self::new(self.x * scale, self.y * scale, self.z * scale)
+    }
+}
+
+impl<T: Copy + Div<T, Output=T>, U> Div<T> for TypedVector3D<T, U> {
+    type Output = Self;
+    #[inline]
+    fn div(self, scale: T) -> Self {
+        Self::new(self.x / scale, self.y / scale, self.z / scale)
+    }
+}
+
+impl<T: Copy + Mul<T, Output=T>, U> MulAssign<T> for TypedVector3D<T, U> {
+    #[inline]
+    fn mul_assign(&mut self, scale: T) {
+        *self = *self * scale
+    }
+}
+
+impl<T: Copy + Div<T, Output=T>, U> DivAssign<T> for TypedVector3D<T, U> {
+    #[inline]
+    fn div_assign(&mut self, scale: T) {
+        *self = *self / scale
+    }
+}
+
+impl<T: Float, U> TypedVector3D<T, U> {
+    #[inline]
+    pub fn min(self, other: TypedVector3D<T, U>) -> TypedVector3D<T, U> {
+         vec3(self.x.min(other.x), self.y.min(other.y), self.z.min(other.z))
+    }
+
+    #[inline]
+    pub fn max(self, other: TypedVector3D<T, U>) -> TypedVector3D<T, U> {
+        vec3(self.x.max(other.x), self.y.max(other.y), self.z.max(other.z))
+    }
+}
+
+impl<T: Round, U> TypedVector3D<T, U> {
+    /// Rounds each component to the nearest integer value.
+    ///
+    /// This behavior is preserved for negative values (unlike the basic cast).
+    #[inline]
+    pub fn round(&self) -> Self {
+        vec3(self.x.round(), self.y.round(), self.z.round())
+    }
+}
+
+impl<T: Ceil, U> TypedVector3D<T, U> {
+    /// Rounds each component to the smallest integer equal or greater than the original value.
+    ///
+    /// This behavior is preserved for negative values (unlike the basic cast).
+    #[inline]
+    pub fn ceil(&self) -> Self {
+        vec3(self.x.ceil(), self.y.ceil(), self.z.ceil())
+    }
+}
+
+impl<T: Floor, U> TypedVector3D<T, U> {
+    /// Rounds each component to the biggest integer equal or lower than the original value.
+    ///
+    /// This behavior is preserved for negative values (unlike the basic cast).
+    #[inline]
+    pub fn floor(&self) -> Self {
+        vec3(self.x.floor(), self.y.floor(), self.z.floor())
+    }
+}
+
+impl<T: NumCast + Copy, U> TypedVector3D<T, U> {
+    /// Cast from one numeric representation to another, preserving the units.
+    ///
+    /// When casting from floating vector to integer coordinates, the decimals are truncated
+    /// as one would expect from a simple cast, but this behavior does not always make sense
+    /// geometrically. Consider using round(), ceil or floor() before casting.
+    #[inline]
+    pub fn cast<NewT: NumCast + Copy>(&self) -> Option<TypedVector3D<NewT, U>> {
+        match (NumCast::from(self.x),
+               NumCast::from(self.y),
+               NumCast::from(self.z)) {
+            (Some(x), Some(y), Some(z)) => Some(vec3(x, y, z)),
+            _ => None
+        }
+    }
+
+    // Convenience functions for common casts
+
+    /// Cast into an `f32` vector.
+    #[inline]
+    pub fn to_f32(&self) -> TypedVector3D<f32, U> {
+        self.cast().unwrap()
+    }
+
+    /// Cast into an `usize` vector, truncating decimals if any.
+    ///
+    /// When casting from floating vector vectors, it is worth considering whether
+    /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
+    /// the desired conversion behavior.
+    #[inline]
+    pub fn to_usize(&self) -> TypedVector3D<usize, U> {
+        self.cast().unwrap()
+    }
+
+    /// Cast into an `i32` vector, truncating decimals if any.
+    ///
+    /// When casting from floating vector vectors, it is worth considering whether
+    /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
+    /// the desired conversion behavior.
+    #[inline]
+    pub fn to_i32(&self) -> TypedVector3D<i32, U> {
+        self.cast().unwrap()
+    }
+
+    /// Cast into an `i64` vector, truncating decimals if any.
+    ///
+    /// When casting from floating vector vectors, it is worth considering whether
+    /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
+    /// the desired conversion behavior.
+    #[inline]
+    pub fn to_i64(&self) -> TypedVector3D<i64, U> {
+        self.cast().unwrap()
+    }
+}
+
+impl<T: Copy+ApproxEq<T>, U> ApproxEq<TypedVector3D<T, U>> for TypedVector3D<T, U> {
+    #[inline]
+    fn approx_epsilon() -> Self {
+        vec3(T::approx_epsilon(), T::approx_epsilon(), T::approx_epsilon())
+    }
+
+    #[inline]
+    fn approx_eq(&self, other: &Self) -> bool {
+        self.x.approx_eq(&other.x)
+            && self.y.approx_eq(&other.y)
+            && self.z.approx_eq(&other.z)
+    }
+
+    #[inline]
+    fn approx_eq_eps(&self, other: &Self, eps: &Self) -> bool {
+        self.x.approx_eq_eps(&other.x, &eps.x)
+            && self.y.approx_eq_eps(&other.y, &eps.y)
+            && self.z.approx_eq_eps(&other.z, &eps.z)
+    }
+}
+
+/// Convenience constructor.
+#[inline]
+pub fn vec2<T: Copy, U>(x: T, y: T) -> TypedVector2D<T, U> {
+    TypedVector2D::new(x, y)
+}
+
+/// Convenience constructor.
+#[inline]
+pub fn vec3<T: Copy, U>(x: T, y: T, z: T) -> TypedVector3D<T, U> {
+    TypedVector3D::new(x, y, z)
+}
+
+#[cfg(test)]
+mod vector2d {
+    use super::{Vector2D, vec2};
+    type Vec2 = Vector2D<f32>;
+
+    #[test]
+    pub fn test_scalar_mul() {
+        let p1: Vec2 = vec2(3.0, 5.0);
+
+        let result = p1 * 5.0;
+
+        assert_eq!(result, Vector2D::new(15.0, 25.0));
+    }
+
+    #[test]
+    pub fn test_dot() {
+        let p1: Vec2 = vec2(2.0, 7.0);
+        let p2: Vec2 = vec2(13.0, 11.0);
+        assert_eq!(p1.dot(p2), 103.0);
+    }
+
+    #[test]
+    pub fn test_cross() {
+        let p1: Vec2 = vec2(4.0, 7.0);
+        let p2: Vec2 = vec2(13.0, 8.0);
+        let r = p1.cross(p2);
+        assert_eq!(r, -59.0);
+    }
+
+    #[test]
+    pub fn test_normalize() {
+        let p0: Vec2 = Vec2::zero();
+        let p1: Vec2 = vec2(4.0, 0.0);
+        let p2: Vec2 = vec2(3.0, -4.0);
+        assert_eq!(p0.normalize(), p0);
+        assert_eq!(p1.normalize(), vec2(1.0, 0.0));
+        assert_eq!(p2.normalize(), vec2(0.6, -0.8));
+    }
+
+    #[test]
+    pub fn test_min() {
+        let p1: Vec2 = vec2(1.0, 3.0);
+        let p2: Vec2 = vec2(2.0, 2.0);
+
+        let result = p1.min(p2);
+
+        assert_eq!(result, vec2(1.0, 2.0));
+    }
+
+    #[test]
+    pub fn test_max() {
+        let p1: Vec2 = vec2(1.0, 3.0);
+        let p2: Vec2 = vec2(2.0, 2.0);
+
+        let result = p1.max(p2);
+
+        assert_eq!(result, vec2(2.0, 3.0));
+    }
+}
+
+#[cfg(test)]
+mod typedvector2d {
+    use super::{TypedVector2D, vec2};
+    use scale_factor::ScaleFactor;
+
+    pub enum Mm {}
+    pub enum Cm {}
+
+    pub type Vector2DMm<T> = TypedVector2D<T, Mm>;
+    pub type Vector2DCm<T> = TypedVector2D<T, Cm>;
+
+    #[test]
+    pub fn test_add() {
+        let p1 = Vector2DMm::new(1.0, 2.0);
+        let p2 = Vector2DMm::new(3.0, 4.0);
+
+        let result = p1 + p2;
+
+        assert_eq!(result, vec2(4.0, 6.0));
+    }
+
+    #[test]
+    pub fn test_add_assign() {
+        let mut p1 = Vector2DMm::new(1.0, 2.0);
+        p1 += vec2(3.0, 4.0);
+
+        assert_eq!(p1, vec2(4.0, 6.0));
+    }
+
+    #[test]
+    pub fn test_scalar_mul() {
+        let p1 = Vector2DMm::new(1.0, 2.0);
+        let cm_per_mm: ScaleFactor<f32, Mm, Cm> = ScaleFactor::new(0.1);
+
+        let result: Vector2DCm<f32> = p1 * cm_per_mm;
+
+        assert_eq!(result, vec2(0.1, 0.2));
+    }
+}
+
+#[cfg(test)]
+mod vector3d {
+    use super::{Vector3D, vec3};
+    type Vec3 = Vector3D<f32>;
+
+    #[test]
+    pub fn test_dot() {
+        let p1: Vec3 = vec3(7.0, 21.0, 32.0);
+        let p2: Vec3 = vec3(43.0, 5.0, 16.0);
+        assert_eq!(p1.dot(p2), 918.0);
+    }
+
+    #[test]
+    pub fn test_cross() {
+        let p1: Vec3 = vec3(4.0, 7.0, 9.0);
+        let p2: Vec3 = vec3(13.0, 8.0, 3.0);
+        let p3 = p1.cross(p2);
+        assert_eq!(p3, vec3(-51.0, 105.0, -59.0));
+    }
+
+    #[test]
+    pub fn test_normalize() {
+        let p0: Vec3 = Vec3::zero();
+        let p1: Vec3 = vec3(0.0, -6.0, 0.0);
+        let p2: Vec3 = vec3(1.0, 2.0, -2.0);
+        assert_eq!(p0.normalize(), p0);
+        assert_eq!(p1.normalize(), vec3(0.0, -1.0, 0.0));
+        assert_eq!(p2.normalize(), vec3(1.0/3.0, 2.0/3.0, -2.0/3.0));
+    }
+
+    #[test]
+    pub fn test_min() {
+        let p1: Vec3 = vec3(1.0, 3.0, 5.0);
+        let p2: Vec3 = vec3(2.0, 2.0, -1.0);
+
+        let result = p1.min(p2);
+
+        assert_eq!(result, vec3(1.0, 2.0, -1.0));
+    }
+
+    #[test]
+    pub fn test_max() {
+        let p1: Vec3 = vec3(1.0, 3.0, 5.0);
+        let p2: Vec3 = vec3(2.0, 2.0, -1.0);
+
+        let result = p1.max(p2);
+
+        assert_eq!(result, vec3(2.0, 3.0, 5.0));
+    }
+}


### PR DESCRIPTION
This changeset implements my proposal from issue #151:
- TypedVector2D and TypedVector3D types are added (no 4D vector)
- Matrix types implement separate transformations for points and vectors
- the 4D vector is removed, and along with it the bug-prone behavior of ignoring its w component half of the time.
- Point arithmetic is changed so that:
  - Point + Point is not implemented
  - Point + Vector = Point
  - Point - Point = Vector

With points and vectors as separate types, we don't need the 4D types anymore because the homogeneous coordinate is part type itself: for vectors it is always zero, and for points it is always one. Matrix transformations always divide the resulting points by w. It avoids the confusion that motivated the PR #157, where w was ignored in half of euclid because the code expected it to be equal to one.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/159)

<!-- Reviewable:end -->
