### PR TITLE
Make the unit a hidden public member instead of private.

### DIFF
--- a/src/length.rs
+++ b/src/length.rs
@@ -35,7 +35,7 @@ use core::fmt;
 ///
 /// [`TypedScale`]: struct.TypedScale.html
 #[repr(C)]
-pub struct Length<T, Unit>(pub T, PhantomData<Unit>);
+pub struct Length<T, Unit>(pub T, #[doc(hidden)] pub PhantomData<Unit>);
 
 impl<T: Clone, Unit> Clone for Length<T, Unit> {
     fn clone(&self) -> Self {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -18,7 +18,12 @@ macro_rules! define_matrix {
         $(#[$attr])*
         pub struct $name<T, $($phantom),+> {
             $(pub $field: T,)+
-            _unit: PhantomData<($($phantom),+)>
+
+            // Keep this (secretly) public for the few cases where we would like to
+            // create static constants which currently can't be initialized with a
+            // function.
+            #[doc(hidden)]
+            pub _unit: PhantomData<($($phantom),+)>
         }
 
         impl<T: Clone, $($phantom),+> Clone for $name<T, $($phantom),+> {

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -38,7 +38,7 @@ use {TypedPoint2D, TypedRect, TypedSize2D, TypedVector2D};
 /// let one_foot_in_mm: Length<f32, Mm> = one_foot * mm_per_inch;
 /// ```
 #[repr(C)]
-pub struct TypedScale<T, Src, Dst>(pub T, PhantomData<(Src, Dst)>);
+pub struct TypedScale<T, Src, Dst>(pub T, #[doc(hidden)] pub PhantomData<(Src, Dst)>);
 
 #[cfg(feature = "serde")]
 impl<'de, T, Src, Dst> Deserialize<'de> for TypedScale<T, Src, Dst>


### PR DESCRIPTION
This is a work-around for the current limitation of not being able to declare static constants from euclid types. There are some RFCs aiming at removing the need to specify phantom types when initializing structs, and we'll eventually be able to evaluate simple functions at compile time, but in the mean time this is the only way to get static constants for euclid types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/296)
<!-- Reviewable:end -->
