### PR TITLE
Make accessing members as lengths more ergonomic.

### DIFF
--- a/src/length.rs
+++ b/src/length.rs
@@ -206,6 +206,12 @@ where T: Copy + One + Add<Output=T> + Sub<Output=T> + Mul<Output=T> {
     }
 }
 
+impl<T, U> From<T> for Length<T, U> {
+    fn from(val: T) -> Self {
+        Length::new(val)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Length;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,10 +49,10 @@
 //! let p = WorldPoint::new(0.0, 1.0, 1.0);
 //! // p.x is an f32.
 //! println!("p.x = {:?} ", p.x);
-//! // p.x is a Length<f32, WorldSpace>.
-//! println!("p.x_typed() = {:?} ", p.x_typed());
+//! // p.x() is a Length<f32, WorldSpace>.
+//! println!("p.x() = {:?} ", p.x());
 //! // Length::get returns the scalar value (f32).
-//! assert_eq!(p.x, p.x_typed().get());
+//! assert_eq!(p.x, p.x().get());
 //! ```
 
 extern crate heapsize;

--- a/src/point.rs
+++ b/src/point.rs
@@ -92,11 +92,11 @@ impl<T: Copy, U> TypedPoint2D<T, U> {
 
     /// Returns self.x as a Length carrying the unit.
     #[inline]
-    pub fn x_typed(&self) -> Length<T, U> { Length::new(self.x) }
+    pub fn x(&self) -> Length<T, U> { Length::new(self.x) }
 
     /// Returns self.y as a Length carrying the unit.
     #[inline]
-    pub fn y_typed(&self) -> Length<T, U> { Length::new(self.y) }
+    pub fn y(&self) -> Length<T, U> { Length::new(self.y) }
 
     /// Drop the units, preserving only the numeric value.
     #[inline]
@@ -441,15 +441,15 @@ impl<T: Copy, U> TypedPoint3D<T, U> {
 
     /// Returns self.x as a Length carrying the unit.
     #[inline]
-    pub fn x_typed(&self) -> Length<T, U> { Length::new(self.x) }
+    pub fn x(&self) -> Length<T, U> { Length::new(self.x) }
 
     /// Returns self.y as a Length carrying the unit.
     #[inline]
-    pub fn y_typed(&self) -> Length<T, U> { Length::new(self.y) }
+    pub fn y(&self) -> Length<T, U> { Length::new(self.y) }
 
     /// Returns self.z as a Length carrying the unit.
     #[inline]
-    pub fn z_typed(&self) -> Length<T, U> { Length::new(self.z) }
+    pub fn z(&self) -> Length<T, U> { Length::new(self.z) }
 
     #[inline]
     pub fn to_array(&self) -> [T; 3] { [self.x, self.y, self.z] }

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -192,17 +192,13 @@ where T: Copy + Clone + Zero + PartialOrd + PartialEq + Add<T, Output=T> + Sub<T
 
     #[inline]
     #[must_use]
-    pub fn inflate(&self, width: T, height: T) -> Self {
+    pub fn inflate<T2: Into<Length<T, U>>>(&self, width: T2, height: T2) -> Self {
+        let w = width.into().get();
+        let h = height.into().get();
         TypedRect::new(
-            TypedPoint2D::new(self.origin.x - width, self.origin.y - height),
-            TypedSize2D::new(self.size.width + width + width, self.size.height + height + height),
+            TypedPoint2D::new(self.origin.x - w, self.origin.y - h),
+            TypedSize2D::new(self.size.width + w + w, self.size.height + h + h),
         )
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn inflate_typed(&self, width: Length<T, U>, height: Length<T, U>) -> Self {
-        self.inflate(width.get(), height.get())
     }
 
     #[inline]

--- a/src/side_offsets.rs
+++ b/src/side_offsets.rs
@@ -62,16 +62,16 @@ impl<T: Copy, U> TypedSideOffsets2D<T, U> {
     }
 
     /// Access self.top as a typed Length instead of a scalar value.
-    pub fn top_typed(&self) -> Length<T, U> { Length::new(self.top) }
+    pub fn top(&self) -> Length<T, U> { Length::new(self.top) }
 
     /// Access self.right as a typed Length instead of a scalar value.
-    pub fn right_typed(&self) -> Length<T, U> { Length::new(self.right) }
+    pub fn right(&self) -> Length<T, U> { Length::new(self.right) }
 
     /// Access self.bottom as a typed Length instead of a scalar value.
-    pub fn bottom_typed(&self) -> Length<T, U> { Length::new(self.bottom) }
+    pub fn bottom(&self) -> Length<T, U> { Length::new(self.bottom) }
 
     /// Access self.left as a typed Length instead of a scalar value.
-    pub fn left_typed(&self) -> Length<T, U> { Length::new(self.left) }
+    pub fn left(&self) -> Length<T, U> { Length::new(self.left) }
 
     /// Constructor setting the same value to all sides, taking a scalar value directly.
     pub fn new_all_same(all: T) -> Self {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -94,11 +94,11 @@ impl<T: Copy, U> TypedVector2D<T, U> {
 
     /// Returns self.x as a Length carrying the unit.
     #[inline]
-    pub fn x_typed(&self) -> Length<T, U> { Length::new(self.x) }
+    pub fn x(&self) -> Length<T, U> { Length::new(self.x) }
 
     /// Returns self.y as a Length carrying the unit.
     #[inline]
-    pub fn y_typed(&self) -> Length<T, U> { Length::new(self.y) }
+    pub fn y(&self) -> Length<T, U> { Length::new(self.y) }
 
     /// Drop the units, preserving only the numeric value.
     #[inline]
@@ -150,6 +150,11 @@ where T: Copy + Mul<T, Output=T> + Add<T, Output=T> + Sub<T, Output=T> {
     #[inline]
     pub fn length(&self) -> T where T: Float + ApproxEq<T> {
         self.square_length().sqrt()
+    }
+
+    #[inline]
+    pub fn length_typed(&self) -> Length<T, U> where T: Float + ApproxEq<T> {
+        Length::new(self.length())
     }
 }
 
@@ -440,15 +445,15 @@ impl<T: Copy, U> TypedVector3D<T, U> {
 
     /// Returns self.x as a Length carrying the unit.
     #[inline]
-    pub fn x_typed(&self) -> Length<T, U> { Length::new(self.x) }
+    pub fn x(&self) -> Length<T, U> { Length::new(self.x) }
 
     /// Returns self.y as a Length carrying the unit.
     #[inline]
-    pub fn y_typed(&self) -> Length<T, U> { Length::new(self.y) }
+    pub fn y(&self) -> Length<T, U> { Length::new(self.y) }
 
     /// Returns self.z as a Length carrying the unit.
     #[inline]
-    pub fn z_typed(&self) -> Length<T, U> { Length::new(self.z) }
+    pub fn z(&self) -> Length<T, U> { Length::new(self.z) }
 
     #[inline]
     pub fn to_array(&self) -> [T; 3] { [self.x, self.y, self.z] }


### PR DESCRIPTION
We don't ever use the `_typed` versions of euclid methods which work with `Length<T, U>` instead of `T`. I believe that this is for a large part because it is simpler and more ergonomic to work directly with the scalar type (say, floats) and access it through shorter notations (`foo.x` vs `foo.x_typed()`).

We can certainly improve on the ergonomics of manipulating lengths:
 - Public members (say `foo.x`) should have very short getters for lengths (`foo.x()` instead of `foo.x_typed()`)
 - If there is an ambiguity between "direct" and the length-based versions of a method, use the prefix `get_` instead of the the suffix `_typed` (for example 'rect.get_min_x()` instead of `rect.min_x_typed()` since `rect.min_x()` already exists for the non-length version)
 - Methods that take the scalar type `T` as parameter (for example `rect.inflate`) can take `T2: Into<Length<T, U>>` which works with both `T` and `Length<T, U>`.
 - Static methods (such as `::new`) are more troublesome, because if we make them generic like regular methods, the compiler can easily run into cases where it does not know which type to infer if the static method is called in generic code. Non-static methods don't usually have this problem because the `self` part of the method carries enough information for the compiler to know what to infer.

While this is technically a breaking change (some function names change), it breaks nothing since these methods aren't ever used a far as I can tell, perhaps we could get away without the huge pain that bumping major versions of euclid is...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/206)
<!-- Reviewable:end -->
