### PR TITLE
Support lexical ordering for macro types and rects

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -83,5 +83,31 @@ macro_rules! define_matrix {
                 $(self.$field.hash(h);)+
             }
         }
+
+        impl<T, $($phantom),+> ::std::cmp::PartialOrd for $name<T, $($phantom),+>
+            where T: ::std::cmp::PartialOrd
+        {
+            fn partial_cmp(&self, other: &Self) -> Option<::std::cmp::Ordering> {
+                $(match self.$field.partial_cmp(&other.$field) {
+                    Some(::std::cmp::Ordering::Equal) => {}
+                    x => return x
+                };)+
+
+                Some(::std::cmp::Ordering::Equal)
+            }
+        }
+
+        impl<T, $($phantom),+> ::std::cmp::Ord for $name<T, $($phantom),+>
+            where T: ::std::cmp::Ord
+        {
+            fn cmp(&self, other: &Self) -> ::std::cmp::Ordering {
+                $(match self.$field.cmp(&other.$field) {
+                    ::std::cmp::Ordering::Equal => {}
+                    x => return x
+                };)+
+
+                ::std::cmp::Ordering::Equal
+            }
+        }
     )
 }

--- a/src/point.rs
+++ b/src/point.rs
@@ -785,6 +785,36 @@ mod typedpoint2d {
         let p: Point2D<i32> = point2(1, 2);
         assert_eq!(p.yx(), point2(2, 1));
     }
+
+    #[test]
+    pub fn test_ord() {
+        let p00: Point2D<i32> = point2(0, 0);
+        let p01: Point2D<i32> = point2(0, 1);
+        let p10: Point2D<i32> = point2(1, 0);
+        let p11: Point2D<i32> = point2(1, 1);
+
+        assert!(!(p11 < p11) && !(p11 > p11));
+        assert!(p00 < p01);
+        assert!(p01 > p00);
+        assert!(p01 < p10);
+        assert!(p01 < p11);
+        assert!(p10 < p11);
+    }
+
+    #[test]
+    pub fn test_partial_ord() {
+        let p00: Point2D<f32> = point2(0.0, 0.0);
+        let p01: Point2D<f32> = point2(0.0, 1.0);
+        let p10: Point2D<f32> = point2(1.0, 0.0);
+        let p11: Point2D<f32> = point2(1.0, 1.0);
+
+        assert!(!(p11 < p11) && !(p11 > p11));
+        assert!(p00 < p01);
+        assert!(p01 > p00);
+        assert!(p01 < p10);
+        assert!(p01 < p11);
+        assert!(p10 < p11);
+    }
 }
 
 #[cfg(test)]

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -18,7 +18,7 @@ use size::TypedSize2D;
 use heapsize::HeapSizeOf;
 use num_traits::NumCast;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::cmp::PartialOrd;
+use std::cmp::{Ord, PartialOrd, Ordering};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::{Add, Sub, Mul, Div};
@@ -77,6 +77,18 @@ impl<T: PartialEq, U> PartialEq<TypedRect<T, U>> for TypedRect<T, U> {
 }
 
 impl<T: Eq, U> Eq for TypedRect<T, U> {}
+
+impl<T: PartialOrd, U> PartialOrd for TypedRect<T, U> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        (&self.origin, &self.size).partial_cmp(&(&other.origin, &other.size))
+    }
+}
+
+impl<T: Ord, U> Ord for TypedRect<T, U> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        (&self.origin, &self.size).cmp(&(&other.origin, &other.size))
+    }
+}
 
 impl<T: fmt::Debug, U> fmt::Debug for TypedRect<T, U> {
    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -696,5 +708,19 @@ mod tests {
             }
             x += 0.1
         }
+    }
+
+    #[test]
+    fn test_ord() {
+        let r1: Rect<i32> = rect(1, 2, 3, 4);
+        let r2: Rect<i32> = rect(2, 3, 1, 1);
+        let r3: Rect<i32> = rect(1, 2, 3, 1);
+        let r4: Rect<i32> = rect(1, 2, 3, 5);
+
+        assert!(!(r1 > r1) && !(r1 < r1));
+        assert!(r1 < r2);
+        assert!(r2 > r1);
+        assert!(r3 < r1);
+        assert!(r4 > r1);
     }
 }


### PR DESCRIPTION
This allows using Euclid types in BTree collections.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/234)
<!-- Reviewable:end -->
