### PR TITLE
Remove unnecessary approxeq trait bounds.

### DIFF
--- a/src/length.rs
+++ b/src/length.rs
@@ -283,26 +283,6 @@ mod tests {
     }
 
     #[test]
-    fn test_fmt_debug() {
-        // Debug and display format the value only.
-        let one_cm: Length<f32, Mm> = Length::new(10.0);
-
-        let result = format!("{:?}", one_cm);
-
-        assert_eq!(result, "10");
-    }
-
-    #[test]
-    fn test_fmt_display() {
-        // Debug and display format the value only.
-        let one_cm: Length<f32, Mm> = Length::new(10.0);
-
-        let result = format!("{}", one_cm);
-
-        assert_eq!(result, "10");
-    }
-
-    #[test]
     fn test_add() {
         let length1: Length<u8, Mm> = Length::new(250);
         let length2: Length<u8, Mm> = Length::new(5);

--- a/src/transform2d.rs
+++ b/src/transform2d.rs
@@ -357,7 +357,6 @@ where T: Copy + Clone +
          Mul<T, Output=T> +
          Div<T, Output=T> +
          Neg<Output=T> +
-         ApproxEq<T> +
          PartialOrd +
          Trig +
          One + Zero {

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -117,7 +117,6 @@ where T: Copy + Clone +
          Mul<T, Output=T> +
          Div<T, Output=T> +
          Neg<Output=T> +
-         ApproxEq<T> +
          PartialOrd +
          Trig +
          One + Zero {
@@ -190,7 +189,8 @@ where T: Copy + Clone +
         (m33 * det) < _0
     }
 
-    pub fn approx_eq(&self, other: &Self) -> bool {
+    pub fn approx_eq(&self, other: &Self) -> bool
+    where T : ApproxEq<T> {
         self.m11.approx_eq(&other.m11) && self.m12.approx_eq(&other.m12) &&
         self.m13.approx_eq(&other.m13) && self.m14.approx_eq(&other.m14) &&
         self.m21.approx_eq(&other.m21) && self.m22.approx_eq(&other.m22) &&

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -166,7 +166,7 @@ where T: Copy + Mul<T, Output=T> + Add<T, Output=T> + Sub<T, Output=T> {
     }
 
     #[inline]
-    pub fn length(&self) -> T where T: Float + ApproxEq<T> {
+    pub fn length(&self) -> T where T: Float {
         self.square_length().sqrt()
     }
 }


### PR DESCRIPTION
I might be able to remove the ApproxEq trait entirely or implement it in terms of the Float trait that is already implemented by implementers of ApproxEq, but in the mean time this already makes life easier for downstream crates that try to be generic over floats without haing to depend on many traits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/253)
<!-- Reviewable:end -->
