### PR TITLE
Add Size::is_empty_or_negative.

### DIFF
--- a/src/size.rs
+++ b/src/size.rs
@@ -121,6 +121,13 @@ where T: Copy + One + Add<Output=T> + Sub<Output=T> + Mul<Output=T> {
     }
 }
 
+impl<T: Zero + PartialOrd, U> TypedSize2D<T, U> {
+    pub fn is_empty_or_negative(&self) -> bool {
+        let zero = T::zero();
+        self.width <= zero || self.height <= zero
+    }
+}
+
 impl<T: Zero, U> TypedSize2D<T, U> {
     pub fn zero() -> Self {
         TypedSize2D::new(


### PR DESCRIPTION
There are a places in webrender where we go through the boilerplate of checking width and height separately, it'd be more convenient to have something handy.

I'm tempted to call it `is_empty` since in practice negative sizes tend to be treated as empty in webrender.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/248)
<!-- Reviewable:end -->
