### PR TITLE
Missing serde impl for Angle, and remove log dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ unstable = []
 [dependencies]
 num-traits = {version = "0.1.32", default-features = false}
 log = "0.3.1"
-serde = "1.0"
+serde = { version = "1.0", features = ["serde_derive"] }
 
 [dev-dependencies]
 rand = "0.3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.16.3"
+version = "0.16.4"
 authors = ["The Servo Project Developers"]
 description = "Geometry primitives"
 documentation = "https://docs.rs/euclid/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ unstable = []
 
 [dependencies]
 num-traits = {version = "0.1.32", default-features = false}
-log = "0.3.1"
 serde = { version = "1.0", features = ["serde_derive"] }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@
 
 #[cfg_attr(test, macro_use)]
 extern crate log;
+#[macro_use]
 extern crate serde;
 
 extern crate num_traits;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,6 @@
 //! assert_eq!(p.x, p.x_typed().get());
 //! ```
 
-#[cfg_attr(test, macro_use)]
-extern crate log;
 #[macro_use]
 extern crate serde;
 

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -17,7 +17,7 @@ use {TypedPoint2D, TypedPoint3D, TypedVector2D, TypedVector3D, Vector3D, point2,
 use {TypedTransform2D, TypedTransform3D, UnknownUnit};
 
 /// An angle in radians
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct Angle<T> {
     pub radians: T,
 }

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -768,7 +768,6 @@ mod tests {
              0.0,  0.0,        -1.0, 0.0,
             -1.0, -1.22222222, -0.0, 1.0
         );
-        debug!("result={:?} expected={:?}", result, expected);
         assert!(result.approx_eq(&expected));
     }
 


### PR DESCRIPTION
The Angle type was missing `Serialize` and `Deserialize` implementations, this PR  addresses that. In the process I removed the dependency to the log crate which was only used in one place in a test and wasn't really needed, and bumped euclid's own version from 0.16.3 to 0.16.4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/265)
<!-- Reviewable:end -->
