### PR TITLE
Rename `to_uint` to `to_usize`.

### DIFF
--- a/src/point.rs
+++ b/src/point.rs
@@ -244,7 +244,7 @@ impl<T: NumCast + Copy, U> TypedPoint2D<T, U> {
     /// When casting from floating point points, it is worth considering whether
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
-    pub fn to_uint(&self) -> TypedPoint2D<usize, U> {
+    pub fn to_usize(&self) -> TypedPoint2D<usize, U> {
         self.cast().unwrap()
     }
 
@@ -481,7 +481,7 @@ impl<T: NumCast + Copy, U> TypedPoint3D<T, U> {
     /// When casting from floating point points, it is worth considering whether
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
-    pub fn to_uint(&self) -> TypedPoint3D<usize, U> {
+    pub fn to_usize(&self) -> TypedPoint3D<usize, U> {
         self.cast().unwrap()
     }
 
@@ -720,7 +720,7 @@ impl<T: NumCast + Copy, U> TypedPoint4D<T, U> {
     /// When casting from floating point points, it is worth considering whether
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
-    pub fn to_uint(&self) -> TypedPoint4D<usize, U> {
+    pub fn to_usize(&self) -> TypedPoint4D<usize, U> {
         self.cast().unwrap()
     }
 

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -404,7 +404,7 @@ impl<T: NumCast + Copy, Unit> TypedRect<T, Unit> {
     /// When casting from floating point rectangles, it is worth considering whether
     /// to `round()`, `round_in()` or `round_out()` before the cast in order to
     /// obtain the desired conversion behavior.
-    pub fn to_uint(&self) -> TypedRect<usize, Unit> {
+    pub fn to_usize(&self) -> TypedRect<usize, Unit> {
         self.cast().unwrap()
     }
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -204,7 +204,7 @@ impl<T: NumCast + Copy, Unit> TypedSize2D<T, Unit> {
     /// When casting from floating point sizes, it is worth considering whether
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
-    pub fn to_uint(&self) -> TypedSize2D<usize, Unit> {
+    pub fn to_usize(&self) -> TypedSize2D<usize, Unit> {
         self.cast().unwrap()
     }
 


### PR DESCRIPTION
The naming was a historical artifact and since the types involved
as `usize`, the name can match.

Fixes #180.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/182)
<!-- Reviewable:end -->
