### PR TITLE
Angle between a Vector and the x axis.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.15.5"
+version = "0.15.6"
 authors = ["The Servo Project Developers"]
 description = "Geometry primitives"
 documentation = "https://docs.rs/euclid/"

--- a/src/trig.rs
+++ b/src/trig.rs
@@ -13,10 +13,11 @@ pub trait Trig {
     fn sin(self) -> Self;
     fn cos(self) -> Self;
     fn tan(self) -> Self;
+    fn fast_atan2(y: Self, x: Self) -> Self;
 }
 
 macro_rules! trig {
-    ($ty:ty) => (
+    ($ty:ident) => (
         impl Trig for $ty {
             #[inline]
             fn sin(self) -> $ty { self.sin() }
@@ -24,9 +25,35 @@ macro_rules! trig {
             fn cos(self) -> $ty { self.cos() }
             #[inline]
             fn tan(self) -> $ty { self.tan() }
+
+            /// A slightly faster approximation of atan2.
+            ///
+            /// Note that it does not deal with the case where both x and y are 0.
+            #[inline]
+            fn fast_atan2(y: $ty, x: $ty) -> $ty {
+                // See https://math.stackexchange.com/questions/1098487/atan2-faster-approximation#1105038
+                use std::$ty::consts;
+                let x_abs = x.abs();
+                let y_abs = y.abs();
+                let a = x_abs.min(y_abs) / x_abs.max(y_abs);
+                let s = a * a;
+                let mut result = ((-0.0464964749 * s + 0.15931422) * s - 0.327622764) * s * a + a;
+                if y_abs > x_abs {
+                    result = consts::FRAC_PI_2 - result;
+                }
+                if x < 0.0 {
+                    result = consts::PI - result
+                }
+                if y < 0.0 {
+                    result = -result
+                }
+
+                result
+            }
         }
     )
 }
 
 trig!(f32);
 trig!(f64);
+

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -13,6 +13,8 @@ use length::Length;
 use point::{TypedPoint2D, TypedPoint3D, point2, point3};
 use size::{TypedSize2D, size2};
 use scale_factor::ScaleFactor;
+use trig::Trig;
+use Radians;
 use num::*;
 use num_traits::{Float, NumCast, Signed};
 use std::fmt;
@@ -123,6 +125,14 @@ impl<T: Copy, U> TypedVector2D<T, U> {
     #[inline]
     pub fn to_array(&self) -> [T; 2] {
         [self.x, self.y]
+    }
+}
+
+impl<T, U> TypedVector2D<T, U>
+where T: Trig + Copy + Sub<T, Output = T> {
+    /// Returns the angle between this vector and the x axis between -PI and PI.
+    pub fn angle_from_x_axis(&self) -> Radians<T> {
+        Radians::new(Trig::fast_atan2(self.y, self.x))
     }
 }
 
@@ -840,6 +850,20 @@ mod vector2d {
         let result = p1.max(p2);
 
         assert_eq!(result, vec2(2.0, 3.0));
+    }
+
+    #[test]
+    pub fn test_angle_from_x_axis() {
+        use std::f32::consts::FRAC_PI_2;
+        use approxeq::ApproxEq;
+
+        let right: Vec2 = vec2(10.0, 0.0);
+        let down: Vec2 = vec2(0.0, 4.0);
+        let up: Vec2 = vec2(0.0, -1.0);
+
+        assert!(right.angle_from_x_axis().get().approx_eq(&0.0));
+        assert!(down.angle_from_x_axis().get().approx_eq(&FRAC_PI_2));
+        assert!(up.angle_from_x_axis().get().approx_eq(&-FRAC_PI_2));
     }
 }
 


### PR DESCRIPTION
I use this a lot in lyon, and having it in euclid would be much nicer.

This PR implements computing the angle between a 2d vector and the x axis using an approximation of atan2. This approximation is faster enough that it made a difference in lyon, so I am very much inclined to use it by default here (or at least use it for f32 vectors).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/235)
<!-- Reviewable:end -->
