### PR TITLE
Implement linear interpolation for some of the types.

### DIFF
--- a/src/length.rs
+++ b/src/length.rs
@@ -13,6 +13,7 @@ use num::Zero;
 
 use heapsize::HeapSizeOf;
 use num_traits::{NumCast, Saturating};
+use num::One;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::cmp::Ordering;
 use std::ops::{Add, Sub, Mul, Div, Neg};
@@ -190,6 +191,18 @@ impl<Unit, T: Clone + Ord> Ord for Length<T, Unit> {
 impl<Unit, T: Zero> Zero for Length<T, Unit> {
     fn zero() -> Length<T, Unit> {
         Length::new(Zero::zero())
+    }
+}
+
+impl<T, U> Length<T, U>
+where T: Copy + One + Add<Output=T> + Sub<Output=T> + Mul<Output=T> {
+    /// Linearly interpolate between this length and another length.
+    ///
+    /// `t` is expected to be between zero and one.
+    #[inline]
+    pub fn lerp(&self, other: Self, t: T) -> Self {
+        let one_t = T::one() - t;
+        Length::new(one_t * self.get() + t * other.get())
     }
 }
 

--- a/src/point.rs
+++ b/src/point.rs
@@ -310,6 +310,21 @@ impl<T: NumCast + Copy, U> TypedPoint2D<T, U> {
     }
 }
 
+impl<T, U> TypedPoint2D<T, U>
+where T: Copy + One + Add<Output=T> + Sub<Output=T> + Mul<Output=T> {
+    /// Linearly interpolate between this point and another point.
+    ///
+    /// `t` is expected to be between zero and one.
+    #[inline]
+    pub fn lerp(&self, other: Self, t: T) -> Self {
+        let one_t = T::one() - t;
+        point2(
+            one_t * self.x + t * other.x,
+            one_t * self.y + t * other.y,
+        )
+    }
+}
+
 impl<T: Copy+ApproxEq<T>, U> ApproxEq<Self> for TypedPoint2D<T, U> {
     #[inline]
     fn approx_epsilon() -> Self {
@@ -366,6 +381,22 @@ impl<T: Copy + One, U> TypedPoint3D<T, U> {
     #[inline]
     pub fn to_array_4d(&self) -> [T; 4] {
         [self.x, self.y, self.z, One::one()]
+    }
+}
+
+impl<T, U> TypedPoint3D<T, U>
+where T: Copy + One + Add<Output=T> + Sub<Output=T> + Mul<Output=T> {
+    /// Linearly interpolate between this point and another point.
+    ///
+    /// `t` is expected to be between zero and one.
+    #[inline]
+    pub fn lerp(&self, other: Self, t: T) -> Self {
+        let one_t = T::one() - t;
+        point3(
+            one_t * self.x + t * other.x,
+            one_t * self.y + t * other.y,
+            one_t * self.z + t * other.z,
+        )
     }
 }
 

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -253,6 +253,20 @@ where T: Copy + Clone + Zero + PartialOrd + PartialEq + Add<T, Output=T> + Sub<T
 }
 
 impl<T, U> TypedRect<T, U>
+where T: Copy + One + Add<Output=T> + Sub<Output=T> + Mul<Output=T> {
+    /// Linearly interpolate between this rectangle and another rectange.
+    ///
+    /// `t` is expected to be between zero and one.
+    #[inline]
+    pub fn lerp(&self, other: Self, t: T) -> Self {
+        Self::new(
+            self.origin.lerp(other.origin, t),
+            self.size.lerp(other.size, t),
+        )
+    }
+}
+
+impl<T, U> TypedRect<T, U>
 where T: Copy + Clone + PartialOrd + Add<T, Output=T> + Sub<T, Output=T> + Zero {
     #[inline]
     pub fn union(&self, other: &TypedRect<T, U>) -> TypedRect<T, U> {

--- a/src/size.rs
+++ b/src/size.rs
@@ -106,6 +106,21 @@ impl<T: Copy + Clone + Mul<T, Output=U>, U> TypedSize2D<T, U> {
     pub fn area(&self) -> U { self.width * self.height }
 }
 
+impl<T, U> TypedSize2D<T, U>
+where T: Copy + One + Add<Output=T> + Sub<Output=T> + Mul<Output=T> {
+    /// Linearly interpolate between this size and another size.
+    ///
+    /// `t` is expected to be between zero and one.
+    #[inline]
+    pub fn lerp(&self, other: Self, t: T) -> Self {
+        let one_t = T::one() - t;
+        size2(
+            one_t * self.width + t * other.width,
+            one_t * self.height + t * other.height,
+        )
+    }
+}
+
 impl<T: Zero, U> TypedSize2D<T, U> {
     pub fn zero() -> TypedSize2D<T, U> {
         TypedSize2D::new(

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -147,6 +147,18 @@ where T: Copy + Mul<T, Output=T> + Add<T, Output=T> + Sub<T, Output=T> {
     }
 }
 
+impl<T, U> TypedVector2D<T, U>
+where T: Copy + One + Add<Output=T> + Sub<Output=T> + Mul<Output=T> {
+    /// Linearly interpolate between this vector and another vector.
+    ///
+    /// `t` is expected to be between zero and one.
+    #[inline]
+    pub fn lerp(&self, other: Self, t: T) -> Self {
+        let one_t = T::one() - t;
+        (*self) * one_t + other * t
+    }
+}
+
 impl<T: Copy + Add<T, Output=T>, U> Add for TypedVector2D<T, U> {
     type Output = Self;
     fn add(self, other: Self) -> Self {
@@ -495,6 +507,18 @@ impl<T: Mul<T, Output=T> +
     #[inline]
     pub fn length(&self) -> T where T: Float + ApproxEq<T> {
         self.square_length().sqrt()
+    }
+}
+
+impl<T, U> TypedVector3D<T, U>
+where T: Copy + One + Add<Output=T> + Sub<Output=T> + Mul<Output=T> {
+    /// Linearly interpolate between this vector and another vector.
+    ///
+    /// `t` is expected to be between zero and one.
+    #[inline]
+    pub fn lerp(&self, other: Self, t: T) -> Self {
+        let one_t = T::one() - t;
+        (*self) * one_t + other * t
     }
 }
 


### PR DESCRIPTION
I am converting code that uses euclid to 0.14, and a pattern that often comes up is interpolating between two points, which used to be simple to write but has become a bit more tedious now that addition between point and point isn't implemented anymore.

This implements `lerp(&self, Self) -> Self` for points, and for the sake of consistency, added vectors, size, rectangles and length.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/203)
<!-- Reviewable:end -->
