### PR TITLE
efficacious `#[must_use]` methods for nightly, fix warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![cfg_attr(feature = "unstable", feature(asm, repr_simd, test))]
+#![cfg_attr(feature = "unstable", feature(asm, repr_simd, test, fn_must_use))]
 
 //! A collection of strongly typed math tools for computer graphics with an inclination
 //! towards 2d graphics and layout.
@@ -132,4 +132,3 @@ pub type Matrix4D<T> = Transform3D<T>;
 /// Temporary alias to facilitate the transition to the new naming scheme
 #[deprecated]
 pub type TypedMatrix4D<T, Src, Dst> = TypedTransform3D<T, Src, Dst>;
-

--- a/src/point.rs
+++ b/src/point.rs
@@ -239,7 +239,7 @@ impl<T: Round, U> TypedPoint2D<T, U> {
     /// This behavior is preserved for negative values (unlike the basic cast).
     /// For example `{ -0.1, -0.8 }.round() == { 0.0, -1.0 }`.
     #[inline]
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn round(&self) -> Self {
         point2(self.x.round(), self.y.round())
     }
@@ -251,7 +251,7 @@ impl<T: Ceil, U> TypedPoint2D<T, U> {
     /// This behavior is preserved for negative values (unlike the basic cast).
     /// For example `{ -0.1, -0.8 }.ceil() == { 0.0, 0.0 }`.
     #[inline]
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn ceil(&self) -> Self {
         point2(self.x.ceil(), self.y.ceil())
     }
@@ -263,7 +263,7 @@ impl<T: Floor, U> TypedPoint2D<T, U> {
     /// This behavior is preserved for negative values (unlike the basic cast).
     /// For example `{ -0.1, -0.8 }.floor() == { -1.0, -1.0 }`.
     #[inline]
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn floor(&self) -> Self {
         point2(self.x.floor(), self.y.floor())
     }
@@ -568,7 +568,7 @@ impl<T: Round, U> TypedPoint3D<T, U> {
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
     #[inline]
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn round(&self) -> Self {
         point3(self.x.round(), self.y.round(), self.z.round())
     }
@@ -579,7 +579,7 @@ impl<T: Ceil, U> TypedPoint3D<T, U> {
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
     #[inline]
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn ceil(&self) -> Self {
         point3(self.x.ceil(), self.y.ceil(), self.z.ceil())
     }
@@ -590,7 +590,7 @@ impl<T: Floor, U> TypedPoint3D<T, U> {
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
     #[inline]
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn floor(&self) -> Self {
         point3(self.x.floor(), self.y.floor(), self.z.floor())
     }

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -167,7 +167,7 @@ where T: Copy + Clone + Zero + PartialOrd + PartialEq + Add<T, Output=T> + Sub<T
 
     /// Returns the same rectangle, translated by a vector.
     #[inline]
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn translate(&self, by: &TypedVector2D<T, U>) -> Self {
         Self::new(self.origin + *by, self.size)
     }
@@ -192,7 +192,7 @@ where T: Copy + Clone + Zero + PartialOrd + PartialEq + Add<T, Output=T> + Sub<T
     }
 
     #[inline]
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn inflate(&self, width: T, height: T) -> Self {
         TypedRect::new(
             TypedPoint2D::new(self.origin.x - width, self.origin.y - height),
@@ -201,7 +201,7 @@ where T: Copy + Clone + Zero + PartialOrd + PartialEq + Add<T, Output=T> + Sub<T
     }
 
     #[inline]
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn inflate_typed(&self, width: Length<T, U>, height: Length<T, U>) -> Self {
         self.inflate(width.get(), height.get())
     }
@@ -222,7 +222,7 @@ where T: Copy + Clone + Zero + PartialOrd + PartialEq + Add<T, Output=T> + Sub<T
     }
 
     #[inline]
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn translate_by_size(&self, size: &TypedSize2D<T, U>) -> Self {
         self.translate(&size.to_vector())
     }
@@ -394,7 +394,7 @@ impl<T: Floor + Ceil + Round + Add<T, Output=T> + Sub<T, Output=T>, U> TypedRect
     /// avoid pixel rounding errors.
     /// Note that this is *not* rounding to nearest integer if the values are negative.
     /// They are always rounding as floor(n + 0.5).
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn round(&self) -> Self {
         let origin = self.origin.round();
         let size = self.origin.add_size(&self.size).round() - origin;
@@ -403,7 +403,7 @@ impl<T: Floor + Ceil + Round + Add<T, Output=T> + Sub<T, Output=T>, U> TypedRect
 
     /// Return a rectangle with edges rounded to integer coordinates, such that
     /// the original rectangle contains the resulting rectangle.
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn round_in(&self) -> Self {
         let origin = self.origin.ceil();
         let size = self.origin.add_size(&self.size).floor() - origin;
@@ -412,7 +412,7 @@ impl<T: Floor + Ceil + Round + Add<T, Output=T> + Sub<T, Output=T>, U> TypedRect
 
     /// Return a rectangle with edges rounded to integer coordinates, such that
     /// the original rectangle is contained in the resulting rectangle.
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn round_out(&self) -> Self {
         let origin = self.origin.floor();
         let size = self.origin.add_size(&self.size).ceil() - origin;

--- a/src/transform2d.rs
+++ b/src/transform2d.rs
@@ -161,7 +161,7 @@ where T: Copy + Clone +
 
     /// Returns the multiplication of the two matrices such that mat's transformation
     /// applies after self's transformation.
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn post_mul<NewDst>(&self, mat: &TypedTransform2D<T, Dst, NewDst>) -> TypedTransform2D<T, Src, NewDst> {
         TypedTransform2D::row_major(
             self.m11 * mat.m11 + self.m12 * mat.m21,
@@ -175,7 +175,7 @@ where T: Copy + Clone +
 
     /// Returns the multiplication of the two matrices such that mat's transformation
     /// applies before self's transformation.
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn pre_mul<NewSrc>(&self, mat: &TypedTransform2D<T, NewSrc, Src>) -> TypedTransform2D<T, NewSrc, Dst> {
         mat.post_mul(self)
     }
@@ -191,13 +191,13 @@ where T: Copy + Clone +
     }
 
     /// Applies a translation after self's transformation and returns the resulting transform.
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn post_translate(&self, v: TypedVector2D<T, Dst>) -> Self {
         self.post_mul(&TypedTransform2D::create_translation(v.x, v.y))
     }
 
     /// Applies a translation before self's transformation and returns the resulting transform.
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn pre_translate(&self, v: TypedVector2D<T, Src>) -> Self {
         self.pre_mul(&TypedTransform2D::create_translation(v.x, v.y))
     }
@@ -213,13 +213,13 @@ where T: Copy + Clone +
     }
 
     /// Applies a scale after self's transformation and returns the resulting transform.
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn post_scale(&self, x: T, y: T) -> Self {
         self.post_mul(&TypedTransform2D::create_scale(x, y))
     }
 
     /// Applies a scale before self's transformation and returns the resulting transform.
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn pre_scale(&self, x: T, y: T) -> Self {
         TypedTransform2D::row_major(
             self.m11 * x, self.m12,
@@ -241,20 +241,20 @@ where T: Copy + Clone +
     }
 
     /// Applies a rotation after self's transformation and returns the resulting transform.
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn post_rotate(&self, theta: Radians<T>) -> Self {
         self.post_mul(&TypedTransform2D::create_rotation(theta))
     }
 
     /// Applies a rotation after self's transformation and returns the resulting transform.
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn pre_rotate(&self, theta: Radians<T>) -> Self {
         self.pre_mul(&TypedTransform2D::create_rotation(theta))
     }
 
     /// Returns the given point transformed by this transform.
     #[inline]
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn transform_point(&self, point: &TypedPoint2D<T, Src>) -> TypedPoint2D<T, Dst> {
         TypedPoint2D::new(point.x * self.m11 + point.y * self.m21 + self.m31,
                           point.x * self.m12 + point.y * self.m22 + self.m32)
@@ -262,7 +262,7 @@ where T: Copy + Clone +
 
     /// Returns the given vector transformed by this matrix.
     #[inline]
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn transform_vector(&self, vec: &TypedVector2D<T, Src>) -> TypedVector2D<T, Dst> {
         vec2(vec.x * self.m11 + vec.y * self.m21,
              vec.x * self.m12 + vec.y * self.m22)
@@ -271,7 +271,7 @@ where T: Copy + Clone +
     /// Returns a rectangle that encompasses the result of transforming the given rectangle by this
     /// transform.
     #[inline]
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn transform_rect(&self, rect: &TypedRect<T, Src>) -> TypedRect<T, Dst> {
         TypedRect::from_points(&[
             self.transform_point(&rect.origin),
@@ -287,7 +287,7 @@ where T: Copy + Clone +
     }
 
     /// Returns the inverse transform if possible.
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn inverse(&self) -> Option<TypedTransform2D<T, Dst, Src>> {
         let det = self.determinant();
 

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -382,7 +382,7 @@ where T: Copy + Clone +
     }
 
     /// Multiplies all of the transform's component by a scalar and returns the result.
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn mul_s(&self, x: T) -> Self {
         TypedTransform3D::row_major(
             self.m11 * x, self.m12 * x, self.m13 * x, self.m14 * x,
@@ -469,13 +469,13 @@ where T: Copy + Clone +
     }
 
     /// Returns a transform with a translation applied before self's transformation.
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn pre_translate(&self, v: TypedVector3D<T, Src>) -> Self {
         self.pre_mul(&TypedTransform3D::create_translation(v.x, v.y, v.z))
     }
 
     /// Returns a transform with a translation applied after self's transformation.
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn post_translate(&self, v: TypedVector3D<T, Dst>) -> Self {
         self.post_mul(&TypedTransform3D::create_translation(v.x, v.y, v.z))
     }
@@ -492,7 +492,7 @@ where T: Copy + Clone +
     }
 
     /// Returns a transform with a scale applied before self's transformation.
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn pre_scale(&self, x: T, y: T, z: T) -> Self {
         TypedTransform3D::row_major(
             self.m11 * x, self.m12,     self.m13,     self.m14,
@@ -503,7 +503,7 @@ where T: Copy + Clone +
     }
 
     /// Returns a transform with a scale applied after self's transformation.
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn post_scale(&self, x: T, y: T, z: T) -> Self {
         self.post_mul(&TypedTransform3D::create_scale(x, y, z))
     }
@@ -546,13 +546,13 @@ where T: Copy + Clone +
     }
 
     /// Returns a transform with a rotation applied after self's transformation.
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn post_rotate(&self, x: T, y: T, z: T, theta: Radians<T>) -> Self {
         self.post_mul(&TypedTransform3D::create_rotation(x, y, z, theta))
     }
 
     /// Returns a transform with a rotation applied before self's transformation.
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn pre_rotate(&self, x: T, y: T, z: T, theta: Radians<T>) -> Self {
         self.pre_mul(&TypedTransform3D::create_rotation(x, y, z, theta))
     }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -272,7 +272,7 @@ impl<T: Round, U> TypedVector2D<T, U> {
     /// This behavior is preserved for negative values (unlike the basic cast).
     /// For example `{ -0.1, -0.8 }.round() == { 0.0, -1.0 }`.
     #[inline]
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn round(&self) -> Self {
         vec2(self.x.round(), self.y.round())
     }
@@ -284,7 +284,7 @@ impl<T: Ceil, U> TypedVector2D<T, U> {
     /// This behavior is preserved for negative values (unlike the basic cast).
     /// For example `{ -0.1, -0.8 }.ceil() == { 0.0, 0.0 }`.
     #[inline]
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn ceil(&self) -> Self {
         vec2(self.x.ceil(), self.y.ceil())
     }
@@ -296,7 +296,7 @@ impl<T: Floor, U> TypedVector2D<T, U> {
     /// This behavior is preserved for negative values (unlike the basic cast).
     /// For example `{ -0.1, -0.8 }.floor() == { -1.0, -1.0 }`.
     #[inline]
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn floor(&self) -> Self {
         vec2(self.x.floor(), self.y.floor())
     }
@@ -637,7 +637,7 @@ impl<T: Round, U> TypedVector3D<T, U> {
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
     #[inline]
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn round(&self) -> Self {
         vec3(self.x.round(), self.y.round(), self.z.round())
     }
@@ -648,7 +648,7 @@ impl<T: Ceil, U> TypedVector3D<T, U> {
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
     #[inline]
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn ceil(&self) -> Self {
         vec3(self.x.ceil(), self.y.ceil(), self.z.ceil())
     }
@@ -659,7 +659,7 @@ impl<T: Floor, U> TypedVector3D<T, U> {
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
     #[inline]
-    #[must_use]
+    #[cfg_attr(feature = "unstable", must_use)]
     pub fn floor(&self) -> Self {
         vec3(self.x.floor(), self.y.floor(), self.z.floor())
     }


### PR DESCRIPTION
137660d9 annotated many methods with `#[must_use]`, but despite not
being rejected by the compiler, this is actually a no-op (as of Rust
1.20). `#[must_use]` for functions is now available on nightly
Rust (since rust-lang/rust@3645b062), under a feature-gate (since
rust-lang/rust@8492ad24 and 35c44941), with a warning if `#[must_use]`
appears on a function or method without the feature being enabled—a
warning that regrettably added a lot of noise to Euclid's build, as
reported in rust-lang/rust#44213. But with judicious use of [`cfg_attr`](https://doc.rust-lang.org/1.19.0/book/first-edition/conditional-compilation.html#cfg_attr),
Euclid can make use of this functionality if our "unstable" feature is
enabled, and shut up the warnings in any case.

![must_euclid](https://user-images.githubusercontent.com/1076988/29959879-3f527186-8eae-11e7-915b-357f39e4be17.png)

(SHA in the screenshot doesn't match because I had to amend the commit message)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/225)
<!-- Reviewable:end -->
