### PR TITLE
Remove dependency to rustc-serialize.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ unstable = []
 
 [dependencies]
 heapsize = "0.4"
-rustc-serialize = "0.3.2"
 num-traits = {version = "0.1.32", default-features = false}
 log = "0.3.1"
 serde = "0.9"

--- a/src/length.rs
+++ b/src/length.rs
@@ -34,7 +34,6 @@ use std::fmt;
 // Uncomment the derive, and remove the macro call, once heapsize gets
 // PhantomData<T> support.
 #[repr(C)]
-#[derive(RustcDecodable, RustcEncodable)]
 pub struct Length<T, Unit>(pub T, PhantomData<Unit>);
 
 impl<T: Clone, Unit> Clone for Length<T, Unit> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,6 @@ extern crate heapsize;
 
 #[cfg_attr(test, macro_use)]
 extern crate log;
-extern crate rustc_serialize;
 extern crate serde;
 
 #[cfg(test)]
@@ -97,7 +96,7 @@ pub mod size;
 pub mod trig;
 
 /// The default unit.
-#[derive(Clone, Copy, RustcDecodable, RustcEncodable)]
+#[derive(Clone, Copy)]
 pub struct UnknownUnit;
 
 /// Unit for angles in radians.

--- a/src/point.rs
+++ b/src/point.rs
@@ -20,7 +20,6 @@ use std::marker::PhantomData;
 
 define_matrix! {
     /// A 2d Point tagged with a unit.
-    #[derive(RustcDecodable, RustcEncodable)]
     pub struct TypedPoint2D<T, U> {
         pub x: T,
         pub y: T,
@@ -302,7 +301,6 @@ impl<T: Copy+ApproxEq<T>, U> ApproxEq<TypedPoint2D<T, U>> for TypedPoint2D<T, U>
 
 define_matrix! {
     /// A 3d Point tagged with a unit.
-    #[derive(RustcDecodable, RustcEncodable)]
     pub struct TypedPoint3D<T, U> {
         pub x: T,
         pub y: T,
@@ -569,7 +567,6 @@ impl<T: Copy+ApproxEq<T>, U> ApproxEq<TypedPoint3D<T, U>> for TypedPoint3D<T, U>
 
 define_matrix! {
     /// A 4d Point tagged with a unit.
-    #[derive(RustcDecodable, RustcEncodable)]
     pub struct TypedPoint4D<T, U> {
         pub x: T,
         pub y: T,

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -22,7 +22,6 @@ use std::fmt;
 use std::ops::{Add, Sub, Mul, Div};
 
 /// A 2d Rectangle optionally tagged with a unit.
-#[derive(RustcDecodable, RustcEncodable)]
 pub struct TypedRect<T, U = UnknownUnit> {
     pub origin: TypedPoint2D<T, U>,
     pub size: TypedSize2D<T, U>,

--- a/src/scale_factor.rs
+++ b/src/scale_factor.rs
@@ -37,7 +37,6 @@ use std::marker::PhantomData;
 /// let one_foot_in_mm: Length<f32, Mm> = one_foot * mm_per_inch;
 /// ```
 #[repr(C)]
-#[derive(RustcDecodable, RustcEncodable)]
 pub struct ScaleFactor<T, Src, Dst>(pub T, PhantomData<(Src, Dst)>);
 
 impl<T: HeapSizeOf, Src, Dst> HeapSizeOf for ScaleFactor<T, Src, Dst> {

--- a/src/size.rs
+++ b/src/size.rs
@@ -19,7 +19,6 @@ use std::marker::PhantomData;
 
 /// A 2d size tagged with a unit.
 define_matrix! {
-    #[derive(RustcDecodable, RustcEncodable)]
     pub struct TypedSize2D<T, U> {
         pub width: T,
         pub height: T,


### PR DESCRIPTION
rustc-serialize is deprecated in favor of serde and servo has moved to serde which means we don't need to carry this dependency anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/191)
<!-- Reviewable:end -->
