### PR TITLE
Remove some ApproxEq bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.16.1"
+version = "0.16.2"
 authors = ["The Servo Project Developers"]
 description = "Geometry primitives"
 documentation = "https://docs.rs/euclid/"

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -216,7 +216,6 @@ where T: Copy + Clone +
          Mul<T, Output=T> +
          Div<T, Output=T> +
          Neg<Output=T> +
-         ApproxEq<T> +
          PartialOrd +
          Float +
          One + Zero
@@ -330,7 +329,8 @@ impl<T, Src, Dst> TypedRotation3D<T, Src, Dst> where T: Copy {
 }
 
 impl<T, Src, Dst> TypedRotation3D<T, Src, Dst>
-where T: Float + ApproxEq<T>
+where
+    T: Float,
 {
     /// Creates the identity rotation.
     #[inline]
@@ -428,7 +428,10 @@ where T: Float + ApproxEq<T>
     }
 
     #[inline]
-    pub fn is_normalized(&self) -> bool {
+    pub fn is_normalized(&self) -> bool
+    where
+        T: ApproxEq<T>,
+    {
         // TODO: we might need to relax the threshold here, because of floating point imprecision.
         self.square_norm().approx_eq(&T::one())
     }
@@ -436,7 +439,10 @@ where T: Float + ApproxEq<T>
     /// Spherical linear interpolation between this rotation and another rotation.
     ///
     /// `t` is expected to be between zero and one.
-    pub fn slerp(&self, other: &Self, t: T) -> Self {
+    pub fn slerp(&self, other: &Self, t: T) -> Self
+    where
+        T: ApproxEq<T>,
+    {
         debug_assert!(self.is_normalized());
         debug_assert!(other.is_normalized());
 
@@ -484,7 +490,10 @@ where T: Float + ApproxEq<T>
     /// Returns the given 3d point transformed by this rotation.
     ///
     /// The input point must be use the unit Src, and the returned point has the unit Dst.
-    pub fn rotate_point3d(&self, point: &TypedPoint3D<T, Src>) -> TypedPoint3D<T, Dst> {
+    pub fn rotate_point3d(&self, point: &TypedPoint3D<T, Src>) -> TypedPoint3D<T, Dst>
+    where
+        T: ApproxEq<T>,
+    {
         debug_assert!(self.is_normalized());
 
         let two = T::one() + T::one();
@@ -501,7 +510,10 @@ where T: Float + ApproxEq<T>
     ///
     /// The input point must be use the unit Src, and the returned point has the unit Dst.
     #[inline]
-    pub fn rotate_point2d(&self, point: &TypedPoint2D<T, Src>) -> TypedPoint2D<T, Dst> {
+    pub fn rotate_point2d(&self, point: &TypedPoint2D<T, Src>) -> TypedPoint2D<T, Dst>
+    where
+        T: ApproxEq<T>,
+    {
         self.rotate_point3d(&point.to_3d()).xy()
     }
 
@@ -509,7 +521,10 @@ where T: Float + ApproxEq<T>
     ///
     /// The input vector must be use the unit Src, and the returned point has the unit Dst.
     #[inline]
-    pub fn rotate_vector3d(&self, vector: &TypedVector3D<T, Src>) -> TypedVector3D<T, Dst> {
+    pub fn rotate_vector3d(&self, vector: &TypedVector3D<T, Src>) -> TypedVector3D<T, Dst>
+    where
+        T: ApproxEq<T>,
+    {
         self.rotate_point3d(&vector.to_point()).to_vector()
     }
 
@@ -517,13 +532,19 @@ where T: Float + ApproxEq<T>
     ///
     /// The input vector must be use the unit Src, and the returned point has the unit Dst.
     #[inline]
-    pub fn rotate_vector2d(&self, vector: &TypedVector2D<T, Src>) -> TypedVector2D<T, Dst> {
+    pub fn rotate_vector2d(&self, vector: &TypedVector2D<T, Src>) -> TypedVector2D<T, Dst>
+    where
+        T: ApproxEq<T>,
+    {
         self.rotate_vector3d(&vector.to_3d()).xy()
     }
 
     /// Returns the matrix representation of this rotation.
     #[inline]
-    pub fn to_transform(&self) -> TypedTransform3D<T, Src, Dst> {
+    pub fn to_transform(&self) -> TypedTransform3D<T, Src, Dst>
+    where
+        T: ApproxEq<T>,
+    {
         debug_assert!(self.is_normalized());
 
         let i2 = self.i + self.i;
@@ -563,7 +584,10 @@ where T: Float + ApproxEq<T>
     }
 
     /// Returns a rotation representing the other rotation followed by this rotation.
-    pub fn pre_rotate<NewSrc>(&self, other: &TypedRotation3D<T, NewSrc, Src>) -> TypedRotation3D<T, NewSrc, Dst> {
+    pub fn pre_rotate<NewSrc>(&self, other: &TypedRotation3D<T, NewSrc, Src>) -> TypedRotation3D<T, NewSrc, Dst>
+    where
+        T: ApproxEq<T>,
+    {
         debug_assert!(self.is_normalized());
         TypedRotation3D::quaternion(
             self.i * other.r + self.r * other.i + self.j * other.k - self.k * other.j,
@@ -575,7 +599,10 @@ where T: Float + ApproxEq<T>
 
     /// Returns a rotation representing this rotation followed by the other rotation.
     #[inline]
-    pub fn post_rotate<NewDst>(&self, other: &TypedRotation3D<T, Dst, NewDst>) -> TypedRotation3D<T, Src, NewDst> {
+    pub fn post_rotate<NewDst>(&self, other: &TypedRotation3D<T, Dst, NewDst>) -> TypedRotation3D<T, Src, NewDst>
+    where
+        T: ApproxEq<T>,
+    {
         other.pre_rotate(self)
     }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -151,7 +151,7 @@ where T: Copy + Mul<T, Output=T> + Add<T, Output=T> + Sub<T, Output=T> {
     }
 
     #[inline]
-    pub fn normalize(self) -> Self where T: Float + ApproxEq<T> {
+    pub fn normalize(self) -> Self where T: Float {
         self / self.length()
     }
 
@@ -542,7 +542,7 @@ impl<T: Mul<T, Output=T> +
     }
 
     #[inline]
-    pub fn normalize(self) -> Self where T: Float + ApproxEq<T> {
+    pub fn normalize(self) -> Self where T: Float {
         self / self.length()
     }
 
@@ -552,7 +552,7 @@ impl<T: Mul<T, Output=T> +
     }
 
     #[inline]
-    pub fn length(&self) -> T where T: Float + ApproxEq<T> {
+    pub fn length(&self) -> T where T: Float {
         self.square_length().sqrt()
     }
 }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -152,12 +152,7 @@ where T: Copy + Mul<T, Output=T> + Add<T, Output=T> + Sub<T, Output=T> {
 
     #[inline]
     pub fn normalize(self) -> Self where T: Float + ApproxEq<T> {
-        let dot = self.dot(self);
-        if dot.approx_eq(&T::zero()) {
-            self
-        } else {
-            self / dot.sqrt()
-        }
+        self / self.length()
     }
 
     #[inline]
@@ -548,12 +543,7 @@ impl<T: Mul<T, Output=T> +
 
     #[inline]
     pub fn normalize(self) -> Self where T: Float + ApproxEq<T> {
-        let dot = self.dot(self);
-        if dot.approx_eq(&T::zero()) {
-            self
-        } else {
-            self / dot.sqrt()
-        }
+        self / self.length()
     }
 
     #[inline]

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -829,7 +829,7 @@ mod vector2d {
         let p0: Vec2 = Vec2::zero();
         let p1: Vec2 = vec2(4.0, 0.0);
         let p2: Vec2 = vec2(3.0, -4.0);
-        assert_eq!(p0.normalize(), p0);
+        assert!(p0.normalize().x.is_nan() && p0.normalize().y.is_nan());
         assert_eq!(p1.normalize(), vec2(1.0, 0.0));
         assert_eq!(p2.normalize(), vec2(0.6, -0.8));
     }
@@ -940,7 +940,7 @@ mod vector3d {
         let p0: Vec3 = Vec3::zero();
         let p1: Vec3 = vec3(0.0, -6.0, 0.0);
         let p2: Vec3 = vec3(1.0, 2.0, -2.0);
-        assert_eq!(p0.normalize(), p0);
+        assert!(p0.normalize().x.is_nan() && p0.normalize().y.is_nan() && p0.normalize().z.is_nan());
         assert_eq!(p1.normalize(), vec3(0.0, -1.0, 0.0));
         assert_eq!(p2.normalize(), vec3(1.0/3.0, 2.0/3.0, -2.0/3.0));
     }


### PR DESCRIPTION
This PR removes `ApproxEq` bounds from several functions. In most cases the bound was unneeded, the major exception being `normalize()`. Here, I removed the divide by zero checks. Let me argue why this is reasonable.

- The previous behavior was surprising. Similar crates (e.g. cgmath, nalgebra) do not make checks. (nalgebra has an additional `try_normalize()` that takes a `min_norm` argument.)
- It was inconsistent with other similar functions in euclid that either do not make checks or return an `Option`. Also, the latter is only done for exact equality with zero and not approximate equality.
- It caused a bug in one of my programs. :smile:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/259)
<!-- Reviewable:end -->
