### PR TITLE
Add some swizzling methods to vectors and points.

### DIFF
--- a/src/point.rs
+++ b/src/point.rs
@@ -90,6 +90,12 @@ impl<T: Copy, U> TypedPoint2D<T, U> {
         vec2(self.x, self.y)
     }
 
+    /// Swap x and y.
+    #[inline]
+    pub fn yx(&self) -> Self {
+        point2(self.y, self.x)
+    }
+
     /// Returns self.x as a Length carrying the unit.
     #[inline]
     pub fn x_typed(&self) -> Length<T, U> { Length::new(self.x) }
@@ -439,6 +445,24 @@ impl<T: Copy, U> TypedPoint3D<T, U> {
         vec3(self.x, self.y, self.z)
     }
 
+    /// Returns a 2d point using this point's x and y coordinates
+    #[inline]
+    pub fn xy(&self) -> TypedPoint2D<T, U> {
+        point2(self.x, self.y)
+    }
+
+    /// Returns a 2d point using this point's x and z coordinates
+    #[inline]
+    pub fn xz(&self) -> TypedPoint2D<T, U> {
+        point2(self.x, self.z)
+    }
+
+    /// Returns a 2d point using this point's x and z coordinates
+    #[inline]
+    pub fn yz(&self) -> TypedPoint2D<T, U> {
+        point2(self.y, self.z)
+    }
+
     /// Returns self.x as a Length carrying the unit.
     #[inline]
     pub fn x_typed(&self) -> Length<T, U> { Length::new(self.x) }
@@ -469,7 +493,7 @@ impl<T: Copy, U> TypedPoint3D<T, U> {
     /// Convert into a 2d point.
     #[inline]
     pub fn to_2d(&self) -> TypedPoint2D<T, U> {
-        point2(self.x, self.y)
+        self.xy()
     }
 }
 
@@ -705,7 +729,7 @@ mod point2d {
 
 #[cfg(test)]
 mod typedpoint2d {
-    use super::TypedPoint2D;
+    use super::{TypedPoint2D, Point2D, point2};
     use scale_factor::ScaleFactor;
     use vector::vec2;
 
@@ -755,11 +779,17 @@ mod typedpoint2d {
             assert_eq!(p.to_vector().to_point(), p);
         }
     }
+
+    #[test]
+    pub fn test_swizzling() {
+        let p: Point2D<i32> = point2(1, 2);
+        assert_eq!(p.yx(), point2(2, 1));
+    }
 }
 
 #[cfg(test)]
 mod point3d {
-    use super::Point3D;
+    use super::{Point3D, point2, point3};
 
     #[test]
     pub fn test_min() {
@@ -792,5 +822,13 @@ mod point3d {
             let p: Point3D<f32> = point3(x, y, z);
             assert_eq!(p.to_vector().to_point(), p);
         }
+    }
+
+    #[test]
+    pub fn test_swizzling() {
+        let p: Point3D<i32> = point3(1, 2, 3);
+        assert_eq!(p.xy(), point2(1, 2));
+        assert_eq!(p.xz(), point2(1, 3));
+        assert_eq!(p.yz(), point2(2, 3));
     }
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -85,6 +85,12 @@ impl<T: Copy, U> TypedVector2D<T, U> {
         point2(self.x, self.y)
     }
 
+    /// Swap x and y.
+    #[inline]
+    pub fn yx(&self) -> Self {
+        vec2(self.y, self.x)
+    }
+
     /// Cast this vector into a size.
     #[inline]
     pub fn to_size(&self) -> TypedSize2D<T, U> {
@@ -438,6 +444,24 @@ impl<T: Copy, U> TypedVector3D<T, U> {
         point3(self.x, self.y, self.z)
     }
 
+    /// Returns a 2d vector using this vector's x and y coordinates
+    #[inline]
+    pub fn xy(&self) -> TypedVector2D<T, U> {
+        vec2(self.x, self.y)
+    }
+
+    /// Returns a 2d vector using this vector's x and z coordinates
+    #[inline]
+    pub fn xz(&self) -> TypedVector2D<T, U> {
+        vec2(self.x, self.z)
+    }
+
+    /// Returns a 2d vector using this vector's x and z coordinates
+    #[inline]
+    pub fn yz(&self) -> TypedVector2D<T, U> {
+        vec2(self.y, self.z)
+    }
+
     /// Returns self.x as a Length carrying the unit.
     #[inline]
     pub fn x_typed(&self) -> Length<T, U> { Length::new(self.x) }
@@ -468,7 +492,7 @@ impl<T: Copy, U> TypedVector3D<T, U> {
     /// Convert into a 2d vector.
     #[inline]
     pub fn to_2d(&self) -> TypedVector2D<T, U> {
-        vec2(self.x, self.y)
+        self.xy()
     }
 }
 
@@ -804,7 +828,7 @@ mod vector2d {
 
 #[cfg(test)]
 mod typedvector2d {
-    use super::{TypedVector2D, vec2};
+    use super::{TypedVector2D, Vector2D, vec2};
     use scale_factor::ScaleFactor;
 
     pub enum Mm {}
@@ -840,11 +864,17 @@ mod typedvector2d {
 
         assert_eq!(result, vec2(0.1, 0.2));
     }
+
+    #[test]
+    pub fn test_swizzling() {
+        let p: Vector2D<i32> = vec2(1, 2);
+        assert_eq!(p.yx(), vec2(2, 1));
+    }
 }
 
 #[cfg(test)]
 mod vector3d {
-    use super::{Vector3D, vec3};
+    use super::{Vector3D, vec2, vec3};
     type Vec3 = Vector3D<f32>;
 
     #[test]
@@ -890,5 +920,13 @@ mod vector3d {
         let result = p1.max(p2);
 
         assert_eq!(result, vec3(2.0, 3.0, 5.0));
+    }
+
+    #[test]
+    pub fn test_swizzling() {
+        let p: Vector3D<i32> = vec3(1, 2, 3);
+        assert_eq!(p.xy(), vec2(1, 2));
+        assert_eq!(p.xz(), vec2(1, 3));
+        assert_eq!(p.yz(), vec2(2, 3));
     }
 }


### PR DESCRIPTION
This adds a few swizzling methods such as `point2.xy()` and more explicit ways to project from 3d to 2d (`point3.xy()`, point3.xz(), etc.).

Having a shorthand to swap x and y is useful to get a tangent vector or to avoid duplicating code in places where there the x/y symmetry can be exploited (for example lyon's y-monotone cubic curves use the x-monotone implementation after swapping x and y).

The added 3d to 2d projections offer a less error-prone alternative to `to_2d()` (which we could remove next time we have a breaking change to make), and make it convenient to project on more than the xy plane.

There are plenty of other swizzling combinations we could add (point.xx(), point.yxz(), etc.) but I'd rather add them whenever/if there is a need for them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/220)
<!-- Reviewable:end -->
