### PR TITLE
Remove heapsize support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.15.6"
+version = "0.16.0"
 authors = ["The Servo Project Developers"]
 description = "Geometry primitives"
 documentation = "https://docs.rs/euclid/"
@@ -13,7 +13,6 @@ license = "MIT / Apache-2.0"
 unstable = []
 
 [dependencies]
-heapsize = "0.4"
 num-traits = {version = "0.1.32", default-features = false}
 log = "0.3.1"
 serde = "1.0"

--- a/src/length.rs
+++ b/src/length.rs
@@ -11,7 +11,6 @@
 use scale::TypedScale;
 use num::Zero;
 
-use heapsize::HeapSizeOf;
 use num_traits::{NumCast, Saturating};
 use num::One;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -32,8 +31,6 @@ use std::fmt;
 ///
 /// You can multiply a `Length` by a `scale::TypedScale` to convert it from one unit to
 /// another. See the `TypedScale` docs for an example.
-// Uncomment the derive, and remove the macro call, once heapsize gets
-// PhantomData<T> support.
 #[repr(C)]
 pub struct Length<T, Unit>(pub T, PhantomData<Unit>);
 
@@ -44,12 +41,6 @@ impl<T: Clone, Unit> Clone for Length<T, Unit> {
 }
 
 impl<T: Copy, Unit> Copy for Length<T, Unit> {}
-
-impl<Unit, T: HeapSizeOf> HeapSizeOf for Length<T, Unit> {
-    fn heap_size_of_children(&self) -> usize {
-        self.0.heap_size_of_children()
-    }
-}
 
 impl<'de, Unit, T> Deserialize<'de> for Length<T, Unit> where T: Deserialize<'de> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -245,7 +236,6 @@ mod tests {
     use super::Length;
     use num::Zero;
 
-    use heapsize::HeapSizeOf;
     use num_traits::Saturating;
     use scale::TypedScale;
     use std::f32::INFINITY;
@@ -270,26 +260,6 @@ mod tests {
 
         assert_eq!(one_foot.get(), 12.0);
         assert_eq!(variable_length.get(), 24.0);
-    }
-
-    #[test]
-    fn test_heapsizeof_builtins() {
-        // Heap size of built-ins is zero by default.
-        let one_foot: Length<f32, Inch> = Length::new(12.0);
-
-        let heap_size_length_f32 = one_foot.heap_size_of_children();
-
-        assert_eq!(heap_size_length_f32, 0);
-    }
-
-    #[test]
-    fn test_heapsizeof_length_vector() {
-        // Heap size of any Length is just the heap size of the length value.
-        for n in 0..5 {
-            let length: Length<Vec<f32>, Inch> = Length::new(Vec::with_capacity(n));
-
-            assert_eq!(length.heap_size_of_children(), length.0.heap_size_of_children());
-        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,6 @@
 //! assert_eq!(p.x, p.x_typed().get());
 //! ```
 
-extern crate heapsize;
-
 #[cfg_attr(test, macro_use)]
 extern crate log;
 extern crate serde;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -32,14 +32,6 @@ macro_rules! define_matrix {
 
         impl<T: Copy, $($phantom),+> Copy for $name<T, $($phantom),+> {}
 
-        impl<T, $($phantom),+> ::heapsize::HeapSizeOf for $name<T, $($phantom),+>
-            where T: ::heapsize::HeapSizeOf
-        {
-            fn heap_size_of_children(&self) -> usize {
-                $(self.$field.heap_size_of_children() +)+ 0
-            }
-        }
-
         impl<'de, T, $($phantom),+> ::serde::Deserialize<'de> for $name<T, $($phantom),+>
             where T: ::serde::Deserialize<'de>
         {

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -15,7 +15,6 @@ use point::TypedPoint2D;
 use vector::TypedVector2D;
 use size::TypedSize2D;
 
-use heapsize::HeapSizeOf;
 use num_traits::NumCast;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::cmp::PartialOrd;
@@ -32,12 +31,6 @@ pub struct TypedRect<T, U = UnknownUnit> {
 
 /// The default rectangle type with no unit.
 pub type Rect<T> = TypedRect<T, UnknownUnit>;
-
-impl<T: HeapSizeOf, U> HeapSizeOf for TypedRect<T, U> {
-    fn heap_size_of_children(&self) -> usize {
-        self.origin.heap_size_of_children() + self.size.heap_size_of_children()
-    }
-}
 
 impl<'de, T: Copy + Deserialize<'de>, U> Deserialize<'de> for TypedRect<T, U> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -10,7 +10,6 @@
 
 use num::One;
 
-use heapsize::HeapSizeOf;
 use num_traits::NumCast;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
@@ -39,12 +38,6 @@ use {TypedRect, TypedSize2D, TypedPoint2D, TypedVector2D};
 /// ```
 #[repr(C)]
 pub struct TypedScale<T, Src, Dst>(pub T, PhantomData<(Src, Dst)>);
-
-impl<T: HeapSizeOf, Src, Dst> HeapSizeOf for TypedScale<T, Src, Dst> {
-    fn heap_size_of_children(&self) -> usize {
-        self.0.heap_size_of_children()
-    }
-}
 
 impl<'de, T, Src, Dst> Deserialize<'de> for TypedScale<T, Src, Dst> where T: Deserialize<'de> {
     fn deserialize<D>(deserializer: D) -> Result<TypedScale<T, Src, Dst>, D::Error>

--- a/src/side_offsets.rs
+++ b/src/side_offsets.rs
@@ -17,9 +17,6 @@ use std::fmt;
 use std::ops::Add;
 use std::marker::PhantomData;
 
-#[cfg(feature = "unstable")]
-use heapsize::HeapSizeOf;
-
 /// A group of side offsets, which correspond to top/left/bottom/right for borders, padding,
 /// and margins in CSS, optionally tagged with a unit.
 define_matrix! {
@@ -135,11 +132,6 @@ pub struct SideOffsets2DSimdI32 {
     pub bottom: i32,
     pub right: i32,
     pub left: i32,
-}
-
-#[cfg(feature = "unstable")]
-impl HeapSizeOf for SideOffsets2DSimdI32 {
-    fn heap_size_of_children(&self) -> usize { 0 }
 }
 
 #[cfg(feature = "unstable")]


### PR DESCRIPTION
Servo now uses malloc_size_of.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/241)
<!-- Reviewable:end -->
