### PR TITLE
Improve the ergonomics of using strongly typed Lengths

### DIFF
--- a/src/length.rs
+++ b/src/length.rs
@@ -12,7 +12,7 @@ use scale::TypedScale;
 use num::Zero;
 
 use num_traits::{NumCast, Saturating};
-use num::One;
+use num::{One, ValueOrLength};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::cmp::Ordering;
@@ -252,6 +252,11 @@ where
         let one_t = T::one() - t;
         Length::new(one_t * self.get() + t * other.get())
     }
+}
+
+impl<T, U> ValueOrLength<T, U> for Length<T, U> {
+    #[inline]
+    fn value(self) -> T { self.0 }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,9 +50,9 @@
 //! // p.x is an f32.
 //! println!("p.x = {:?} ", p.x);
 //! // p.x is a Length<f32, WorldSpace>.
-//! println!("p.x_typed() = {:?} ", p.x_typed());
+//! println!("p.get_x() = {:?} ", p.get_x());
 //! // Length::get returns the scalar value (f32).
-//! assert_eq!(p.x, p.x_typed().get());
+//! assert_eq!(p.x, p.get_x().get());
 //! ```
 
 #[cfg(feature = "serde")]

--- a/src/num.rs
+++ b/src/num.rs
@@ -10,6 +10,46 @@
 
 use num_traits;
 
+/// A trait for parameters that can be either a `Length<T, U>` or the raw
+/// scalar value `T`.
+///
+/// This makes it possible to write methods that accept both, for example `TypedVector2D::new`
+/// works with both strongly typed length arguments and direct scalar values:
+///
+/// ```
+/// use euclid::{Length, TypedVector2D};
+/// struct WorldSpace;
+/// struct ScreenSpace;
+/// type WorldVec2 = TypedVector2D<f32, WorldSpace>;
+/// type WorldLength = Length<f32, WorldSpace>;
+/// type ScreenLength = Length<f32, ScreenSpace>;
+/// // Convenient synatx:
+/// let v1 = WorldVec2::new(1.0, 2.0);
+/// // Statically checked synatx:
+/// let v2 = WorldVec2::new(WorldLength::new(1.0), WorldLength::new(2.0));
+/// // This would give a compile time error because units do not match:
+/// // let not_good = WorldVec2::new(ScreenLength:new(1.0), ScreenLength::new(2.0));
+/// ```
+pub trait ValueOrLength<T, U> {
+    fn value(self) -> T;
+}
+
+impl<T, U> ValueOrLength<T, U> for T {
+    #[inline]
+    fn value(self) -> T { self }
+}
+
+
+pub trait ValueOrScale<T, Src, Dst> {
+    fn value(self) -> T;
+}
+
+impl<T, Src, Dst> ValueOrScale<T, Src, Dst> for T {
+    #[inline]
+    fn value(self) -> T { self }
+}
+
+
 pub trait Zero {
     fn zero() -> Self;
 }

--- a/src/point.rs
+++ b/src/point.rs
@@ -102,13 +102,13 @@ impl<T: Copy, U> TypedPoint2D<T, U> {
 
     /// Returns self.x as a Length carrying the unit.
     #[inline]
-    pub fn x_typed(&self) -> Length<T, U> {
+    pub fn get_x(&self) -> Length<T, U> {
         Length::new(self.x)
     }
 
     /// Returns self.y as a Length carrying the unit.
     #[inline]
-    pub fn y_typed(&self) -> Length<T, U> {
+    pub fn get_y(&self) -> Length<T, U> {
         Length::new(self.y)
     }
 
@@ -484,19 +484,19 @@ impl<T: Copy, U> TypedPoint3D<T, U> {
 
     /// Returns self.x as a Length carrying the unit.
     #[inline]
-    pub fn x_typed(&self) -> Length<T, U> {
+    pub fn get_x(&self) -> Length<T, U> {
         Length::new(self.x)
     }
 
     /// Returns self.y as a Length carrying the unit.
     #[inline]
-    pub fn y_typed(&self) -> Length<T, U> {
+    pub fn get_y(&self) -> Length<T, U> {
         Length::new(self.y)
     }
 
     /// Returns self.z as a Length carrying the unit.
     #[inline]
-    pub fn z_typed(&self) -> Length<T, U> {
+    pub fn get_z(&self) -> Length<T, U> {
         Length::new(self.z)
     }
 

--- a/src/point.rs
+++ b/src/point.rs
@@ -32,11 +32,24 @@ define_matrix! {
 /// `Point2D` provides the same methods as `TypedPoint2D`.
 pub type Point2D<T> = TypedPoint2D<T, UnknownUnit>;
 
+impl<T, U> TypedPoint2D<T, U> {
+    /// Constructor taking scalar values or `Length`.
+    #[inline]
+    pub fn new<N>(x: N, y: N) -> Self
+    where N: ValueOrLength<T, U> {
+        TypedPoint2D {
+            x: x.value(),
+            y: y.value(),
+            _unit: PhantomData,
+        }
+    }
+}
+
 impl<T: Copy + Zero, U> TypedPoint2D<T, U> {
     /// Constructor, setting all components to zero.
     #[inline]
     pub fn origin() -> Self {
-        point2(Zero::zero(), Zero::zero())
+        point2(T::zero(), T::zero())
     }
 
     #[inline]
@@ -64,26 +77,11 @@ impl<T: fmt::Display, U> fmt::Display for TypedPoint2D<T, U> {
 }
 
 impl<T: Copy, U> TypedPoint2D<T, U> {
-    /// Constructor taking scalar values directly.
-    #[inline]
-    pub fn new(x: T, y: T) -> Self {
-        TypedPoint2D {
-            x: x,
-            y: y,
-            _unit: PhantomData,
-        }
-    }
-
-    /// Constructor taking properly typed Lengths instead of scalar values.
-    #[inline]
-    pub fn from_lengths(x: Length<T, U>, y: Length<T, U>) -> Self {
-        point2(x.0, y.0)
-    }
-
     /// Create a 3d point from this one, using the specified z value.
     #[inline]
-    pub fn extend(&self, z: T) -> TypedPoint3D<T, U> {
-        point3(self.x, self.y, z)
+    pub fn extend<N>(&self, z: N) -> TypedPoint3D<T, U>
+    where N: ValueOrLength<T, U> {
+        point3(self.x, self.y, z.value())
     }
 
     /// Cast this point into a vector.
@@ -285,7 +283,7 @@ impl<T: NumCast + Copy, U> TypedPoint2D<T, U> {
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
     #[inline]
     pub fn cast<NewT: NumCast + Copy>(&self) -> Option<TypedPoint2D<NewT, U>> {
-        match (NumCast::from(self.x), NumCast::from(self.y)) {
+        match (NewT::from(self.x), NewT::from(self.y)) {
             (Some(x), Some(y)) => Some(point2(x, y)),
             _ => None,
         }
@@ -397,7 +395,7 @@ impl<T: Copy + Zero, U> TypedPoint3D<T, U> {
     /// Constructor, setting all copmonents to zero.
     #[inline]
     pub fn origin() -> Self {
-        point3(Zero::zero(), Zero::zero(), Zero::zero())
+        point3(T::zero(), T::zero(), T::zero())
     }
 }
 
@@ -438,24 +436,20 @@ impl<T: fmt::Display, U> fmt::Display for TypedPoint3D<T, U> {
     }
 }
 
-impl<T: Copy, U> TypedPoint3D<T, U> {
-    /// Constructor taking scalar values directly.
+impl<T, U> TypedPoint3D<T, U> {
+    /// Constructor taking scalar values or `Length`.
     #[inline]
-    pub fn new(x: T, y: T, z: T) -> Self {
+    pub fn new<N: ValueOrLength<T, U>>(x: N, y: N, z: N) -> Self {
         TypedPoint3D {
-            x: x,
-            y: y,
-            z: z,
+            x: x.value(),
+            y: y.value(),
+            z: z.value(),
             _unit: PhantomData,
         }
     }
+}
 
-    /// Constructor taking properly typed Lengths instead of scalar values.
-    #[inline]
-    pub fn from_lengths(x: Length<T, U>, y: Length<T, U>, z: Length<T, U>) -> Self {
-        point3(x.0, y.0, z.0)
-    }
-
+impl<T: Copy, U> TypedPoint3D<T, U> {
     /// Cast this point into a vector.
     ///
     /// Equivalent to substracting the origin to this point.
@@ -640,9 +634,9 @@ impl<T: NumCast + Copy, U> TypedPoint3D<T, U> {
     #[inline]
     pub fn cast<NewT: NumCast + Copy>(&self) -> Option<TypedPoint3D<NewT, U>> {
         match (
-            NumCast::from(self.x),
-            NumCast::from(self.y),
-            NumCast::from(self.z),
+            NewT::from(self.x),
+            NewT::from(self.y),
+            NewT::from(self.z),
         ) {
             (Some(x), Some(y), Some(z)) => Some(point3(x, y, z)),
             _ => None,
@@ -728,11 +722,11 @@ impl<T: Copy, U> From<[T; 3]> for TypedPoint3D<T, U> {
     }
 }
 
-pub fn point2<T: Copy, U>(x: T, y: T) -> TypedPoint2D<T, U> {
+pub fn point2<T, U>(x: T, y: T) -> TypedPoint2D<T, U> {
     TypedPoint2D::new(x, y)
 }
 
-pub fn point3<T: Copy, U>(x: T, y: T, z: T) -> TypedPoint3D<T, U> {
+pub fn point3<T, U>(x: T, y: T, z: T) -> TypedPoint3D<T, U> {
     TypedPoint3D::new(x, y, z)
 }
 

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -199,20 +199,17 @@ where
 
     #[inline]
     #[cfg_attr(feature = "unstable", must_use)]
-    pub fn inflate(&self, width: T, height: T) -> Self {
+    pub fn inflate<N>(&self, width: N, height: N) -> Self
+    where N: ValueOrLength<T, U> {
+        let w = width.value();
+        let h = height.value();
         TypedRect::new(
-            TypedPoint2D::new(self.origin.x - width, self.origin.y - height),
+            TypedPoint2D::new(self.origin.x - w, self.origin.y - h),
             TypedSize2D::new(
-                self.size.width + width + width,
-                self.size.height + height + height,
+                self.size.width + w + w,
+                self.size.height + h + h,
             ),
         )
-    }
-
-    #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
-    pub fn inflate_typed(&self, width: Length<T, U>, height: Length<T, U>) -> Self {
-        self.inflate(width.get(), height.get())
     }
 
     #[inline]

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -133,22 +133,22 @@ where
     }
 
     #[inline]
-    pub fn max_x_typed(&self) -> Length<T, U> {
+    pub fn get_max_x(&self) -> Length<T, U> {
         Length::new(self.max_x())
     }
 
     #[inline]
-    pub fn min_x_typed(&self) -> Length<T, U> {
+    pub fn get_min_x(&self) -> Length<T, U> {
         Length::new(self.min_x())
     }
 
     #[inline]
-    pub fn max_y_typed(&self) -> Length<T, U> {
+    pub fn get_max_y(&self) -> Length<T, U> {
         Length::new(self.max_y())
     }
 
     #[inline]
-    pub fn min_y_typed(&self) -> Length<T, U> {
+    pub fn get_min_y(&self) -> Length<T, U> {
         Length::new(self.min_y())
     }
 

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -8,8 +8,7 @@
 // except according to those terms.
 //! A type-checked scaling factor between units.
 
-use num::One;
-
+use num::{One, ValueOrScale};
 use num_traits::NumCast;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -39,6 +38,11 @@ use {TypedPoint2D, TypedRect, TypedSize2D, TypedVector2D};
 /// ```
 #[repr(C)]
 pub struct TypedScale<T, Src, Dst>(pub T, PhantomData<(Src, Dst)>);
+
+impl<T, Src, Dst> ValueOrScale<T, Src, Dst> for TypedScale<T, Src, Dst> {
+    #[inline]
+    fn value(self) -> T { self.0 }
+}
 
 #[cfg(feature = "serde")]
 impl<'de, T, Src, Dst> Deserialize<'de> for TypedScale<T, Src, Dst>

--- a/src/side_offsets.rs
+++ b/src/side_offsets.rs
@@ -12,7 +12,7 @@
 
 use super::UnknownUnit;
 use length::Length;
-use num::Zero;
+use num::{Zero, ValueOrLength};
 use std::fmt;
 use std::ops::Add;
 use std::marker::PhantomData;
@@ -41,28 +41,22 @@ impl<T: fmt::Debug, U> fmt::Debug for TypedSideOffsets2D<T, U> {
 /// The default side offset type with no unit.
 pub type SideOffsets2D<T> = TypedSideOffsets2D<T, UnknownUnit>;
 
-impl<T: Copy, U> TypedSideOffsets2D<T, U> {
-    /// Constructor taking a scalar for each side.
-    pub fn new(top: T, right: T, bottom: T, left: T) -> Self {
+
+impl<T, U> TypedSideOffsets2D<T, U> {
+    /// Constructor taking a scalar or a `Length` for each side.
+    pub fn new<N>(top: N, right: N, bottom: N, left: N) -> Self
+    where N: ValueOrLength<T, U> {
         TypedSideOffsets2D {
-            top: top,
-            right: right,
-            bottom: bottom,
-            left: left,
+            top: top.value(),
+            right: right.value(),
+            bottom: bottom.value(),
+            left: left.value(),
             _unit: PhantomData,
         }
     }
+}
 
-    /// Constructor taking a typed Length for each side.
-    pub fn from_lengths(
-        top: Length<T, U>,
-        right: Length<T, U>,
-        bottom: Length<T, U>,
-        left: Length<T, U>,
-    ) -> Self {
-        TypedSideOffsets2D::new(top.0, right.0, bottom.0, left.0)
-    }
-
+impl<T: Copy, U> TypedSideOffsets2D<T, U> {
     /// Access self.top as a typed Length instead of a scalar value.
     pub fn get_top(&self) -> Length<T, U> {
         Length::new(self.top)
@@ -84,13 +78,10 @@ impl<T: Copy, U> TypedSideOffsets2D<T, U> {
     }
 
     /// Constructor setting the same value to all sides, taking a scalar value directly.
-    pub fn new_all_same(all: T) -> Self {
-        TypedSideOffsets2D::new(all, all, all, all)
-    }
-
-    /// Constructor setting the same value to all sides, taking a typed Length.
-    pub fn from_length_all_same(all: Length<T, U>) -> Self {
-        TypedSideOffsets2D::new_all_same(all.0)
+    pub fn new_all_same<N>(all: N) -> Self
+    where N: ValueOrLength<T, U> {
+        let v = all.value();
+        TypedSideOffsets2D::new(v, v, v, v)
     }
 }
 
@@ -133,6 +124,6 @@ where
 impl<T: Copy + Zero, U> TypedSideOffsets2D<T, U> {
     /// Constructor, setting all sides to zero.
     pub fn zero() -> Self {
-        TypedSideOffsets2D::new(Zero::zero(), Zero::zero(), Zero::zero(), Zero::zero())
+        TypedSideOffsets2D::new(T::zero(), T::zero(), T::zero(), T::zero())
     }
 }

--- a/src/side_offsets.rs
+++ b/src/side_offsets.rs
@@ -64,22 +64,22 @@ impl<T: Copy, U> TypedSideOffsets2D<T, U> {
     }
 
     /// Access self.top as a typed Length instead of a scalar value.
-    pub fn top_typed(&self) -> Length<T, U> {
+    pub fn get_top(&self) -> Length<T, U> {
         Length::new(self.top)
     }
 
     /// Access self.right as a typed Length instead of a scalar value.
-    pub fn right_typed(&self) -> Length<T, U> {
+    pub fn get_right(&self) -> Length<T, U> {
         Length::new(self.right)
     }
 
     /// Access self.bottom as a typed Length instead of a scalar value.
-    pub fn bottom_typed(&self) -> Length<T, U> {
+    pub fn get_bottom(&self) -> Length<T, U> {
         Length::new(self.bottom)
     }
 
     /// Access self.left as a typed Length instead of a scalar value.
-    pub fn left_typed(&self) -> Length<T, U> {
+    pub fn get_left(&self) -> Length<T, U> {
         Length::new(self.left)
     }
 
@@ -106,11 +106,11 @@ where
         self.top + self.bottom
     }
 
-    pub fn horizontal_typed(&self) -> Length<T, U> {
+    pub fn get_horizontal(&self) -> Length<T, U> {
         Length::new(self.horizontal())
     }
 
-    pub fn vertical_typed(&self) -> Length<T, U> {
+    pub fn get_vertical(&self) -> Length<T, U> {
         Length::new(self.vertical())
     }
 }

--- a/src/size.rs
+++ b/src/size.rs
@@ -179,13 +179,13 @@ impl<T: Copy + Div<T, Output = T>, U1, U2> Div<TypedScale<T, U1, U2>> for TypedS
 impl<T: Copy, U> TypedSize2D<T, U> {
     /// Returns self.width as a Length carrying the unit.
     #[inline]
-    pub fn width_typed(&self) -> Length<T, U> {
+    pub fn get_width(&self) -> Length<T, U> {
         Length::new(self.width)
     }
 
     /// Returns self.height as a Length carrying the unit.
     #[inline]
-    pub fn height_typed(&self) -> Length<T, U> {
+    pub fn get_height(&self) -> Length<T, U> {
         Length::new(self.height)
     }
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -45,19 +45,13 @@ impl<T: fmt::Display, U> fmt::Display for TypedSize2D<T, U> {
 
 impl<T, U> TypedSize2D<T, U> {
     /// Constructor taking scalar values.
-    pub fn new(width: T, height: T) -> Self {
+    pub fn new<N>(width: N, height: N) -> Self
+    where N: ValueOrLength<T, U> {
         TypedSize2D {
-            width: width,
-            height: height,
+            width: width.value(),
+            height: height.value(),
             _unit: PhantomData,
         }
-    }
-}
-
-impl<T: Clone, U> TypedSize2D<T, U> {
-    /// Constructor taking scalar strongly typed lengths.
-    pub fn from_lengths(width: Length<T, U>, height: Length<T, U>) -> Self {
-        TypedSize2D::new(width.get(), height.get())
     }
 }
 
@@ -134,13 +128,13 @@ impl<T: Zero + PartialOrd, U> TypedSize2D<T, U> {
 
 impl<T: Zero, U> TypedSize2D<T, U> {
     pub fn zero() -> Self {
-        TypedSize2D::new(Zero::zero(), Zero::zero())
+        TypedSize2D::new(T::zero(), T::zero())
     }
 }
 
 impl<T: Zero, U> Zero for TypedSize2D<T, U> {
     fn zero() -> Self {
-        TypedSize2D::new(Zero::zero(), Zero::zero())
+        TypedSize2D::new(T::zero(), T::zero())
     }
 }
 
@@ -217,7 +211,7 @@ impl<T: NumCast + Copy, Unit> TypedSize2D<T, Unit> {
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
     pub fn cast<NewT: NumCast + Copy>(&self) -> Option<TypedSize2D<NewT, Unit>> {
-        match (NumCast::from(self.width), NumCast::from(self.height)) {
+        match (NewT::from(self.width), NewT::from(self.height)) {
             (Some(w), Some(h)) => Some(TypedSize2D::new(w, h)),
             _ => None,
         }

--- a/src/transform2d.rs
+++ b/src/transform2d.rs
@@ -8,7 +8,7 @@
 // except according to those terms.
 
 use super::{UnknownUnit, Angle};
-use num::{One, Zero};
+use num::{One, Zero, ValueOrScale};
 use point::TypedPoint2D;
 use vector::{TypedVector2D, vec2};
 use rect::TypedRect;
@@ -223,11 +223,12 @@ where T: Copy + Clone +
     }
 
     /// Returns a scale transform.
-    pub fn create_scale(x: T, y: T) -> Self {
+    pub fn create_scale<N>(x: N, y: N) -> Self
+    where N: ValueOrScale<T, Src, Dst> {
         let _0 = Zero::zero();
         TypedTransform2D::row_major(
-             x, _0,
-            _0,  y,
+             x.value(), _0,
+            _0,  y.value(),
             _0, _0
         )
     }

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -15,7 +15,7 @@ use vector::{TypedVector2D, TypedVector3D, vec2, vec3};
 use rect::TypedRect;
 use transform2d::TypedTransform2D;
 use scale::TypedScale;
-use num::{One, Zero};
+use num::{One, Zero, ValueOrScale};
 use std::ops::{Add, Mul, Sub, Div, Neg};
 use std::marker::PhantomData;
 use std::fmt;
@@ -482,8 +482,12 @@ where T: Copy + Clone +
     }
 
     /// Create a 3d scale transform
-    pub fn create_scale(x: T, y: T, z: T) -> Self {
-        let (_0, _1): (T, T) = (Zero::zero(), One::one());
+    pub fn create_scale<N>(x: N, y: N, z: N) -> Self
+    where N: ValueOrScale<T, Src, Dst> {
+        let (_0, _1) = (T::zero(), T::one());
+        let x = x.value();
+        let y = y.value();
+        let z = z.value();
         TypedTransform3D::row_major(
              x, _0, _0, _0,
             _0,  y, _0, _0,

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -107,13 +107,13 @@ impl<T: Copy, U> TypedVector2D<T, U> {
 
     /// Returns self.x as a Length carrying the unit.
     #[inline]
-    pub fn x_typed(&self) -> Length<T, U> {
+    pub fn get_x(&self) -> Length<T, U> {
         Length::new(self.x)
     }
 
     /// Returns self.y as a Length carrying the unit.
     #[inline]
-    pub fn y_typed(&self) -> Length<T, U> {
+    pub fn get_y(&self) -> Length<T, U> {
         Length::new(self.y)
     }
 
@@ -180,6 +180,14 @@ where
         T: Float,
     {
         self.square_length().sqrt()
+    }
+
+    #[inline]
+    pub fn get_length(&self) -> Length<T, U>
+    where
+        T: Float,
+    {
+        Length::new(self.length())
     }
 }
 
@@ -512,19 +520,19 @@ impl<T: Copy, U> TypedVector3D<T, U> {
 
     /// Returns self.x as a Length carrying the unit.
     #[inline]
-    pub fn x_typed(&self) -> Length<T, U> {
+    pub fn get_x(&self) -> Length<T, U> {
         Length::new(self.x)
     }
 
     /// Returns self.y as a Length carrying the unit.
     #[inline]
-    pub fn y_typed(&self) -> Length<T, U> {
+    pub fn get_y(&self) -> Length<T, U> {
         Length::new(self.y)
     }
 
     /// Returns self.z as a Length carrying the unit.
     #[inline]
-    pub fn z_typed(&self) -> Length<T, U> {
+    pub fn get_z(&self) -> Length<T, U> {
         Length::new(self.z)
     }
 
@@ -589,6 +597,14 @@ impl<T: Mul<T, Output = T> + Add<T, Output = T> + Sub<T, Output = T> + Copy, U>
         T: Float,
     {
         self.square_length().sqrt()
+    }
+
+    #[inline]
+    pub fn get_length(&self) -> Length<T, U>
+    where
+        T: Float,
+    {
+        Length::new(self.length())
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -38,7 +38,7 @@ impl<T: Copy + Zero, U> TypedVector2D<T, U> {
     /// Constructor, setting all components to zero.
     #[inline]
     pub fn zero() -> Self {
-        TypedVector2D::new(Zero::zero(), Zero::zero())
+        TypedVector2D::new(T::zero(), T::zero())
     }
 
     /// Convert into a 3d vector.
@@ -61,28 +61,24 @@ impl<T: fmt::Display, U> fmt::Display for TypedVector2D<T, U> {
 }
 
 impl<T, U> TypedVector2D<T, U> {
-    /// Constructor taking scalar values directly.
+    /// Constructor taking scalar values or `Length`.
     #[inline]
-    pub fn new(x: T, y: T) -> Self {
+    pub fn new<N>(x: N, y: N) -> Self
+    where N: ValueOrLength<T, U> {
         TypedVector2D {
-            x: x,
-            y: y,
+            x: x.value(),
+            y: y.value(),
             _unit: PhantomData,
         }
     }
 }
 
 impl<T: Copy, U> TypedVector2D<T, U> {
-    /// Constructor taking properly typed Lengths instead of scalar values.
-    #[inline]
-    pub fn from_lengths(x: Length<T, U>, y: Length<T, U>) -> Self {
-        vec2(x.0, y.0)
-    }
-
     /// Create a 3d vector from this one, using the specified z value.
     #[inline]
-    pub fn extend(&self, z: T) -> TypedVector3D<T, U> {
-        vec3(self.x, self.y, z)
+    pub fn extend<N>(&self, z: N) -> TypedVector3D<T, U>
+    where N: ValueOrLength<T, U> {
+        vec3(self.x, self.y, z.value())
     }
 
     /// Cast this vector into a point.
@@ -344,7 +340,7 @@ impl<T: NumCast + Copy, U> TypedVector2D<T, U> {
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
     #[inline]
     pub fn cast<NewT: NumCast + Copy>(&self) -> Option<TypedVector2D<NewT, U>> {
-        match (NumCast::from(self.x), NumCast::from(self.y)) {
+        match (NewT::from(self.x), NewT::from(self.y)) {
             (Some(x), Some(y)) => Some(TypedVector2D::new(x, y)),
             _ => None,
         }
@@ -473,25 +469,20 @@ impl<T: fmt::Display, U> fmt::Display for TypedVector3D<T, U> {
 }
 
 impl<T, U> TypedVector3D<T, U> {
-    /// Constructor taking scalar values directly.
+    /// Constructor taking scalar values or `Length`.
     #[inline]
-    pub fn new(x: T, y: T, z: T) -> Self {
+    pub fn new<N>(x: N, y: N, z: N) -> Self
+    where N: ValueOrLength<T, U> {
         TypedVector3D {
-            x: x,
-            y: y,
-            z: z,
+            x: x.value(),
+            y: y.value(),
+            z: z.value(),
             _unit: PhantomData,
         }
     }
 }
 
 impl<T: Copy, U> TypedVector3D<T, U> {
-    /// Constructor taking properly typed Lengths instead of scalar values.
-    #[inline]
-    pub fn from_lengths(x: Length<T, U>, y: Length<T, U>, z: Length<T, U>) -> TypedVector3D<T, U> {
-        vec3(x.0, y.0, z.0)
-    }
-
     /// Cast this vector into a point.
     ///
     /// Equivalent to adding this vector to the origin.


### PR DESCRIPTION
This PR renames all `foo_typed` into `get_foo` which I find to be nicer, and Introduces the `ValueOrLength` trait which makes it possible to for functions to take either lengths or scalar values directly. Here is the example from the doc:

```rust
use euclid::{Length, TypedVector2D};
struct WorldSpace;
struct ScreenSpace;
type WorldVec2 = TypedVector2D<f32, WorldSpace>;
type WorldLength = Length<f32, WorldSpace>;
type ScreenLength = Length<f32, ScreenSpace>;
// Convenient synatx:
let v1 = WorldVec2::new(1.0, 2.0);
// Statically checked synatx:
let v2 = WorldVec2::new(WorldLength::new(1.0), WorldLength::new(2.0));
// This would give a compile time error because units do not match:
// let not_good = WorldVec2::new(ScreenLength:new(1.0), ScreenLength::new(2.0));
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/271)
<!-- Reviewable:end -->
