### PR TITLE
Bump minimum-supported rust version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.15.1
+  - 1.17.0
   - stable
   - beta
   - nightly


### PR DESCRIPTION
Gecko has changed their requirment to 1.17.0.

https://bugzilla.mozilla.org/show_bug.cgi?id=1374807

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/217)
<!-- Reviewable:end -->
