### PR TITLE
Properly support no_std

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
     - rust: stable
       env: FEATURES=""
     - rust: stable
+      env: FEATURES="--no-default-features" TEST=no
+    - rust: stable
       env: FEATURES="--features mint"
     - rust: beta
       env: FEATURES=""
@@ -25,4 +27,4 @@ matrix:
 
 script:
   - cargo build $FEATURES
-  - cargo test --verbose $FEATURES
+  - if [ $TEST != "no" ]; then cargo test --verbose $FEATURES; fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.19.4"
+version = "0.19.5"
 authors = ["The Servo Project Developers"]
 description = "Geometry primitives"
 documentation = "https://docs.rs/euclid/"
@@ -11,9 +11,11 @@ license = "MIT / Apache-2.0"
 
 [features]
 unstable = []
+std = ["num-traits/std"]
+default = ["std"]
 
 [dependencies]
-num-traits = { version = "0.2" }
+num-traits = { version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["serde_derive"], optional = true }
 mint = {version = "0.5.1", optional = true}
 

--- a/src/approxeq.rs
+++ b/src/approxeq.rs
@@ -7,6 +7,9 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(not(feature = "std"))]
+use num_traits::float::FloatCore;
+
 /// Trait for testing approximate equality
 pub trait ApproxEq<Eps> {
     fn approx_epsilon() -> Eps;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 // except according to those terms.
 
 #![cfg_attr(feature = "unstable", feature(fn_must_use))]
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(any(feature = "std", test)), no_std)]
 
 //! A collection of strongly typed math tools for computer graphics with an inclination
 //! towards 2d graphics and layout.
@@ -65,7 +65,7 @@ pub extern crate mint;
 extern crate num_traits;
 #[cfg(test)]
 extern crate rand;
-#[cfg(test)]
+#[cfg(any(test, feature = "std"))]
 use std as core;
 
 pub use length::Length;

--- a/src/num.rs
+++ b/src/num.rs
@@ -10,6 +10,9 @@
 
 use num_traits;
 
+#[cfg(not(feature = "std"))]
+use num_traits::float::FloatCore;
+
 pub trait Zero {
     fn zero() -> Self;
 }
@@ -56,6 +59,26 @@ macro_rules! num_int {
         }
     )
 }
+
+#[cfg(not(any(feature = "std", test)))]
+macro_rules! num_float {
+    ($ty:ty) => (
+        impl Round for $ty {
+            #[inline]
+            fn round(self) -> $ty { <$ty as FloatCore>::round(self) }
+        }
+        impl Floor for $ty {
+            #[inline]
+            fn floor(self) -> $ty { <$ty as FloatCore>::floor(self) }
+        }
+        impl Ceil for $ty {
+            #[inline]
+            fn ceil(self) -> $ty { <$ty as FloatCore>::ceil(self) }
+        }
+    )
+}
+
+#[cfg(any(feature = "std", test))]
 macro_rules! num_float {
     ($ty:ty) => (
         impl Round for $ty {

--- a/src/point.rs
+++ b/src/point.rs
@@ -15,7 +15,8 @@ use size::TypedSize2D;
 #[cfg(feature = "mint")]
 use mint;
 use num::*;
-use num_traits::{Float, NumCast};
+use num_traits::NumCast;
+use num_traits::float::FloatCore;
 use vector::{TypedVector2D, TypedVector3D, vec2, vec3};
 use core::fmt;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
@@ -188,7 +189,7 @@ impl<T: Copy + Sub<T, Output = T>, U> Sub<TypedVector2D<T, U>> for TypedPoint2D<
     }
 }
 
-impl<T: Float, U> TypedPoint2D<T, U> {
+impl<T: FloatCore, U> TypedPoint2D<T, U> {
     #[inline]
     pub fn min(self, other: Self) -> Self {
         point2(self.x.min(other.x), self.y.min(other.y))
@@ -608,7 +609,7 @@ impl<T: Copy + Div<T, Output = T>, U> Div<T> for TypedPoint3D<T, U> {
     }
 }
 
-impl<T: Float, U> TypedPoint3D<T, U> {
+impl<T: FloatCore, U> TypedPoint3D<T, U> {
     #[inline]
     pub fn min(self, other: Self) -> Self {
         point3(

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -8,13 +8,19 @@
 // except according to those terms.
 
 use approxeq::ApproxEq;
-use num_traits::{Float, FloatConst, One, Zero};
+#[cfg(feature = "std")]
+use num_traits::Float;
+use num_traits::{FloatConst, One, Zero};
 use core::fmt;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, Sub, SubAssign};
 use core::marker::PhantomData;
 use trig::Trig;
-use {TypedPoint2D, TypedPoint3D, TypedVector2D, TypedVector3D, Vector3D, point2, point3, vec3};
-use {TypedTransform2D, TypedTransform3D, UnknownUnit};
+#[cfg(feature = "std")]
+use {TypedPoint2D, TypedPoint3D, TypedVector2D, TypedVector3D, point2, point3};
+use {Vector3D, vec3};
+#[cfg(feature = "std")]
+use TypedTransform3D;
+use {TypedTransform2D, UnknownUnit};
 
 /// An angle in radians
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Hash)]
@@ -72,6 +78,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T> Angle<T>
 where
     T: Float,
@@ -229,6 +236,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T, Src, Dst> TypedRotation2D<T, Src, Dst>
 where
     T: Copy
@@ -367,6 +375,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T, Src, Dst> TypedRotation3D<T, Src, Dst>
 where
     T: Float,

--- a/src/size.rs
+++ b/src/size.rs
@@ -14,8 +14,8 @@ use length::Length;
 use scale::TypedScale;
 use vector::{TypedVector2D, vec2, BoolVector2D};
 use num::*;
-
-use num_traits::{Float, NumCast, Signed};
+use num_traits::{NumCast, Signed};
+use num_traits::float::FloatCore;
 use core::fmt;
 use core::ops::{Add, Div, Mul, Sub};
 use core::marker::PhantomData;
@@ -329,7 +329,7 @@ impl<T: PartialEq, U> TypedSize2D<T, U> {
     }
 }
 
-impl<T: Float, U> TypedSize2D<T, U> {
+impl<T: FloatCore, U> TypedSize2D<T, U> {
     #[inline]
     pub fn min(self, other: Self) -> Self {
         size2(

--- a/src/trig.rs
+++ b/src/trig.rs
@@ -19,6 +19,7 @@ pub trait Trig {
 
 macro_rules! trig {
     ($ty:ident) => (
+        #[cfg(feature = "std")]
         impl Trig for $ty {
             #[inline]
             fn sin(self) -> $ty { self.sin() }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -18,7 +18,11 @@ use scale::TypedScale;
 use trig::Trig;
 use Angle;
 use num::*;
-use num_traits::{Float, NumCast, Signed};
+
+#[cfg(feature = "std")]
+use num_traits::Float;
+use num_traits::{NumCast, Signed};
+use num_traits::float::FloatCore;
 use core::fmt;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use core::marker::PhantomData;
@@ -165,6 +169,7 @@ where
     }
 
     #[inline]
+    #[cfg(feature = "std")]
     pub fn normalize(self) -> Self
     where
         T: Float,
@@ -174,6 +179,7 @@ where
 
     /// Return the normalized vector even if the length is larger than the max value of Float.
     #[inline]
+    #[cfg(feature = "std")]
     pub fn robust_normalize(self) -> Self
     where
         T: Float,
@@ -193,6 +199,7 @@ where
     }
 
     #[inline]
+    #[cfg(feature = "std")]
     pub fn length(&self) -> T
     where
         T: Float,
@@ -252,7 +259,7 @@ impl<T: Copy + Neg<Output = T>, U> Neg for TypedVector2D<T, U> {
     }
 }
 
-impl<T: Float, U> TypedVector2D<T, U> {
+impl<T: FloatCore, U> TypedVector2D<T, U> {
     #[inline]
     pub fn min(self, other: Self) -> Self {
         vec2(self.x.min(other.x), self.y.min(other.y))
@@ -615,6 +622,7 @@ impl<T: Mul<T, Output = T> + Add<T, Output = T> + Sub<T, Output = T> + Copy, U>
     }
 
     #[inline]
+    #[cfg(feature = "std")]
     pub fn normalize(self) -> Self
     where
         T: Float,
@@ -624,6 +632,7 @@ impl<T: Mul<T, Output = T> + Add<T, Output = T> + Sub<T, Output = T> + Copy, U>
 
     /// Return the normalized vector even if the length is larger than the max value of Float.
     #[inline]
+    #[cfg(feature = "std")]
     pub fn robust_normalize(self) -> Self
     where
         T: Float,
@@ -643,6 +652,7 @@ impl<T: Mul<T, Output = T> + Add<T, Output = T> + Sub<T, Output = T> + Copy, U>
     }
 
     #[inline]
+    #[cfg(feature = "std")]
     pub fn length(&self) -> T
     where
         T: Float,
@@ -733,6 +743,7 @@ impl<T: Copy + Div<T, Output = T>, U> DivAssign<T> for TypedVector3D<T, U> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<T: Float, U> TypedVector3D<T, U> {
     #[inline]
     pub fn min(self, other: Self) -> Self {


### PR DESCRIPTION
num-traits isn't no-std by default, and we use a bunch of stuff from it that requires std

r? @SimonSapin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/312)
<!-- Reviewable:end -->
