### PR TITLE
Allow euclid to be built in no_std environments

### DIFF
--- a/src/homogen.rs
+++ b/src/homogen.rs
@@ -12,9 +12,9 @@ use vector::{TypedVector2D, TypedVector3D};
 
 use num::{One, Zero};
 
-use std::fmt;
-use std::marker::PhantomData;
-use std::ops::Div;
+use core::fmt;
+use core::marker::PhantomData;
+use core::ops::Div;
 
 
 define_matrix! {

--- a/src/length.rs
+++ b/src/length.rs
@@ -15,11 +15,11 @@ use num_traits::{NumCast, Saturating};
 use num::One;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::cmp::Ordering;
-use std::ops::{Add, Div, Mul, Neg, Sub};
-use std::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
-use std::marker::PhantomData;
-use std::fmt;
+use core::cmp::Ordering;
+use core::ops::{Add, Div, Mul, Neg, Sub};
+use core::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
+use core::marker::PhantomData;
+use core::fmt;
 
 /// A one-dimensional distance, with value represented by `T` and unit of measurement `Unit`.
 ///
@@ -263,7 +263,7 @@ mod tests {
 
     use num_traits::Saturating;
     use scale::TypedScale;
-    use std::f32::INFINITY;
+    use core::f32::INFINITY;
 
     enum Inch {}
     enum Mm {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 // except according to those terms.
 
 #![cfg_attr(feature = "unstable", feature(fn_must_use))]
+#![cfg_attr(not(test), no_std)]
 
 //! A collection of strongly typed math tools for computer graphics with an inclination
 //! towards 2d graphics and layout.
@@ -62,6 +63,9 @@ extern crate serde;
 extern crate num_traits;
 #[cfg(test)]
 extern crate rand;
+
+#[cfg(test)]
+use std as core;
 
 pub use length::Length;
 pub use scale::TypedScale;
@@ -123,4 +127,3 @@ pub type ScaleFactor<T, Src, Dst> = TypedScale<T, Src, Dst>;
 /// Temporary alias to facilitate the transition to the new naming scheme
 #[deprecated]
 pub use Angle as Radians;
-

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -59,21 +59,21 @@ macro_rules! define_matrix {
             }
         }
 
-        impl<T, $($phantom),+> ::std::cmp::Eq for $name<T, $($phantom),+>
-            where T: ::std::cmp::Eq {}
+        impl<T, $($phantom),+> ::core::cmp::Eq for $name<T, $($phantom),+>
+            where T: ::core::cmp::Eq {}
 
-        impl<T, $($phantom),+> ::std::cmp::PartialEq for $name<T, $($phantom),+>
-            where T: ::std::cmp::PartialEq
+        impl<T, $($phantom),+> ::core::cmp::PartialEq for $name<T, $($phantom),+>
+            where T: ::core::cmp::PartialEq
         {
             fn eq(&self, other: &Self) -> bool {
                 true $(&& self.$field == other.$field)+
             }
         }
 
-        impl<T, $($phantom),+> ::std::hash::Hash for $name<T, $($phantom),+>
-            where T: ::std::hash::Hash
+        impl<T, $($phantom),+> ::core::hash::Hash for $name<T, $($phantom),+>
+            where T: ::core::hash::Hash
         {
-            fn hash<H: ::std::hash::Hasher>(&self, h: &mut H) {
+            fn hash<H: ::core::hash::Hasher>(&self, h: &mut H) {
                 $(self.$field.hash(h);)+
             }
         }

--- a/src/point.rs
+++ b/src/point.rs
@@ -15,9 +15,9 @@ use size::TypedSize2D;
 use num::*;
 use num_traits::{Float, NumCast};
 use vector::{TypedVector2D, TypedVector3D, vec2, vec3};
-use std::fmt;
-use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
-use std::marker::PhantomData;
+use core::fmt;
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
+use core::marker::PhantomData;
 
 define_matrix! {
     /// A 2d Point tagged with a unit.

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -20,11 +20,11 @@ use num_traits::NumCast;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use std::borrow::Borrow;
-use std::cmp::PartialOrd;
-use std::fmt;
-use std::hash::{Hash, Hasher};
-use std::ops::{Add, Div, Mul, Sub};
+use core::borrow::Borrow;
+use core::cmp::PartialOrd;
+use core::fmt;
+use core::hash::{Hash, Hasher};
+use core::ops::{Add, Div, Mul, Sub};
 
 
 /// A 2d Rectangle optionally tagged with a unit.

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -9,9 +9,9 @@
 
 use approxeq::ApproxEq;
 use num_traits::{Float, FloatConst, One, Zero};
-use std::fmt;
-use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, Sub, SubAssign};
-use std::marker::PhantomData;
+use core::fmt;
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, Sub, SubAssign};
+use core::marker::PhantomData;
 use trig::Trig;
 use {TypedPoint2D, TypedPoint3D, TypedVector2D, TypedVector3D, Vector3D, point2, point3, vec3};
 use {TypedTransform2D, TypedTransform3D, UnknownUnit};
@@ -740,7 +740,7 @@ where
 
 #[test]
 fn simple_rotation_2d() {
-    use std::f32::consts::{FRAC_PI_2, PI};
+    use core::f32::consts::{FRAC_PI_2, PI};
     let ri = Rotation2D::identity();
     let r90 = Rotation2D::radians(FRAC_PI_2);
     let rm90 = Rotation2D::radians(-FRAC_PI_2);
@@ -773,7 +773,7 @@ fn simple_rotation_2d() {
 
 #[test]
 fn simple_rotation_3d_in_2d() {
-    use std::f32::consts::{FRAC_PI_2, PI};
+    use core::f32::consts::{FRAC_PI_2, PI};
     let ri = Rotation3D::identity();
     let r90 = Rotation3D::around_z(Angle::radians(FRAC_PI_2));
     let rm90 = Rotation3D::around_z(Angle::radians(-FRAC_PI_2));
@@ -806,7 +806,7 @@ fn simple_rotation_3d_in_2d() {
 
 #[test]
 fn pre_post() {
-    use std::f32::consts::FRAC_PI_2;
+    use core::f32::consts::FRAC_PI_2;
     let r1 = Rotation3D::around_x(Angle::radians(FRAC_PI_2));
     let r2 = Rotation3D::around_y(Angle::radians(FRAC_PI_2));
     let r3 = Rotation3D::around_z(Angle::radians(FRAC_PI_2));
@@ -831,7 +831,7 @@ fn pre_post() {
 
 #[test]
 fn to_transform3d() {
-    use std::f32::consts::{FRAC_PI_2, PI};
+    use core::f32::consts::{FRAC_PI_2, PI};
     let rotations = [
         Rotation3D::identity(),
         Rotation3D::around_x(Angle::radians(FRAC_PI_2)),
@@ -931,7 +931,7 @@ fn slerp() {
 
 #[test]
 fn around_axis() {
-    use std::f32::consts::{FRAC_PI_2, PI};
+    use core::f32::consts::{FRAC_PI_2, PI};
 
     // Two sort of trivial cases:
     let r1 = Rotation3D::around_axis(vec3(1.0, 1.0, 0.0), Angle::radians(PI));
@@ -956,7 +956,7 @@ fn around_axis() {
 
 #[test]
 fn from_euler() {
-    use std::f32::consts::FRAC_PI_2;
+    use core::f32::consts::FRAC_PI_2;
 
     // First test simple separate yaw pitch and roll rotations, because it is easy to come
     // up with the corresponding quaternion.
@@ -1001,7 +1001,7 @@ fn from_euler() {
 
 #[test]
 fn wrap_angles() {
-    use std::f32::consts::{FRAC_PI_2, PI};
+    use core::f32::consts::{FRAC_PI_2, PI};
     assert!(Angle::radians(0.0).positive().radians.approx_eq(&0.0));
     assert!(
         Angle::radians(FRAC_PI_2)

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -13,9 +13,9 @@ use num::One;
 use num_traits::NumCast;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::fmt;
-use std::ops::{Add, Div, Mul, Neg, Sub};
-use std::marker::PhantomData;
+use core::fmt;
+use core::ops::{Add, Div, Mul, Neg, Sub};
+use core::marker::PhantomData;
 use {TypedPoint2D, TypedRect, TypedSize2D, TypedVector2D};
 
 /// A scaling factor between two different units of measurement.

--- a/src/side_offsets.rs
+++ b/src/side_offsets.rs
@@ -13,9 +13,9 @@
 use super::UnknownUnit;
 use length::Length;
 use num::Zero;
-use std::fmt;
-use std::ops::Add;
-use std::marker::PhantomData;
+use core::fmt;
+use core::ops::Add;
+use core::marker::PhantomData;
 
 /// A group of side offsets, which correspond to top/left/bottom/right for borders, padding,
 /// and margins in CSS, optionally tagged with a unit.

--- a/src/size.rs
+++ b/src/size.rs
@@ -14,9 +14,9 @@ use vector::{TypedVector2D, vec2, BoolVector2D};
 use num::*;
 
 use num_traits::{NumCast, Signed};
-use std::fmt;
-use std::ops::{Add, Div, Mul, Sub};
-use std::marker::PhantomData;
+use core::fmt;
+use core::ops::{Add, Div, Mul, Sub};
+use core::marker::PhantomData;
 
 /// A 2d size tagged with a unit.
 define_matrix! {

--- a/src/transform2d.rs
+++ b/src/transform2d.rs
@@ -13,11 +13,11 @@ use point::TypedPoint2D;
 use vector::{TypedVector2D, vec2};
 use rect::TypedRect;
 use transform3d::TypedTransform3D;
-use std::ops::{Add, Mul, Div, Sub, Neg};
-use std::marker::PhantomData;
+use core::ops::{Add, Mul, Div, Sub, Neg};
+use core::marker::PhantomData;
 use approxeq::ApproxEq;
 use trig::Trig;
-use std::fmt;
+use core::fmt;
 use num_traits::NumCast;
 
 define_matrix! {
@@ -347,7 +347,7 @@ where T: Copy + Clone +
             self.m21, self.m22,
             self.m31, self.m32,
         )
-    }   
+    }
 }
 
 impl <T, Src, Dst> TypedTransform2D<T, Src, Dst>
@@ -395,7 +395,7 @@ mod test {
     use point::Point2D;
     use Angle;
 
-    use std::f32::consts::FRAC_PI_2;
+    use core::f32::consts::FRAC_PI_2;
 
     type Mat = Transform2D<f32>;
 
@@ -502,7 +502,7 @@ mod test {
 
     #[test]
     fn test_size_of() {
-        use std::mem::size_of;
+        use core::mem::size_of;
         assert_eq!(size_of::<Transform2D<f32>>(), 6*size_of::<f32>());
         assert_eq!(size_of::<Transform2D<f64>>(), 6*size_of::<f64>());
     }

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -17,9 +17,9 @@ use rect::TypedRect;
 use transform2d::TypedTransform2D;
 use scale::TypedScale;
 use num::{One, Zero};
-use std::ops::{Add, Mul, Sub, Div, Neg};
-use std::marker::PhantomData;
-use std::fmt;
+use core::ops::{Add, Mul, Sub, Div, Neg};
+use core::marker::PhantomData;
+use core::fmt;
 use num_traits::NumCast;
 
 define_matrix! {
@@ -727,7 +727,7 @@ mod tests {
     use Angle;
     use super::*;
 
-    use std::f32::consts::{FRAC_PI_2, PI};
+    use core::f32::consts::{FRAC_PI_2, PI};
 
     type Mf32 = Transform3D<f32>;
 
@@ -906,7 +906,7 @@ mod tests {
 
     #[test]
     fn test_size_of() {
-        use std::mem::size_of;
+        use core::mem::size_of;
         assert_eq!(size_of::<Transform3D<f32>>(), 16*size_of::<f32>());
         assert_eq!(size_of::<Transform3D<f64>>(), 16*size_of::<f64>());
     }

--- a/src/trig.rs
+++ b/src/trig.rs
@@ -33,7 +33,7 @@ macro_rules! trig {
             #[inline]
             fn fast_atan2(y: $ty, x: $ty) -> $ty {
                 // See https://math.stackexchange.com/questions/1098487/atan2-faster-approximation#1105038
-                use std::$ty::consts;
+                use core::$ty::consts;
                 let x_abs = x.abs();
                 let y_abs = y.abs();
                 let a = x_abs.min(y_abs) / x_abs.max(y_abs);

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -17,9 +17,9 @@ use trig::Trig;
 use Angle;
 use num::*;
 use num_traits::{Float, NumCast, Signed};
-use std::fmt;
-use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
-use std::marker::PhantomData;
+use core::fmt;
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use core::marker::PhantomData;
 
 define_matrix! {
     /// A 2d Vector tagged with a unit.
@@ -1188,7 +1188,7 @@ mod vector2d {
 
     #[test]
     pub fn test_angle_from_x_axis() {
-        use std::f32::consts::FRAC_PI_2;
+        use core::f32::consts::FRAC_PI_2;
         use approxeq::ApproxEq;
 
         let right: Vec2 = vec2(10.0, 0.0);


### PR DESCRIPTION
(blocked on #279, since only `num-traits` > 0.2 is `no_std` compatible)

Since this crate does not use any `std`-specific features, this pull request makes it `no_std`.

The tests are still built and run using `std`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/289)
<!-- Reviewable:end -->
