### PR TITLE
Implement to_f64 where to_f32 exists.

### DIFF
--- a/src/point.rs
+++ b/src/point.rs
@@ -291,6 +291,12 @@ impl<T: NumCast + Copy, U> TypedPoint2D<T, U> {
         self.cast().unwrap()
     }
 
+    /// Cast into an `f64` point.
+    #[inline]
+    pub fn to_f64(&self) -> TypedPoint2D<f64, U> {
+        self.cast().unwrap()
+    }
+
     /// Cast into an `usize` point, truncating decimals if any.
     ///
     /// When casting from floating point points, it is worth considering whether
@@ -617,6 +623,12 @@ impl<T: NumCast + Copy, U> TypedPoint3D<T, U> {
     /// Cast into an `f32` point.
     #[inline]
     pub fn to_f32(&self) -> TypedPoint3D<f32, U> {
+        self.cast().unwrap()
+    }
+
+    /// Cast into an `f64` point.
+    #[inline]
+    pub fn to_f64(&self) -> TypedPoint3D<f64, U> {
         self.cast().unwrap()
     }
 

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -427,6 +427,11 @@ impl<T: NumCast + Copy, Unit> TypedRect<T, Unit> {
         self.cast().unwrap()
     }
 
+    /// Cast into an `f64` rectangle.
+    pub fn to_f64(&self) -> TypedRect<f64, Unit> {
+        self.cast().unwrap()
+    }
+
     /// Cast into an `usize` rectangle, truncating decimals if any.
     ///
     /// When casting from floating point rectangles, it is worth considering whether

--- a/src/size.rs
+++ b/src/size.rs
@@ -217,6 +217,11 @@ impl<T: NumCast + Copy, Unit> TypedSize2D<T, Unit> {
         self.cast().unwrap()
     }
 
+    /// Cast into an `f64` size.
+    pub fn to_f64(&self) -> TypedSize2D<f64, Unit> {
+        self.cast().unwrap()
+    }
+
     /// Cast into an `uint` size, truncating decimals if any.
     ///
     /// When casting from floating point sizes, it is worth considering whether

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -326,6 +326,12 @@ impl<T: NumCast + Copy, U> TypedVector2D<T, U> {
         self.cast().unwrap()
     }
 
+    /// Cast into an `f64` vector.
+    #[inline]
+    pub fn to_f64(&self) -> TypedVector2D<f64, U> {
+        self.cast().unwrap()
+    }
+
     /// Cast into an `usize` vector, truncating decimals if any.
     ///
     /// When casting from floating vector vectors, it is worth considering whether
@@ -697,6 +703,12 @@ impl<T: NumCast + Copy, U> TypedVector3D<T, U> {
     /// Cast into an `f32` vector.
     #[inline]
     pub fn to_f32(&self) -> TypedVector3D<f32, U> {
+        self.cast().unwrap()
+    }
+
+    /// Cast into an `f64` vector.
+    #[inline]
+    pub fn to_f64(&self) -> TypedVector3D<f64, U> {
         self.cast().unwrap()
     }
 


### PR DESCRIPTION
I am missing this in a few places.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/236)
<!-- Reviewable:end -->
