### PR TITLE
Remove duplicate Travis-CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,17 @@
 language: rust
-rust:
-  - 1.17.0
-  - stable
-  - beta
-  - nightly
 
 notifications:
   webhooks: http://build.servo.org:54856/travis
 
 matrix:
   include:
+    - rust: 1.21.0
     - rust: stable
-      env: FEATURES=""
     - rust: beta
-      env: FEATURES=""
     - rust: nightly
-      env: FEATURES=""
     - rust: nightly
-      env: FEATURES="unstable"
+      env: FEATURES="--features unstable"
 
 script:
-  - cargo build --verbose --features "$FEATURES"
-  - cargo test --verbose --features "$FEATURES"
+  - cargo build $FEATURES
+  - cargo test --verbose $FEATURES


### PR DESCRIPTION
Currently Travis-CI makes 8 jobs for each build, but it looks like only 5 are necessary.

Also, Firefox requires Rust 1.21+ since https://bugzilla.mozilla.org/show_bug.cgi?id=1409533, so we can test that instead of 1.17.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/244)
<!-- Reviewable:end -->
