### PR TITLE
Add BoolVector2D/3D.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ pub use transform2d::{Transform2D, TypedTransform2D};
 pub use transform3d::{Transform3D, TypedTransform3D};
 pub use point::{Point2D, Point3D, TypedPoint2D, TypedPoint3D, point2, point3};
 pub use vector::{TypedVector2D, TypedVector3D, Vector2D, Vector3D, vec2, vec3};
+pub use vector::{BoolVector2D, BoolVector3D, bvec2, bvec3};
 pub use homogen::HomogeneousVector;
 
 pub use rect::{rect, Rect, TypedRect};

--- a/src/size.rs
+++ b/src/size.rs
@@ -10,7 +10,7 @@
 use super::UnknownUnit;
 use length::Length;
 use scale::TypedScale;
-use vector::{TypedVector2D, vec2};
+use vector::{TypedVector2D, vec2, BoolVector2D};
 use num::*;
 
 use num_traits::{NumCast, Signed};
@@ -282,6 +282,39 @@ where
 
     pub fn is_positive(&self) -> bool {
         self.width.is_positive() && self.height.is_positive()
+    }
+}
+
+impl<T: PartialOrd, U> TypedSize2D<T, U> {
+    pub fn greater_than(&self, other: &Self) -> BoolVector2D {
+        BoolVector2D {
+            x: self.width > other.width,
+            y: self.height > other.height,
+        }
+    }
+
+    pub fn lower_than(&self, other: &Self) -> BoolVector2D {
+        BoolVector2D {
+            x: self.width < other.width,
+            y: self.height < other.height,
+        }
+    }
+}
+
+
+impl<T: PartialEq, U> TypedSize2D<T, U> {
+    pub fn equal(&self, other: &Self) -> BoolVector2D {
+        BoolVector2D {
+            x: self.width == other.width,
+            y: self.height == other.height,
+        }
+    }
+
+    pub fn not_equal(&self, other: &Self) -> BoolVector2D {
+        BoolVector2D {
+            x: self.width != other.width,
+            y: self.height != other.height,
+        }
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -869,6 +869,241 @@ where
     }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct BoolVector2D {
+    pub x: bool,
+    pub y: bool,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct BoolVector3D {
+    pub x: bool,
+    pub y: bool,
+    pub z: bool,
+}
+
+impl BoolVector2D {
+    #[inline]
+    pub fn all(&self) -> bool {
+        self.x && self.y
+    }
+
+    #[inline]
+    pub fn any(&self) -> bool {
+        self.x || self.y
+    }
+
+    #[inline]
+    pub fn none(&self) -> bool {
+        !self.any()
+    }
+
+    #[inline]
+    pub fn and(&self, other: Self) -> Self {
+        BoolVector2D {
+            x: self.x && other.x,
+            y: self.y && other.y,
+        }
+    }
+
+    #[inline]
+    pub fn or(&self, other: Self) -> Self {
+        BoolVector2D {
+            x: self.x || other.x,
+            y: self.y || other.y,
+        }
+    }
+
+    #[inline]
+    pub fn not(&self) -> Self {
+        BoolVector2D {
+            x: !self.x,
+            y: !self.y,
+        }
+    }
+
+    #[inline]
+    pub fn select_point<T: Copy, U>(&self, a: &TypedPoint2D<T, U>, b: &TypedPoint2D<T, U>) -> TypedPoint2D<T, U> {
+        point2(
+            if self.x { a.x } else { b.x },
+            if self.y { a.y } else { b.y },
+        )
+    }
+
+    #[inline]
+    pub fn select_vector<T: Copy, U>(&self, a: &TypedVector2D<T, U>, b: &TypedVector2D<T, U>) -> TypedVector2D<T, U> {
+        vec2(
+            if self.x { a.x } else { b.x },
+            if self.y { a.y } else { b.y },
+        )
+    }
+
+    #[inline]
+    pub fn select_size<T: Copy, U>(&self, a: &TypedSize2D<T, U>, b: &TypedSize2D<T, U>) -> TypedSize2D<T, U> {
+        size2(
+            if self.x { a.width } else { b.width },
+            if self.y { a.height } else { b.height },
+        )
+    }
+}
+
+impl BoolVector3D {
+    #[inline]
+    pub fn all(&self) -> bool {
+        self.x && self.y && self.z
+    }
+
+    #[inline]
+    pub fn any(&self) -> bool {
+        self.x || self.y || self.z
+    }
+
+    #[inline]
+    pub fn none(&self) -> bool {
+        !self.any()
+    }
+
+    #[inline]
+    pub fn and(&self, other: Self) -> Self {
+        BoolVector3D {
+            x: self.x && other.x,
+            y: self.y && other.y,
+            z: self.z && other.z,
+        }
+    }
+
+    #[inline]
+    pub fn or(&self, other: Self) -> Self {
+        BoolVector3D {
+            x: self.x || other.x,
+            y: self.y || other.y,
+            z: self.z || other.z,
+        }
+    }
+
+    #[inline]
+    pub fn not(&self) -> Self {
+        BoolVector3D {
+            x: !self.x,
+            y: !self.y,
+            z: !self.z,
+        }
+    }
+
+
+    #[inline]
+    pub fn select_point<T: Copy, U>(&self, a: &TypedPoint3D<T, U>, b: &TypedPoint3D<T, U>) -> TypedPoint3D<T, U> {
+        point3(
+            if self.x { a.x } else { b.x },
+            if self.y { a.y } else { b.y },
+            if self.z { a.z } else { b.z },
+        )
+    }
+
+    #[inline]
+    pub fn select_vector<T: Copy, U>(&self, a: &TypedVector3D<T, U>, b: &TypedVector3D<T, U>) -> TypedVector3D<T, U> {
+        vec3(
+            if self.x { a.x } else { b.x },
+            if self.y { a.y } else { b.y },
+            if self.z { a.z } else { b.z },
+        )
+    }
+
+    #[inline]
+    pub fn xy(&self) -> BoolVector2D {
+        BoolVector2D {
+            x: self.x,
+            y: self.y,
+        }
+    }
+
+    #[inline]
+    pub fn xz(&self) -> BoolVector2D {
+        BoolVector2D {
+            x: self.x,
+            y: self.z,
+        }
+    }
+
+    #[inline]
+    pub fn yz(&self) -> BoolVector2D {
+        BoolVector2D {
+            x: self.y,
+            y: self.z,
+        }
+    }
+}
+
+impl<T: PartialOrd, U> TypedVector2D<T, U> {
+    pub fn greater_than(&self, other: &Self) -> BoolVector2D {
+        BoolVector2D {
+            x: self.x > other.x,
+            y: self.y > other.y,
+        }
+    }
+
+    pub fn lower_than(&self, other: &Self) -> BoolVector2D {
+        BoolVector2D {
+            x: self.x < other.x,
+            y: self.y < other.y,
+        }
+    }
+}
+
+
+impl<T: PartialEq, U> TypedVector2D<T, U> {
+    pub fn equal(&self, other: &Self) -> BoolVector2D {
+        BoolVector2D {
+            x: self.x == other.x,
+            y: self.y == other.y,
+        }
+    }
+
+    pub fn not_equal(&self, other: &Self) -> BoolVector2D {
+        BoolVector2D {
+            x: self.x != other.x,
+            y: self.y != other.y,
+        }
+    }
+}
+
+impl<T: PartialOrd, U> TypedVector3D<T, U> {
+    pub fn greater_than(&self, other: &Self) -> BoolVector3D {
+        BoolVector3D {
+            x: self.x > other.x,
+            y: self.y > other.y,
+            z: self.z > other.z,
+        }
+    }
+
+    pub fn lower_than(&self, other: &Self) -> BoolVector3D {
+        BoolVector3D {
+            x: self.x < other.x,
+            y: self.y < other.y,
+            z: self.z < other.z,
+        }
+    }
+}
+
+
+impl<T: PartialEq, U> TypedVector3D<T, U> {
+    pub fn equal(&self, other: &Self) -> BoolVector3D {
+        BoolVector3D {
+            x: self.x == other.x,
+            y: self.y == other.y,
+            z: self.z == other.z,
+        }
+    }
+
+    pub fn not_equal(&self, other: &Self) -> BoolVector3D {
+        BoolVector3D {
+            x: self.x != other.x,
+            y: self.y != other.y,
+            z: self.z != other.z,
+        }
+    }
+}
+
 /// Convenience constructor.
 #[inline]
 pub fn vec2<T, U>(x: T, y: T) -> TypedVector2D<T, U> {
@@ -880,6 +1115,17 @@ pub fn vec2<T, U>(x: T, y: T) -> TypedVector2D<T, U> {
 pub fn vec3<T, U>(x: T, y: T, z: T) -> TypedVector3D<T, U> {
     TypedVector3D::new(x, y, z)
 }
+
+#[inline]
+pub fn bvec2(x: bool, y: bool) -> BoolVector2D {
+    BoolVector2D { x, y }
+}
+
+#[inline]
+pub fn bvec3(x: bool, y: bool, z: bool) -> BoolVector3D {
+    BoolVector3D { x, y, z }
+}
+
 
 #[cfg(test)]
 mod vector2d {
@@ -1075,4 +1321,97 @@ mod vector3d {
         assert_eq!(p.xz(), vec2(1, 3));
         assert_eq!(p.yz(), vec2(2, 3));
     }
+}
+
+mod bool_vector {
+    use super::*;
+    type Vec2 = Vector2D<f32>;
+    type Vec3 = Vector3D<f32>;
+
+    #[test]
+    fn test_bvec2() {
+
+        assert_eq!(
+            Vec2::new(1.0, 2.0).greater_than(&Vec2::new(2.0, 1.0)),
+            bvec2(false, true),
+        );
+
+        assert_eq!(
+            Vec2::new(1.0, 2.0).lower_than(&Vec2::new(2.0, 1.0)),
+            bvec2(true, false),
+        );
+
+        assert_eq!(
+            Vec2::new(1.0, 2.0).equal(&Vec2::new(1.0, 3.0)),
+            bvec2(true, false),
+        );
+
+        assert_eq!(
+            Vec2::new(1.0, 2.0).not_equal(&Vec2::new(1.0, 3.0)),
+            bvec2(false, true),
+        );
+
+        assert!(bvec2(true, true).any());
+        assert!(bvec2(false, true).any());
+        assert!(bvec2(true, false).any());
+        assert!(!bvec2(false, false).any());
+        assert!(bvec2(false, false).none());
+        assert!(bvec2(true, true).all());
+        assert!(!bvec2(false, true).all());
+        assert!(!bvec2(true, false).all());
+        assert!(!bvec2(false, false).all());
+
+        assert_eq!(bvec2(true, false).not(), bvec2(false, true));
+        assert_eq!(bvec2(true, false).and(bvec2(true, true)), bvec2(true, false));
+        assert_eq!(bvec2(true, false).or(bvec2(true, true)), bvec2(true, true));
+
+        assert_eq!(
+            bvec2(true, false).select_vector(&Vec2::new(1.0, 2.0), &Vec2::new(3.0, 4.0)),
+            Vec2::new(1.0, 4.0),
+        );
+    }
+
+    #[test]
+    fn test_bvec3() {
+
+        assert_eq!(
+            Vec3::new(1.0, 2.0, 3.0).greater_than(&Vec3::new(3.0, 2.0, 1.0)),
+            bvec3(false, false, true),
+        );
+
+        assert_eq!(
+            Vec3::new(1.0, 2.0, 3.0).lower_than(&Vec3::new(3.0, 2.0, 1.0)),
+            bvec3(true, false, false),
+        );
+
+        assert_eq!(
+            Vec3::new(1.0, 2.0, 3.0).equal(&Vec3::new(3.0, 2.0, 1.0)),
+            bvec3(false, true, false),
+        );
+
+        assert_eq!(
+            Vec3::new(1.0, 2.0, 3.0).not_equal(&Vec3::new(3.0, 2.0, 1.0)),
+            bvec3(true, false, true),
+        );
+
+        assert!(bvec3(true, true, false).any());
+        assert!(bvec3(false, true, false).any());
+        assert!(bvec3(true, false, false).any());
+        assert!(!bvec3(false, false, false).any());
+        assert!(bvec3(false, false, false).none());
+        assert!(bvec3(true, true, true).all());
+        assert!(!bvec3(false, true, false).all());
+        assert!(!bvec3(true, false, false).all());
+        assert!(!bvec3(false, false, false).all());
+
+        assert_eq!(bvec3(true, false, true).not(), bvec3(false, true, false));
+        assert_eq!(bvec3(true, false, true).and(bvec3(true, true, false)), bvec3(true, false, false));
+        assert_eq!(bvec3(true, false, false).or(bvec3(true, true, false)), bvec3(true, true, false));
+
+        assert_eq!(
+            bvec3(true, false, true).select_vector(&Vec3::new(1.0, 2.0, 3.0), &Vec3::new(4.0, 5.0, 6.0)),
+            Vec3::new(1.0, 5.0, 3.0),
+        );
+    }
+
 }


### PR DESCRIPTION
This is something I have been missing for a while, not enough to go ahead and make the PR until now, but I think it is a nice addition.

This adds boolean vectors similar to what you can see in glsl and let you rewrite things like:

```rust
if some_vec3.x > another_vec3.x ||
  some_vec3.y > another_vec3.y ||
  some_vec3.z > another_vec3.z) {
  // do the thing!
}
```

into:

```rust
if some_vec3.greater_than(&another_vec3).any() {
  // do the thing!
}
```

We don't get to use the `>` operator because rust wants it to return a boolean, but I think it already makes things quite a bit nicer as is.
This PR doesn't implement all of the various candies we can think of for vector boolean ops, nor does it implement BoolVector4D but they can be added as followups if we need/want them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/287)
<!-- Reviewable:end -->
