### PR TITLE
Mark TypedRect as repr(C)

### DIFF
--- a/src/rect.rs
+++ b/src/rect.rs
@@ -24,6 +24,7 @@ use std::hash::{Hash, Hasher};
 use std::ops::{Add, Sub, Mul, Div};
 
 /// A 2d Rectangle optionally tagged with a unit.
+#[repr(C)]
 pub struct TypedRect<T, U = UnknownUnit> {
     pub origin: TypedPoint2D<T, U>,
     pub size: TypedSize2D<T, U>,


### PR DESCRIPTION
TypedPoint2D and TypedSize2D are both repr(C) so TypedRect can be marked repr(C). This helps improve the FFI interface for WebRender.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/216)
<!-- Reviewable:end -->
