### PR TITLE
Update TypedTransform2D docs

### DIFF
--- a/src/transform2d.rs
+++ b/src/transform2d.rs
@@ -21,7 +21,7 @@ use std::fmt;
 use num_traits::NumCast;
 
 define_matrix! {
-    /// A 2d transform stored as a 2 by 3 matrix in row-major order in memory.
+    /// A 2d transform stored as a 3 by 2 matrix in row-major order in memory.
     ///
     /// Transforms can be parametrized over the source and destination units, to describe a
     /// transformation from a space to another.


### PR DESCRIPTION
I think matrix dimensions are typically talked about as <num_row> by <num_col> instead of the opposite <num_col> by <num_row>.

https://en.wikipedia.org/wiki/Matrix_(mathematics)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/272)
<!-- Reviewable:end -->
