### PR TITLE
Add 3D cuboid implementation

### DIFF
--- a/src/approxord.rs
+++ b/src/approxord.rs
@@ -1,0 +1,43 @@
+// Copyright 2013 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+/// Utilities for testing approximate ordering - especially true for 
+/// floating point types, where NaN's cannot be ordered. 
+pub fn min<T: Clone + PartialOrd>(x: T, y: T) -> T {
+    if x <= y {
+        x
+    } else {
+        y
+    }
+}
+
+pub fn max<T: Clone + PartialOrd>(x: T, y: T) -> T {
+    if x >= y {
+        x
+    } else {
+        y
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_min() {
+        assert!(min(0u32, 1u32) == 0u32);
+        assert!(min(-1.0f32, 0.0f32) == -1.0f32);
+    }
+
+    #[test]
+    fn test_max() {
+        assert!(max(0u32, 1u32) == 1u32);
+        assert!(max(-1.0f32, 0.0f32) == 0.0f32);
+    }
+}

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -1,0 +1,922 @@
+// Copyright 2013 The Servo Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use super::UnknownUnit;
+use length::Length;
+use scale::TypedScale;
+use num::*;
+use point::TypedPoint3D;
+use vector::TypedVector3D;
+use size::TypedSize3D;
+use approxord::{min, max};
+
+use num_traits::NumCast;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use core::borrow::Borrow;
+use core::cmp::PartialOrd;
+use core::fmt;
+use core::hash::{Hash, Hasher};
+use core::ops::{Add, Div, Mul, Sub};
+
+
+/// An axis aligned 3D box represented by its minimum and maximum coordinates.
+#[repr(C)]
+pub struct TypedBox3D<T, U = UnknownUnit> {
+    pub min: TypedPoint3D<T, U>, 
+    pub max: TypedPoint3D<T, U>,
+}
+
+/// The default box 3d type with no unit.
+pub type Box3D<T> = TypedBox3D<T, UnknownUnit>;
+
+#[cfg(feature = "serde")]
+impl<'de, T: Copy + Deserialize<'de>, U> Deserialize<'de> for TypedBox3D<T, U> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let (min, max) = try!(Deserialize::deserialize(deserializer));
+        Ok(TypedBox3D::new(min, max))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T: Serialize, U> Serialize for TypedBox3D<T, U> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        (&self.min, &self.max).serialize(serializer)
+    }
+}
+
+impl<T: Hash, U> Hash for TypedBox3D<T, U> {
+    fn hash<H: Hasher>(&self, h: &mut H) {
+        self.min.hash(h);
+        self.max.hash(h);
+    }
+}
+
+impl<T: Copy, U> Copy for TypedBox3D<T, U> {}
+
+impl<T: Copy, U> Clone for TypedBox3D<T, U> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T: PartialEq, U> PartialEq<TypedBox3D<T, U>> for TypedBox3D<T, U> {
+    fn eq(&self, other: &Self) -> bool {
+        self.min.eq(&other.min) && self.max.eq(&other.max)
+    }
+}
+
+impl<T: Eq, U> Eq for TypedBox3D<T, U> {}
+
+impl<T: fmt::Debug, U> fmt::Debug for TypedBox3D<T, U> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "TypedBox3D({:?}, {:?})", self.min, self.max)
+    }
+}
+
+impl<T: fmt::Display, U> fmt::Display for TypedBox3D<T, U> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "Box3D({}, {})", self.min, self.max)
+    }
+}
+
+impl<T, U> TypedBox3D<T, U> {
+    /// Constructor.
+    pub fn new(min: TypedPoint3D<T, U>, max: TypedPoint3D<T, U>) -> Self {
+        TypedBox3D {
+            min,
+            max,
+        }
+    }
+}
+
+impl<T, U> TypedBox3D<T, U>
+where
+    T: Copy + Zero + PartialOrd,
+{
+    /// Creates a Box3D of the given size, at offset zero.
+    #[inline]
+    pub fn from_size(size: TypedSize3D<T, U>) -> Self {
+        let zero = TypedPoint3D::zero();
+        let point = size.to_vector().to_point();
+        TypedBox3D::from_points(&[zero, point])
+    }
+}
+
+impl<T, U> TypedBox3D<T, U>
+where
+    T: Copy,
+{
+    #[inline]
+    pub fn max_x(&self) -> T {
+        self.max.x
+    }
+
+    #[inline]
+    pub fn min_x(&self) -> T {
+        self.min.x
+    }
+
+    #[inline]
+    pub fn max_y(&self) -> T {
+        self.max.y
+    }
+
+    #[inline]
+    pub fn min_y(&self) -> T {
+        self.min.y
+    }
+
+    #[inline]
+    pub fn max_z(&self) -> T {
+        self.max.z
+    }
+
+    #[inline]
+    pub fn min_z(&self) -> T {
+        self.min.z
+    }
+
+    #[inline]
+    pub fn max_x_typed(&self) -> Length<T, U> {
+        Length::new(self.max_x())
+    }
+
+    #[inline]
+    pub fn min_x_typed(&self) -> Length<T, U> {
+        Length::new(self.min_x())
+    }
+
+    #[inline]
+    pub fn max_y_typed(&self) -> Length<T, U> {
+        Length::new(self.max_y())
+    }
+
+    #[inline]
+    pub fn min_y_typed(&self) -> Length<T, U> {
+        Length::new(self.min_y())
+    }
+
+    #[inline]
+    pub fn max_z_typed(&self) -> Length<T, U> {
+        Length::new(self.max_z())
+    }
+
+    #[inline]
+    pub fn min_z_typed(&self) -> Length<T, U> {
+        Length::new(self.min_z())
+    }
+}
+
+impl<T, U> TypedBox3D<T, U>
+where
+    T: Copy + PartialOrd,
+{
+    #[inline]
+    pub fn intersects(&self, other: &Self) -> bool {
+        self.min_x() < other.max_x()
+            && self.max_x() > other.min_x()
+            && self.min_y() < other.max_y()
+            && self.max_y() > other.min_y()
+            && self.min_z() < other.max_z()
+            && self.max_z() > other.min_z()
+    }
+
+    #[inline]
+    pub fn try_intersection(&self, other: &Self) -> Option<Self> {
+        if !self.intersects(other) {
+            return None;
+        }
+
+        Some(self.intersection(other))
+    }
+
+    pub fn intersection(&self, other: &Self) -> Self {
+        let intersection_min = TypedPoint3D::new(
+            max(self.min_x(), other.min_x()),
+            max(self.min_y(), other.min_y()),
+            max(self.min_z(), other.min_z()),
+        );
+
+        let intersection_max = TypedPoint3D::new(
+            min(self.max_x(), other.max_x()),
+            min(self.max_y(), other.max_y()),
+            min(self.max_z(), other.max_z()),
+        );
+
+        TypedBox3D::new(
+            intersection_min, 
+            intersection_max,
+        )
+    }
+}
+
+impl<T, U> TypedBox3D<T, U>
+where
+    T: Copy + Add<T, Output = T>,
+{
+    /// Returns the same box3d, translated by a vector.
+    #[inline]
+    #[cfg_attr(feature = "unstable", must_use)]
+    pub fn translate(&self, by: &TypedVector3D<T, U>) -> Self {
+        Self::new(self.min + *by, self.max + *by)
+    }
+}
+
+impl<T, U> TypedBox3D<T, U>
+where
+    T: Copy + PartialOrd + Zero,
+{
+    /// Returns true if this box3d contains the point. Points are considered
+    /// in the box3d if they are on the front, left or top faces, but outside if they
+    /// are on the back, right or bottom faces.
+    #[inline]
+    pub fn contains(&self, other: &TypedPoint3D<T, U>) -> bool {
+        self.min_x() <= other.x && other.x < self.max_x()
+            && self.min_y() < other.y && other.y <= self.max_y()
+            && self.min_z() < other.z && other.z <= self.max_z()
+    }
+}
+
+impl<T, U> TypedBox3D<T, U>
+where
+    T: Copy + PartialOrd + Zero + Sub<T, Output = T>,
+{
+    /// Returns true if this box3d contains the interior of the other box3d. Always
+    /// returns true if other is empty, and always returns false if other is
+    /// nonempty but this box3d is empty.
+    #[inline]
+    pub fn contains_box(&self, other: &Self) -> bool {
+        other.is_empty()
+            || (self.min_x() <= other.min_x() && other.max_x() <= self.max_x()
+                && self.min_y() <= other.min_y() && other.max_y() <= self.max_y()
+                && self.min_z() <= other.min_z() && other.max_z() <= self.max_z())
+    }
+}
+
+impl<T, U> TypedBox3D<T, U>
+where
+    T: Copy + Sub<T, Output = T>,
+{
+    #[inline]
+    pub fn size(&self)-> TypedSize3D<T, U> {
+        TypedSize3D::new(
+            self.max_x() - self.min_x(),
+            self.max_y() - self.min_y(),
+            self.max_z() - self.min_z(),
+        )
+    }
+}
+
+impl<T, U> TypedBox3D<T, U>
+where
+    T: Copy + PartialEq + Add<T, Output = T> + Sub<T, Output = T>,
+{
+    /// Inflates the box by the specified sizes on each side respectively.
+    #[inline]
+    #[cfg_attr(feature = "unstable", must_use)]
+    pub fn inflate(&self, width: T, height: T, depth: T) -> Self {
+        TypedBox3D::new(
+            TypedPoint3D::new(self.min_x() - width, self.min_y() - height, self.min_z() - depth),
+            TypedPoint3D::new(self.max_x() + width, self.max_x() + height, self.max_z() + depth),
+        )
+    }
+
+    #[inline]
+    #[cfg_attr(feature = "unstable", must_use)]
+    pub fn inflate_typed(&self, width: Length<T, U>, height: Length<T, U>, depth: Length<T, U>) -> Self {
+        self.inflate(width.get(), height.get(), depth.get())
+    }
+}
+
+impl<T, U> TypedBox3D<T, U>
+where
+    T: Copy + Zero + PartialOrd,
+{
+    /// Returns the smallest box containing all of the provided points.
+    pub fn from_points<I>(points: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Borrow<TypedPoint3D<T, U>>,
+    {
+        let mut points = points.into_iter();
+
+        // Need at least 2 different points for a valid box3d (ie: volume > 0).
+        let (mut min_x, mut min_y, mut min_z) = match points.next() {
+            Some(first) => (first.borrow().x, first.borrow().y, first.borrow().z),
+            None => return TypedBox3D::zero(),
+        };
+        let (mut max_x, mut max_y, mut max_z) = (min_x, min_y, min_z);
+
+        {
+            let mut assign_min_max = |point: I::Item| {
+                let p = point.borrow();
+                if p.x < min_x {
+                    min_x = p.x
+                }
+                if p.x > max_x {
+                    max_x = p.x
+                }
+                if p.y < min_y {
+                    min_y = p.y
+                }
+                if p.y > max_y {
+                    max_y = p.y
+                }
+                if p.z < min_z {
+                    min_z = p.z
+                }
+                if p.z > max_z {
+                    max_z = p.z
+                }
+            };
+                    
+            match points.next() {
+                Some(second) => assign_min_max(second),
+                None => return TypedBox3D::zero(),
+            }
+
+            for point in points {
+                assign_min_max(point);
+            }
+        }
+
+        Self::new(TypedPoint3D::new(min_x, min_y, min_z), TypedPoint3D::new(max_x, max_y, max_z))
+    }
+}
+
+impl<T, U> TypedBox3D<T, U>
+where
+    T: Copy + One + Add<Output = T> + Sub<Output = T> + Mul<Output = T>,
+{
+    /// Linearly interpolate between this box3d and another box3d.
+    ///
+    /// `t` is expected to be between zero and one.
+    #[inline]
+    pub fn lerp(&self, other: Self, t: T) -> Self {
+        Self::new(
+            self.min.lerp(other.min, t),
+            self.max.lerp(other.max, t),
+        )
+    }
+}
+
+impl<T, U> TypedBox3D<T, U>
+where
+    T: Copy + One + Add<Output = T> + Div<Output = T>,
+{
+    pub fn center(&self) -> TypedPoint3D<T, U> {
+        let two = T::one() + T::one();
+        (self.min + self.max.to_vector()) / two
+    }
+}
+
+impl<T, U> TypedBox3D<T, U>
+where
+    T: Copy + Clone + PartialOrd + Add<T, Output = T> + Sub<T, Output = T> + Zero,
+{
+    #[inline]
+    pub fn union(&self, other: &Self) -> Self {
+        TypedBox3D::new(
+            TypedPoint3D::new(
+                min(self.min_x(), other.min_x()),
+                min(self.min_y(), other.min_y()),
+                min(self.min_z(), other.min_z()),
+            ),
+            TypedPoint3D::new(
+                max(self.max_x(), other.max_x()),
+                max(self.max_y(), other.max_y()),
+                max(self.max_z(), other.max_z()),
+            ),
+        )
+    }
+}
+
+impl<T, U> TypedBox3D<T, U>
+where
+    T: Copy,
+{
+    #[inline]
+    pub fn scale<S: Copy>(&self, x: S, y: S, z: S) -> Self
+    where
+        T: Mul<S, Output = T>
+    {
+        TypedBox3D::new(
+            TypedPoint3D::new(self.min.x * x, self.min.y * y, self.min.z * z),
+            TypedPoint3D::new(self.max.x * x, self.max.y * y, self.max.z * z),
+        )
+    }
+}
+
+impl<T, U> TypedBox3D<T, U>
+where
+    T: Copy + Mul<T, Output = T> + Sub<T, Output = T>,
+{
+    #[inline]
+    pub fn volume(&self) -> T {
+        let size = self.size();
+        size.width * size.height * size.depth
+    }
+
+    #[inline]
+    pub fn xy_area(&self) -> T {
+        let size = self.size();
+        size.width * size.height
+    }
+
+    #[inline]
+    pub fn yz_area(&self) -> T {
+        let size = self.size();
+        size.depth * size.height
+    }
+
+    #[inline]
+    pub fn xz_area(&self) -> T {
+        let size = self.size();
+        size.depth * size.width
+    }
+}
+
+impl<T, U> TypedBox3D<T, U> 
+where
+    T: Copy + Zero,
+{
+    /// Constructor, setting all sides to zero.
+    pub fn zero() -> Self {
+        TypedBox3D::new(TypedPoint3D::zero(), TypedPoint3D::zero())
+    }
+}
+
+impl<T, U> TypedBox3D<T, U> 
+where
+    T: Copy + PartialEq + Zero + Sub<T, Output = T>,
+{
+    /// Returns true if the size is zero, regardless of a or b's value.
+    pub fn is_empty(&self) -> bool {
+        let size = self.size();
+        size.width == Zero::zero() || size.height == Zero::zero() || size.depth == Zero::zero()
+    }
+}
+
+impl<T, U> Mul<T> for TypedBox3D<T, U> 
+where
+    T: Copy + Mul<T, Output = T>,
+{
+    type Output = Self;
+    #[inline]
+    fn mul(self, scale: T) -> Self {
+        TypedBox3D::new(self.min * scale, self.max * scale)
+    }
+}
+
+impl<T, U> Div<T> for TypedBox3D<T, U> 
+where
+    T: Copy + Div<T, Output = T>,
+{
+    type Output = Self;
+    #[inline]
+    fn div(self, scale: T) -> Self {
+        TypedBox3D::new(self.min / scale, self.max / scale)
+    }
+}
+
+impl<T, U1, U2> Mul<TypedScale<T, U1, U2>> for TypedBox3D<T, U1> 
+where
+    T: Copy + Mul<T, Output = T>,
+{
+    type Output = TypedBox3D<T, U2>;
+    #[inline]
+    fn mul(self, scale: TypedScale<T, U1, U2>) -> TypedBox3D<T, U2> {
+        TypedBox3D::new(self.min * scale, self.max * scale)
+    }
+}
+
+impl<T, U1, U2> Div<TypedScale<T, U1, U2>> for TypedBox3D<T, U2> 
+where
+    T: Copy + Div<T, Output = T>,
+{
+    type Output = TypedBox3D<T, U1>;
+    #[inline]
+    fn div(self, scale: TypedScale<T, U1, U2>) -> TypedBox3D<T, U1> {
+        TypedBox3D::new(self.min / scale, self.max / scale)
+    }
+}
+
+impl<T, Unit> TypedBox3D<T, Unit> 
+where
+    T: Copy,
+{
+    /// Drop the units, preserving only the numeric value.
+    pub fn to_untyped(&self) -> Box3D<T> {
+        TypedBox3D::new(self.min.to_untyped(), self.max.to_untyped())
+    }
+
+    /// Tag a unitless value with units.
+    pub fn from_untyped(c: &Box3D<T>) -> TypedBox3D<T, Unit> {
+        TypedBox3D::new(
+            TypedPoint3D::from_untyped(&c.min),
+            TypedPoint3D::from_untyped(&c.max),
+        )
+    }
+}
+
+impl<T0, Unit> TypedBox3D<T0, Unit> 
+where
+    T0: NumCast + Copy,
+{
+    /// Cast from one numeric representation to another, preserving the units.
+    ///
+    /// When casting from floating point to integer coordinates, the decimals are truncated
+    /// as one would expect from a simple cast, but this behavior does not always make sense
+    /// geometrically. Consider using round(), round_in or round_out() before casting.
+    pub fn cast<T1: NumCast + Copy>(&self) -> TypedBox3D<T1, Unit> {
+        TypedBox3D::new(
+            self.min.cast(),
+            self.max.cast(),
+        )
+    }
+
+    /// Fallible cast from one numeric representation to another, preserving the units.
+    ///
+    /// When casting from floating point to integer coordinates, the decimals are truncated
+    /// as one would expect from a simple cast, but this behavior does not always make sense
+    /// geometrically. Consider using round(), round_in or round_out() before casting.
+    pub fn try_cast<T1: NumCast + Copy>(&self) -> Option<TypedBox3D<T1, Unit>> {
+        match (self.min.try_cast(), self.max.try_cast()) {
+            (Some(a), Some(b)) => Some(TypedBox3D::new(a, b)),
+            _ => None,
+        }
+    }
+}
+
+impl<T, U> TypedBox3D<T, U> 
+where
+    T: Round,
+{
+    /// Return a box3d with edges rounded to integer coordinates, such that
+    /// the returned box3d has the same set of pixel centers as the original
+    /// one.
+    /// Values equal to 0.5 round up.
+    /// Suitable for most places where integral device coordinates
+    /// are needed, but note that any translation should be applied first to
+    /// avoid pixel rounding errors.
+    /// Note that this is *not* rounding to nearest integer if the values are negative.
+    /// They are always rounding as floor(n + 0.5).
+    #[cfg_attr(feature = "unstable", must_use)]
+    pub fn round(&self) -> Self {
+        TypedBox3D::new(self.min.round(), self.max.round())
+    }
+}
+
+impl<T, U> TypedBox3D<T, U> 
+where
+    T: Floor + Ceil,
+{
+    /// Return a box3d with faces/edges rounded to integer coordinates, such that
+    /// the original box3d contains the resulting box3d.
+    #[cfg_attr(feature = "unstable", must_use)]
+    pub fn round_in(&self) -> Self {
+        let min_x = self.min.x.ceil();
+        let min_y = self.min.y.ceil();
+        let min_z = self.min.z.ceil();
+        let max_x = self.max.x.floor();
+        let max_y = self.max.y.floor();
+        let max_z = self.max.z.floor();
+        TypedBox3D::new(
+            TypedPoint3D::new(min_x, min_y, min_z), 
+            TypedPoint3D::new(max_x, max_y, max_z),
+        )
+    }
+
+    /// Return a box3d with faces/edges rounded to integer coordinates, such that
+    /// the original box3d is contained in the resulting box3d.
+    #[cfg_attr(feature = "unstable", must_use)]
+    pub fn round_out(&self) -> Self {
+        let min_x = self.min.x.floor();
+        let min_y = self.min.y.floor();
+        let min_z = self.min.z.floor();
+        let max_x = self.max.x.ceil();
+        let max_y = self.max.y.ceil();
+        let max_z = self.max.z.ceil();
+        TypedBox3D::new(
+            TypedPoint3D::new(min_x, min_y, min_z), 
+            TypedPoint3D::new(max_x, max_y, max_z),
+        )
+    }
+}
+
+// Convenience functions for common casts
+impl<T: NumCast + Copy, Unit> TypedBox3D<T, Unit> {
+    /// Cast into an `f32` box3d.
+    pub fn to_f32(&self) -> TypedBox3D<f32, Unit> {
+        self.cast()
+    }
+
+    /// Cast into an `f64` box3d.
+    pub fn to_f64(&self) -> TypedBox3D<f64, Unit> {
+        self.cast()
+    }
+
+    /// Cast into an `usize` box3d, truncating decimals if any.
+    ///
+    /// When casting from floating point cuboids, it is worth considering whether
+    /// to `round()`, `round_in()` or `round_out()` before the cast in order to
+    /// obtain the desired conversion behavior.
+    pub fn to_usize(&self) -> TypedBox3D<usize, Unit> {
+        self.cast()
+    }
+
+    /// Cast into an `u32` box3d, truncating decimals if any.
+    ///
+    /// When casting from floating point cuboids, it is worth considering whether
+    /// to `round()`, `round_in()` or `round_out()` before the cast in order to
+    /// obtain the desired conversion behavior.
+    pub fn to_u32(&self) -> TypedBox3D<u32, Unit> {
+        self.cast()
+    }
+
+    /// Cast into an `i32` box3d, truncating decimals if any.
+    ///
+    /// When casting from floating point cuboids, it is worth considering whether
+    /// to `round()`, `round_in()` or `round_out()` before the cast in order to
+    /// obtain the desired conversion behavior.
+    pub fn to_i32(&self) -> TypedBox3D<i32, Unit> {
+        self.cast()
+    }
+
+    /// Cast into an `i64` box3d, truncating decimals if any.
+    ///
+    /// When casting from floating point cuboids, it is worth considering whether
+    /// to `round()`, `round_in()` or `round_out()` before the cast in order to
+    /// obtain the desired conversion behavior.
+    pub fn to_i64(&self) -> TypedBox3D<i64, Unit> {
+        self.cast()
+    }
+}
+
+impl<T, U> From<TypedSize3D<T, U>> for TypedBox3D<T, U>
+where 
+    T: Copy + Zero + PartialOrd,
+{
+    fn from(b: TypedSize3D<T, U>) -> Self {
+        Self::from_size(b)
+    }
+}
+
+/// Shorthand for `TypedBox3D::new(TypedPoint3D::new(x1, y1, z1), TypedPoint3D::new(x2, y2, z2))`.
+pub fn box3d<T: Copy, U>(min_x: T, min_y: T, min_z: T, max_x: T, max_y: T, max_z: T) -> TypedBox3D<T, U> {
+    TypedBox3D::new(TypedPoint3D::new(min_x, min_y, min_z), TypedPoint3D::new(max_x, max_y, max_z))
+}
+
+#[cfg(test)]
+mod tests {
+    use vector::vec3;
+    use size::size3;
+    use point::{point3, Point3D};
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let b = Box3D::new(point3(-1.0, -1.0, -1.0), point3(1.0, 1.0, 1.0));
+        assert!(b.min.x == -1.0);
+        assert!(b.min.y == -1.0);
+        assert!(b.min.z == -1.0);
+        assert!(b.max.x == 1.0);
+        assert!(b.max.y == 1.0);
+        assert!(b.max.z == 1.0);
+    }
+
+    #[test]
+    fn test_size() {
+        let b = Box3D::new(point3(-10.0, -10.0, -10.0), point3(10.0, 10.0, 10.0));
+        assert!(b.size().width == 20.0);
+        assert!(b.size().height == 20.0);
+        assert!(b.size().depth == 20.0);
+    }
+
+    #[test]
+    fn test_center() {
+        let b = Box3D::new(point3(-10.0, -10.0, -10.0), point3(10.0, 10.0, 10.0));
+        assert!(b.center() == Point3D::zero());
+    }
+
+    #[test]
+    fn test_volume() {
+        let b = Box3D::new(point3(-10.0, -10.0, -10.0), point3(10.0, 10.0, 10.0));
+        assert!(b.volume() == 8000.0);
+    }
+
+    #[test]
+    fn test_area() {
+        let b = Box3D::new(point3(-10.0, -10.0, -10.0), point3(10.0, 10.0, 10.0));
+        assert!(b.xy_area() == 400.0);
+        assert!(b.yz_area() == 400.0);
+        assert!(b.xz_area() == 400.0);
+    }
+
+    #[test]
+    fn test_from_points() {
+        let b = Box3D::from_points(&[point3(50.0, 160.0, 12.5), point3(100.0, 25.0, 200.0)]);
+        assert!(b.min == point3(50.0, 25.0, 12.5));
+        assert!(b.max == point3(100.0, 160.0, 200.0));
+    }
+
+    #[test]
+    fn test_min_max() {
+        let b = Box3D::from_points(&[point3(50.0, 25.0, 12.5), point3(100.0, 160.0, 200.0)]);
+        assert!(b.min_x() == 50.0);
+        assert!(b.min_y() == 25.0);
+        assert!(b.min_z() == 12.5);
+        assert!(b.max_x() == 100.0);
+        assert!(b.max_y() == 160.0);
+        assert!(b.max_z() == 200.0);
+    }
+
+    #[test]
+    fn test_round_in() {
+        let b = Box3D::from_points(&[point3(-25.5, -40.4, -70.9), point3(60.3, 36.5, 89.8)]).round_in();
+        assert!(b.min_x() == -25.0);
+        assert!(b.min_y() == -40.0);
+        assert!(b.min_z() == -70.0);
+        assert!(b.max_x() == 60.0);
+        assert!(b.max_y() == 36.0);
+        assert!(b.max_z() == 89.0);
+    }
+
+    #[test]
+    fn test_round_out() {
+        let b = Box3D::from_points(&[point3(-25.5, -40.4, -70.9), point3(60.3, 36.5, 89.8)]).round_out();
+        assert!(b.min_x() == -26.0);
+        assert!(b.min_y() == -41.0);
+        assert!(b.min_z() == -71.0);
+        assert!(b.max_x() == 61.0);
+        assert!(b.max_y() == 37.0);
+        assert!(b.max_z() == 90.0);
+    }
+
+    #[test]
+    fn test_round() {
+        let b = Box3D::from_points(&[point3(-25.5, -40.4, -70.9), point3(60.3, 36.5, 89.8)]).round();
+        assert!(b.min_x() == -26.0);
+        assert!(b.min_y() == -40.0);
+        assert!(b.min_z() == -71.0);
+        assert!(b.max_x() == 60.0);
+        assert!(b.max_y() == 37.0);
+        assert!(b.max_z() == 90.0);
+    }
+
+    #[test]
+    fn test_from_size() {
+        let b = Box3D::from_size(size3(30.0, 40.0, 50.0));
+        assert!(b.min == Point3D::zero());
+        assert!(b.size().width == 30.0);
+        assert!(b.size().height == 40.0);
+        assert!(b.size().depth == 50.0);
+    }
+
+    #[test]
+    fn test_translate() {
+        let size = size3(15.0, 15.0, 200.0);
+        let mut center = (size / 2.0).to_vector().to_point();
+        let b = Box3D::from_size(size);
+        assert!(b.center() == center);
+        let translation = vec3(10.0, 2.5, 9.5);
+        let b = b.translate(&translation);
+        center += translation;
+        assert!(b.center() == center);
+        assert!(b.max_x() == 25.0);
+        assert!(b.max_y() == 17.5);
+        assert!(b.max_z() == 209.5);
+        assert!(b.min_x() == 10.0);
+        assert!(b.min_y() == 2.5);
+        assert!(b.min_z() == 9.5);
+    }
+
+    #[test]
+    fn test_union() {
+        let b1 = Box3D::from_points(&[point3(-20.0, -20.0, -20.0), point3(0.0, 20.0, 20.0)]);
+        let b2 = Box3D::from_points(&[point3(0.0, 20.0, 20.0), point3(20.0, -20.0, -20.0)]);
+        let b = b1.union(&b2);
+        assert!(b.max_x() == 20.0);
+        assert!(b.max_y() == 20.0);
+        assert!(b.max_z() == 20.0);
+        assert!(b.min_x() == -20.0);
+        assert!(b.min_y() == -20.0);
+        assert!(b.min_z() == -20.0);
+        assert!(b.volume() == (40.0 * 40.0 * 40.0));
+    }
+
+    #[test]
+    fn test_intersects() {
+        let b1 = Box3D::from_points(&[point3(-15.0, -20.0, -20.0), point3(10.0, 20.0, 20.0)]);
+        let b2 = Box3D::from_points(&[point3(-10.0, 20.0, 20.0), point3(15.0, -20.0, -20.0)]);
+        assert!(b1.intersects(&b2));
+    }
+
+    #[test]
+    fn test_intersection() {
+        let b1 = Box3D::from_points(&[point3(-15.0, -20.0, -20.0), point3(10.0, 20.0, 20.0)]);
+        let b2 = Box3D::from_points(&[point3(-10.0, 20.0, 20.0), point3(15.0, -20.0, -20.0)]);
+        let b = b1.intersection(&b2);
+        assert!(b.max_x() == 10.0);
+        assert!(b.max_y() == 20.0);
+        assert!(b.max_z() == 20.0);
+        assert!(b.min_x() == -10.0);
+        assert!(b.min_y() == -20.0);
+        assert!(b.min_z() == -20.0);
+        assert!(b.volume() == (20.0 * 40.0 * 40.0));
+    }
+
+    #[test]
+    fn test_try_intersection() {
+        let b1 = Box3D::from_points(&[point3(-15.0, -20.0, -20.0), point3(10.0, 20.0, 20.0)]);
+        let b2 = Box3D::from_points(&[point3(-10.0, 20.0, 20.0), point3(15.0, -20.0, -20.0)]);
+        assert!(b1.try_intersection(&b2).is_some());
+    
+        let b1 = Box3D::from_points(&[point3(-15.0, -20.0, -20.0), point3(-10.0, 20.0, 20.0)]);
+        let b2 = Box3D::from_points(&[point3(10.0, 20.0, 20.0), point3(15.0, -20.0, -20.0)]);
+        assert!(b1.try_intersection(&b2).is_none());
+    }
+
+    #[test]
+    fn test_scale() {
+        let b = Box3D::from_points(&[point3(-10.0, -10.0, -10.0), point3(10.0, 10.0, 10.0)]);
+        let b = b.scale(0.5, 0.5, 0.5);
+        assert!(b.max_x() == 5.0);
+        assert!(b.max_y() == 5.0);
+        assert!(b.max_z() == 5.0);
+        assert!(b.min_x() == -5.0);
+        assert!(b.min_y() == -5.0);
+        assert!(b.min_z() == -5.0);
+    }
+
+    #[test]
+    fn test_zero() {
+        let b = Box3D::<f64>::zero();
+        assert!(b.max_x() == 0.0);
+        assert!(b.max_y() == 0.0);
+        assert!(b.max_z() == 0.0);
+        assert!(b.min_x() == 0.0);
+        assert!(b.min_y() == 0.0);
+        assert!(b.min_z() == 0.0);
+    }
+
+    #[test]
+    fn test_lerp() {
+        let b1 = Box3D::from_points(&[point3(-20.0, -20.0, -20.0), point3(-10.0, -10.0, -10.0)]);
+        let b2 = Box3D::from_points(&[point3(10.0, 10.0, 10.0), point3(20.0, 20.0, 20.0)]);
+        let b = b1.lerp(b2, 0.5);
+        assert!(b.center() == Point3D::zero());
+        assert!(b.size().width == 10.0);
+        assert!(b.size().height == 10.0);
+        assert!(b.size().depth == 10.0);
+    }
+
+    #[test]
+    fn test_contains() {
+        let b = Box3D::from_points(&[point3(-20.0, -20.0, -20.0), point3(20.0, 20.0, 20.0)]);
+        assert!(b.contains(&point3(-15.3, 10.5, 18.4)));
+    }
+
+    #[test]
+    fn test_contains_box() {
+        let b1 = Box3D::from_points(&[point3(-20.0, -20.0, -20.0), point3(20.0, 20.0, 20.0)]);
+        let b2 = Box3D::from_points(&[point3(-14.3, -16.5, -19.3), point3(6.7, 17.6, 2.5)]);
+        assert!(b1.contains_box(&b2));
+    }
+
+    #[test]
+    fn test_inflate() {
+        let b = Box3D::from_points(&[point3(-20.0, -20.0, -20.0), point3(20.0, 20.0, 20.0)]);
+        let b = b.inflate(10.0, 5.0, 2.0);
+        assert!(b.size().width == 60.0);
+        assert!(b.size().height == 50.0);
+        assert!(b.size().depth == 44.0);
+        assert!(b.center() == Point3D::zero());
+    }
+
+    #[test]
+    fn test_is_empty() {
+        for i in 0..3 {
+            let mut coords_neg = [-20.0, -20.0, -20.0];
+            let mut coords_pos = [20.0, 20.0, 20.0];
+            coords_neg[i] = 0.0;
+            coords_pos[i] = 0.0;
+            let b = Box3D::from_points(&[Point3D::from(coords_neg), Point3D::from(coords_pos)]);
+            assert!(b.is_empty());
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@ pub use vector::{BoolVector2D, BoolVector3D, bvec2, bvec3};
 pub use homogen::HomogeneousVector;
 
 pub use rect::{rect, Rect, TypedRect};
+pub use box3d::{box3d, Box3D, TypedBox3D};
 pub use translation::{TypedTranslation2D, TypedTranslation3D};
 pub use rotation::{Angle, Rotation2D, Rotation3D, TypedRotation2D, TypedRotation3D};
 pub use side_offsets::{SideOffsets2D, TypedSideOffsets2D};
@@ -90,6 +91,7 @@ pub use trig::Trig;
 mod macros;
 
 pub mod approxeq;
+pub mod approxord;
 mod homogen;
 pub mod num;
 mod length;
@@ -104,6 +106,7 @@ mod transform3d;
 mod translation;
 mod trig;
 mod vector;
+mod box3d;
 
 /// The default unit.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/point.rs
+++ b/src/point.rs
@@ -11,7 +11,7 @@ use super::UnknownUnit;
 use approxeq::ApproxEq;
 use length::Length;
 use scale::TypedScale;
-use size::TypedSize2D;
+use size::{TypedSize2D, TypedSize3D};
 #[cfg(feature = "mint")]
 use mint;
 use num::*;
@@ -440,6 +440,11 @@ impl<T: Copy + Zero, U> TypedPoint3D<T, U> {
     pub fn origin() -> Self {
         point3(Zero::zero(), Zero::zero(), Zero::zero())
     }
+
+    #[inline]
+    pub fn zero() -> Self {
+        Self::origin()
+    }
 }
 
 impl<T: Copy + One, U> TypedPoint3D<T, U> {
@@ -575,6 +580,13 @@ impl<T: Copy, U> TypedPoint3D<T, U> {
     }
 }
 
+impl<T: Copy + Add<T, Output = T>, U> TypedPoint3D<T, U> {
+    #[inline]
+    pub fn add_size(&self, other: &TypedSize3D<T, U>) -> Self {
+        point3(self.x + other.width, self.y + other.height, self.z + other.depth)
+    }
+}
+
 impl<T: Copy + Add<T, Output = T>, U> AddAssign<TypedVector3D<T, U>> for TypedPoint3D<T, U> {
     #[inline]
     fn add_assign(&mut self, other: TypedVector3D<T, U>) {
@@ -621,11 +633,27 @@ impl<T: Copy + Mul<T, Output = T>, U> Mul<T> for TypedPoint3D<T, U> {
     }
 }
 
+impl<T: Copy + Mul<T, Output = T>, U1, U2> Mul<TypedScale<T, U1, U2>> for TypedPoint3D<T, U1> {
+    type Output = TypedPoint3D<T, U2>;
+    #[inline]
+    fn mul(self, scale: TypedScale<T, U1, U2>) -> TypedPoint3D<T, U2> {
+        point3(self.x * scale.get(), self.y * scale.get(), self.z * scale.get())
+    }
+}
+
 impl<T: Copy + Div<T, Output = T>, U> Div<T> for TypedPoint3D<T, U> {
     type Output = Self;
     #[inline]
     fn div(self, scale: T) -> Self {
         point3(self.x / scale, self.y / scale, self.z / scale)
+    }
+}
+
+impl<T: Copy + Div<T, Output = T>, U1, U2> Div<TypedScale<T, U1, U2>> for TypedPoint3D<T, U2> {
+    type Output = TypedPoint3D<T, U1>;
+    #[inline]
+    fn div(self, scale: TypedScale<T, U1, U2>) -> TypedPoint3D<T, U1> {
+        point3(self.x / scale.get(), self.y / scale.get(), self.z / scale.get())
     }
 }
 

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -15,6 +15,7 @@ use point::TypedPoint2D;
 use vector::TypedVector2D;
 use side_offsets::TypedSideOffsets2D;
 use size::TypedSize2D;
+use approxord::{min, max};
 
 use num_traits::NumCast;
 #[cfg(feature = "serde")]
@@ -428,22 +429,6 @@ impl<T: Copy + PartialEq + Zero, U> TypedRect<T, U> {
     }
 }
 
-pub fn min<T: Clone + PartialOrd>(x: T, y: T) -> T {
-    if x <= y {
-        x
-    } else {
-        y
-    }
-}
-
-pub fn max<T: Clone + PartialOrd>(x: T, y: T) -> T {
-    if x >= y {
-        x
-    } else {
-        y
-    }
-}
-
 impl<T: Copy + Mul<T, Output = T>, U> Mul<T> for TypedRect<T, U> {
     type Output = Self;
     #[inline]
@@ -622,15 +607,6 @@ mod tests {
     use side_offsets::SideOffsets2D;
     use size::Size2D;
     use super::*;
-
-    #[test]
-    fn test_min_max() {
-        assert!(min(0u32, 1u32) == 0u32);
-        assert!(min(-1.0f32, 0.0f32) == -1.0f32);
-
-        assert!(max(0u32, 1u32) == 1u32);
-        assert!(max(-1.0f32, 0.0f32) == 0.0f32);
-    }
 
     #[test]
     fn test_translate() {

--- a/src/side_offsets.rs
+++ b/src/side_offsets.rs
@@ -17,7 +17,7 @@ use core::fmt;
 use core::ops::Add;
 use core::marker::PhantomData;
 
-/// A group of side offsets, which correspond to top/left/bottom/right for borders, padding,
+/// A group of 2D side offsets, which correspond to top/left/bottom/right for borders, padding,
 /// and margins in CSS, optionally tagged with a unit.
 #[derive(EuclidMatrix)]
 #[repr(C)]
@@ -40,7 +40,7 @@ impl<T: fmt::Debug, U> fmt::Debug for TypedSideOffsets2D<T, U> {
     }
 }
 
-/// The default side offset type with no unit.
+/// The default 2D side offset type with no unit.
 pub type SideOffsets2D<T> = TypedSideOffsets2D<T, UnknownUnit>;
 
 impl<T: Copy, U> TypedSideOffsets2D<T, U> {

--- a/src/size.rs
+++ b/src/size.rs
@@ -13,6 +13,7 @@ use mint;
 use length::Length;
 use scale::TypedScale;
 use vector::{TypedVector2D, vec2, BoolVector2D};
+use vector::{TypedVector3D, vec3, BoolVector3D};
 use num::*;
 
 use num_traits::{Float, NumCast, Signed};
@@ -444,5 +445,382 @@ mod size2d {
         let s2 = Size2D::from(sm);
 
         assert_eq!(s1, s2);
+    }
+}
+
+/// A 3d size tagged with a unit.
+#[derive(EuclidMatrix)]
+#[repr(C)]
+pub struct TypedSize3D<T, U> {
+    pub width: T,
+    pub height: T,
+    pub depth: T,
+    #[doc(hidden)]
+    pub _unit: PhantomData<U>,
+}
+
+/// Default 3d size type with no unit.
+///
+/// `Size3D` provides the same methods as `TypedSize3D`.
+pub type Size3D<T> = TypedSize3D<T, UnknownUnit>;
+
+impl<T: fmt::Debug, U> fmt::Debug for TypedSize3D<T, U> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}×{:?}×{:?}", self.width, self.height, self.depth)
+    }
+}
+
+impl<T: fmt::Display, U> fmt::Display for TypedSize3D<T, U> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "({}x{}x{})", self.width, self.height, self.depth)
+    }
+}
+
+impl<T, U> TypedSize3D<T, U> {
+    /// Constructor taking scalar values.
+    pub fn new(width: T, height: T, depth: T) -> Self {
+        TypedSize3D {
+            width,
+            height,
+            depth,
+            _unit: PhantomData,
+        }
+    }
+}
+
+impl<T: Clone, U> TypedSize3D<T, U> {
+    /// Constructor taking scalar strongly typed lengths.
+    pub fn from_lengths(width: Length<T, U>, height: Length<T, U>, depth: Length<T, U>) -> Self {
+        TypedSize3D::new(width.get(), height.get(), depth.get())
+    }
+}
+
+impl<T: Round, U> TypedSize3D<T, U> {
+    /// Rounds each component to the nearest integer value.
+    ///
+    /// This behavior is preserved for negative values (unlike the basic cast).
+    pub fn round(&self) -> Self {
+        TypedSize3D::new(self.width.round(), self.height.round(), self.depth.round())
+    }
+}
+
+impl<T: Ceil, U> TypedSize3D<T, U> {
+    /// Rounds each component to the smallest integer equal or greater than the original value.
+    ///
+    /// This behavior is preserved for negative values (unlike the basic cast).
+    pub fn ceil(&self) -> Self {
+        TypedSize3D::new(self.width.ceil(), self.height.ceil(), self.depth.ceil())
+    }
+}
+
+impl<T: Floor, U> TypedSize3D<T, U> {
+    /// Rounds each component to the biggest integer equal or lower than the original value.
+    ///
+    /// This behavior is preserved for negative values (unlike the basic cast).
+    pub fn floor(&self) -> Self {
+        TypedSize3D::new(self.width.floor(), self.height.floor(), self.depth.floor())
+    }
+}
+
+impl<T: Copy + Add<T, Output = T>, U> Add for TypedSize3D<T, U> {
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        TypedSize3D::new(self.width + other.width, self.height + other.height, self.depth + other.depth)
+    }
+}
+
+impl<T: Copy + Sub<T, Output = T>, U> Sub for TypedSize3D<T, U> {
+    type Output = Self;
+    fn sub(self, other: Self) -> Self {
+        TypedSize3D::new(self.width - other.width, self.height - other.height, self.depth - other.depth)
+    }
+}
+
+impl<T: Copy + Clone + Mul<T, Output=T>, U> TypedSize3D<T, U> {
+    pub fn volume(&self) -> T {
+        self.width * self.height * self.depth
+    }
+}
+
+impl<T, U> TypedSize3D<T, U>
+where
+    T: Copy + One + Add<Output = T> + Sub<Output = T> + Mul<Output = T>,
+{
+    /// Linearly interpolate between this size and another size.
+    ///
+    /// `t` is expected to be between zero and one.
+    #[inline]
+    pub fn lerp(&self, other: Self, t: T) -> Self {
+        let one_t = T::one() - t;
+        size3(
+            one_t * self.width + t * other.width,
+            one_t * self.height + t * other.height,
+            one_t * self.depth + t * other.depth,
+        )
+    }
+}
+
+impl<T: Zero + PartialOrd, U> TypedSize3D<T, U> {
+    pub fn is_empty_or_negative(&self) -> bool {
+        let zero = T::zero();
+        self.width <= zero || self.height <= zero || self.depth <= zero
+    }
+}
+
+impl<T: Zero, U> TypedSize3D<T, U> {
+    pub fn zero() -> Self {
+        TypedSize3D::new(Zero::zero(), Zero::zero(), Zero::zero())
+    }
+}
+
+impl<T: Zero, U> Zero for TypedSize3D<T, U> {
+    fn zero() -> Self {
+        TypedSize3D::new(Zero::zero(), Zero::zero(), Zero::zero())
+    }
+}
+
+impl<T: Copy + Mul<T, Output = T>, U> Mul<T> for TypedSize3D<T, U> {
+    type Output = Self;
+    #[inline]
+    fn mul(self, scale: T) -> Self {
+        TypedSize3D::new(self.width * scale, self.height * scale, self.depth * scale)
+    }
+}
+
+impl<T: Copy + Div<T, Output = T>, U> Div<T> for TypedSize3D<T, U> {
+    type Output = Self;
+    #[inline]
+    fn div(self, scale: T) -> Self {
+        TypedSize3D::new(self.width / scale, self.height / scale, self.depth / scale)
+    }
+}
+
+impl<T: Copy + Mul<T, Output = T>, U1, U2> Mul<TypedScale<T, U1, U2>> for TypedSize3D<T, U1> {
+    type Output = TypedSize3D<T, U2>;
+    #[inline]
+    fn mul(self, scale: TypedScale<T, U1, U2>) -> TypedSize3D<T, U2> {
+        TypedSize3D::new(self.width * scale.get(), self.height * scale.get(), self.depth * scale.get())
+    }
+}
+
+impl<T: Copy + Div<T, Output = T>, U1, U2> Div<TypedScale<T, U1, U2>> for TypedSize3D<T, U2> {
+    type Output = TypedSize3D<T, U1>;
+    #[inline]
+    fn div(self, scale: TypedScale<T, U1, U2>) -> TypedSize3D<T, U1> {
+        TypedSize3D::new(self.width / scale.get(), self.height / scale.get(), self.depth / scale.get())
+    }
+}
+
+impl<T: Copy, U> TypedSize3D<T, U> {
+    /// Returns self.width as a Length carrying the unit.
+    #[inline]
+    pub fn width_typed(&self) -> Length<T, U> {
+        Length::new(self.width)
+    }
+
+    /// Returns self.height as a Length carrying the unit.
+    #[inline]
+    pub fn height_typed(&self) -> Length<T, U> {
+        Length::new(self.height)
+    }
+
+    /// Returns self.depth as a Length carrying the unit.
+    #[inline]
+    pub fn depth_typed(&self) -> Length<T, U> {
+        Length::new(self.depth)
+    }
+
+    #[inline]
+    pub fn to_array(&self) -> [T; 3] {
+        [self.width, self.height, self.depth]
+    }
+
+    #[inline]
+    pub fn to_vector(&self) -> TypedVector3D<T, U> {
+        vec3(self.width, self.height, self.depth)
+    }
+
+    /// Drop the units, preserving only the numeric value.
+    pub fn to_untyped(&self) -> Size3D<T> {
+        TypedSize3D::new(self.width, self.height, self.depth)
+    }
+
+    /// Tag a unitless value with units.
+    pub fn from_untyped(p: &Size3D<T>) -> Self {
+        TypedSize3D::new(p.width, p.height, p.depth)
+    }
+}
+
+impl<T: NumCast + Copy, Unit> TypedSize3D<T, Unit> {
+    /// Cast from one numeric representation to another, preserving the units.
+    ///
+    /// When casting from floating point to integer coordinates, the decimals are truncated
+    /// as one would expect from a simple cast, but this behavior does not always make sense
+    /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
+    pub fn cast<NewT: NumCast + Copy>(&self) -> TypedSize3D<NewT, Unit> {
+        self.try_cast().unwrap()
+    }
+
+    /// Fallible cast from one numeric representation to another, preserving the units.
+    ///
+    /// When casting from floating point to integer coordinates, the decimals are truncated
+    /// as one would expect from a simple cast, but this behavior does not always make sense
+    /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
+    pub fn try_cast<NewT: NumCast + Copy>(&self) -> Option<TypedSize3D<NewT, Unit>> {
+        match (NumCast::from(self.width), NumCast::from(self.height), NumCast::from(self.depth)) {
+            (Some(w), Some(h), Some(d)) => Some(TypedSize3D::new(w, h, d)),
+            _ => None,
+        }
+    }
+
+    // Convenience functions for common casts
+
+    /// Cast into an `f32` size.
+    pub fn to_f32(&self) -> TypedSize3D<f32, Unit> {
+        self.cast()
+    }
+
+    /// Cast into an `f64` size.
+    pub fn to_f64(&self) -> TypedSize3D<f64, Unit> {
+        self.cast()
+    }
+
+    /// Cast into an `uint` size, truncating decimals if any.
+    ///
+    /// When casting from floating point sizes, it is worth considering whether
+    /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
+    /// the desired conversion behavior.
+    pub fn to_usize(&self) -> TypedSize3D<usize, Unit> {
+        self.cast()
+    }
+
+    /// Cast into an `u32` size, truncating decimals if any.
+    ///
+    /// When casting from floating point sizes, it is worth considering whether
+    /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
+    /// the desired conversion behavior.
+    pub fn to_u32(&self) -> TypedSize3D<u32, Unit> {
+        self.cast()
+    }
+
+    /// Cast into an `i32` size, truncating decimals if any.
+    ///
+    /// When casting from floating point sizes, it is worth considering whether
+    /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
+    /// the desired conversion behavior.
+    pub fn to_i32(&self) -> TypedSize3D<i32, Unit> {
+        self.cast()
+    }
+
+    /// Cast into an `i64` size, truncating decimals if any.
+    ///
+    /// When casting from floating point sizes, it is worth considering whether
+    /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
+    /// the desired conversion behavior.
+    pub fn to_i64(&self) -> TypedSize3D<i64, Unit> {
+        self.cast()
+    }
+}
+
+impl<T, U> TypedSize3D<T, U>
+where
+    T: Signed,
+{
+    pub fn abs(&self) -> Self {
+        size3(self.width.abs(), self.height.abs(), self.depth.abs())
+    }
+
+    pub fn is_positive(&self) -> bool {
+        self.width.is_positive() && self.height.is_positive() && self.depth.is_positive()
+    }
+}
+
+impl<T: PartialOrd, U> TypedSize3D<T, U> {
+    pub fn greater_than(&self, other: &Self) -> BoolVector3D {
+        BoolVector3D {
+            x: self.width > other.width,
+            y: self.height > other.height,
+            z: self.depth > other.depth,
+        }
+    }
+
+    pub fn lower_than(&self, other: &Self) -> BoolVector3D {
+        BoolVector3D {
+            x: self.width < other.width,
+            y: self.height < other.height,
+            z: self.depth < other.depth,
+        }
+    }
+}
+
+
+impl<T: PartialEq, U> TypedSize3D<T, U> {
+    pub fn equal(&self, other: &Self) -> BoolVector3D {
+        BoolVector3D {
+            x: self.width == other.width,
+            y: self.height == other.height,
+            z: self.depth == other.depth,
+        }
+    }
+
+    pub fn not_equal(&self, other: &Self) -> BoolVector3D {
+        BoolVector3D {
+            x: self.width != other.width,
+            y: self.height != other.height,
+            z: self.depth != other.depth,
+        }
+    }
+}
+
+impl<T: Float, U> TypedSize3D<T, U> {
+    #[inline]
+    pub fn min(self, other: Self) -> Self {
+        size3(
+            self.width.min(other.width),
+            self.height.min(other.height),
+            self.depth.min(other.depth),
+        )
+    }
+
+    #[inline]
+    pub fn max(self, other: Self) -> Self {
+        size3(
+            self.width.max(other.width),
+            self.height.max(other.height),
+            self.depth.max(other.depth),
+        )
+    }
+
+    #[inline]
+    pub fn clamp(&self, start: Self, end: Self) -> Self {
+        self.max(start).min(end)
+    }
+}
+
+
+/// Shorthand for `TypedSize3D::new(w, h, d)`.
+pub fn size3<T, U>(w: T, h: T, d: T) -> TypedSize3D<T, U> {
+    TypedSize3D::new(w, h, d)
+}
+
+#[cfg(feature = "mint")]
+impl<T, U> From<mint::Vector3<T>> for TypedSize3D<T, U> {
+    fn from(v: mint::Vector3<T>) -> Self {
+        TypedSize3D {
+            width: v.x,
+            height: v.y,
+            depth: v.z,
+            _unit: PhantomData,
+        }
+    }
+}
+#[cfg(feature = "mint")]
+impl<T, U> Into<mint::Vector3<T>> for TypedSize3D<T, U> {
+    fn into(self) -> mint::Vector3<T> {
+        mint::Vector3 {
+            x: self.width,
+            y: self.height,
+            z: self.depth,
+        }
     }
 }


### PR DESCRIPTION
Extends the library to add support for the 3D primitive `Cuboid`. Not sure if you intend this library to be mostly 2D only, but there is already some 3D support, so this is just a little extra - cuboids are pretty useful. Couldn't call this Box as it would conflict with rust's Box.

I plan to use this for my own project later on.

Tests are pending - I would like your feedback first (ok PR or not), then go from there.

For the z-axis equivalent of (horizontal, vertical), I have called it applicate. This is what googling around suggested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/311)
<!-- Reviewable:end -->
