### PR TITLE
Make serde optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,22 @@ language: rust
 notifications:
   webhooks: http://build.servo.org:54856/travis
 
+rust:
+  - 1.21.0
+  - stable
+  - beta
+  - nightly
+
+env:
+  - FEATURES=""
+  - FEATURES="--features serde"
+
 matrix:
   include:
-    - rust: 1.21.0
-    - rust: stable
-    - rust: beta
-    - rust: nightly
     - rust: nightly
       env: FEATURES="--features unstable"
+    - rust: nightly
+      env: FEATURES="--features unstable,serde"
 
 script:
   - cargo build $FEATURES

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ notifications:
   webhooks: http://build.servo.org:54856/travis
 
 rust:
-  - 1.21.0
+  - 1.23.0
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ unstable = []
 
 [dependencies]
 num-traits = {version = "0.1.32", default-features = false}
-serde = { version = "1.0", features = ["serde_derive"] }
+serde = { version = "1.0", features = ["serde_derive"], optional = true }
 
 [dev-dependencies]
 rand = "0.3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.16.4"
+version = "0.17.0"
 authors = ["The Servo Project Developers"]
 description = "Geometry primitives"
 documentation = "https://docs.rs/euclid/"

--- a/src/length.rs
+++ b/src/length.rs
@@ -13,6 +13,7 @@ use num::Zero;
 
 use num_traits::{NumCast, Saturating};
 use num::One;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::cmp::Ordering;
 use std::ops::{Add, Div, Mul, Neg, Sub};
@@ -42,6 +43,7 @@ impl<T: Clone, Unit> Clone for Length<T, Unit> {
 
 impl<T: Copy, Unit> Copy for Length<T, Unit> {}
 
+#[cfg(feature = "serde")]
 impl<'de, Unit, T> Deserialize<'de> for Length<T, Unit>
 where
     T: Deserialize<'de>,
@@ -57,6 +59,7 @@ where
     }
 }
 
+#[cfg(feature = "serde")]
 impl<T, Unit> Serialize for Length<T, Unit>
 where
     T: Serialize,
@@ -260,14 +263,26 @@ mod tests {
     use scale::TypedScale;
     use std::f32::INFINITY;
 
-    extern crate serde_test;
-    use self::serde_test::Token;
-    use self::serde_test::assert_tokens;
-
     enum Inch {}
     enum Mm {}
     enum Cm {}
     enum Second {}
+
+    #[cfg(feature = "serde")]
+    mod serde {
+        use super::*;
+
+        extern crate serde_test;
+        use self::serde_test::Token;
+        use self::serde_test::assert_tokens;
+
+        #[test]
+        fn test_length_serde() {
+            let one_cm: Length<f32, Mm> = Length::new(10.0);
+
+            assert_tokens(&one_cm, &[Token::F32(10.0)]);
+        }
+    }
 
     #[test]
     fn test_clone() {
@@ -280,13 +295,6 @@ mod tests {
 
         assert_eq!(one_foot.get(), 12.0);
         assert_eq!(variable_length.get(), 24.0);
-    }
-
-    #[test]
-    fn test_length_serde() {
-        let one_cm: Length<f32, Mm> = Length::new(10.0);
-
-        assert_tokens(&one_cm, &[Token::F32(10.0)]);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@
 //! assert_eq!(p.x, p.x_typed().get());
 //! ```
 
+#[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -32,6 +32,7 @@ macro_rules! define_matrix {
 
         impl<T: Copy, $($phantom),+> Copy for $name<T, $($phantom),+> {}
 
+        #[cfg(feature = "serde")]
         impl<'de, T, $($phantom),+> ::serde::Deserialize<'de> for $name<T, $($phantom),+>
             where T: ::serde::Deserialize<'de>
         {
@@ -47,6 +48,7 @@ macro_rules! define_matrix {
             }
         }
 
+        #[cfg(feature = "serde")]
         impl<T, $($phantom),+> ::serde::Serialize for $name<T, $($phantom),+>
             where T: ::serde::Serialize
         {

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -17,6 +17,7 @@ use side_offsets::TypedSideOffsets2D;
 use size::TypedSize2D;
 
 use num_traits::NumCast;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::cmp::PartialOrd;
 use std::fmt;
@@ -33,6 +34,7 @@ pub struct TypedRect<T, U = UnknownUnit> {
 /// The default rectangle type with no unit.
 pub type Rect<T> = TypedRect<T, UnknownUnit>;
 
+#[cfg(feature = "serde")]
 impl<'de, T: Copy + Deserialize<'de>, U> Deserialize<'de> for TypedRect<T, U> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -43,6 +45,7 @@ impl<'de, T: Copy + Deserialize<'de>, U> Deserialize<'de> for TypedRect<T, U> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<T: Serialize, U> Serialize for TypedRect<T, U> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -17,7 +17,8 @@ use {TypedPoint2D, TypedPoint3D, TypedVector2D, TypedVector3D, Vector3D, point2,
 use {TypedTransform2D, TypedTransform3D, UnknownUnit};
 
 /// An angle in radians
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Angle<T> {
     pub radians: T,
 }

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -11,6 +11,7 @@
 use num::One;
 
 use num_traits::NumCast;
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 use std::ops::{Add, Div, Mul, Neg, Sub};
@@ -39,6 +40,7 @@ use {TypedPoint2D, TypedRect, TypedSize2D, TypedVector2D};
 #[repr(C)]
 pub struct TypedScale<T, Src, Dst>(pub T, PhantomData<(Src, Dst)>);
 
+#[cfg(feature = "serde")]
 impl<'de, T, Src, Dst> Deserialize<'de> for TypedScale<T, Src, Dst>
 where
     T: Deserialize<'de>,
@@ -54,6 +56,7 @@ where
     }
 }
 
+#[cfg(feature = "serde")]
 impl<T, Src, Dst> Serialize for TypedScale<T, Src, Dst>
 where
     T: Serialize,


### PR DESCRIPTION
Closes #264 

This PR makes serde support optional. At the moment it is disabled by default.

I am not very sure about my changes to `.travis.yml` but it seems to work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/267)
<!-- Reviewable:end -->
