### PR TITLE
Add extend method and get euclid to build with rustc 1.15.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.14.2"
+version = "0.14.3"
 authors = ["The Servo Project Developers"]
 description = "Geometry primitives"
 documentation = "https://docs.rs/euclid/"

--- a/src/point.rs
+++ b/src/point.rs
@@ -76,6 +76,12 @@ impl<T: Copy, U> TypedPoint2D<T, U> {
         point2(x.0, y.0)
     }
 
+    /// Create a 3d point from this one, using the specified z value.
+    #[inline]
+    pub fn extend(&self, z: T) -> TypedPoint3D<T, U> {
+        point3(self.x, self.y, z)
+    }
+
     /// Cast this point into a vector.
     ///
     /// Equivalent to substracting the origin to this point.
@@ -325,7 +331,7 @@ where T: Copy + One + Add<Output=T> + Sub<Output=T> + Mul<Output=T> {
     }
 }
 
-impl<T: Copy+ApproxEq<T>, U> ApproxEq<Self> for TypedPoint2D<T, U> {
+impl<T: Copy+ApproxEq<T>, U> ApproxEq<TypedPoint2D<T, U>> for TypedPoint2D<T, U> {
     #[inline]
     fn approx_epsilon() -> Self {
         point2(T::approx_epsilon(), T::approx_epsilon())
@@ -621,7 +627,7 @@ impl<T: NumCast + Copy, U> TypedPoint3D<T, U> {
     }
 }
 
-impl<T: Copy+ApproxEq<T>, U> ApproxEq<Self> for TypedPoint3D<T, U> {
+impl<T: Copy+ApproxEq<T>, U> ApproxEq<TypedPoint3D<T, U>> for TypedPoint3D<T, U> {
     #[inline]
     fn approx_epsilon() -> Self {
         point3(T::approx_epsilon(), T::approx_epsilon(), T::approx_epsilon())

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -71,6 +71,12 @@ impl<T: Copy, U> TypedVector2D<T, U> {
         vec2(x.0, y.0)
     }
 
+    /// Create a 3d vector from this one, using the specified z value.
+    #[inline]
+    pub fn extend(&self, z: T) -> TypedVector3D<T, U> {
+        vec3(self.x, self.y, z)
+    }
+
     /// Cast this vector into a point.
     ///
     /// Equivalent to adding this vector to the origin.


### PR DESCRIPTION
WebRender's CI runs rustc 1.15 to match gecko's, and in euclid 14.0 we introduced a usage of self that apparently was not allowed with this version of the compiler.
This commit also adds the extend method suggested in the review of the euclid bump in WebRender.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/208)
<!-- Reviewable:end -->
