### PR TITLE
Add RigidTransform3D type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ pub use vector::{BoolVector2D, BoolVector3D, bvec2, bvec3};
 pub use homogen::HomogeneousVector;
 
 pub use rect::{rect, Rect, TypedRect};
+pub use rigid::{RigidTransform3D, TypedRigidTransform3D};
 pub use box3d::{box3d, Box3D, TypedBox3D};
 pub use translation::{TypedTranslation2D, TypedTranslation3D};
 pub use rotation::{Angle, Rotation2D, Rotation3D, TypedRotation2D, TypedRotation3D};
@@ -99,6 +100,7 @@ pub mod num;
 mod length;
 mod point;
 mod rect;
+mod rigid;
 mod rotation;
 mod scale;
 mod side_offsets;

--- a/src/rigid.rs
+++ b/src/rigid.rs
@@ -1,0 +1,167 @@
+use approxeq::ApproxEq;
+use num_traits::Float;
+use trig::Trig;
+use {TypedRotation3D, TypedTransform3D, TypedVector3D, UnknownUnit};
+
+/// A rigid transformation. All lengths are preserved under such a transformation.
+///
+///
+/// Internally, this is a rotation and a translation, with the rotation
+/// applied first (i.e. `Translation * Rotation`)
+///
+/// This can be more efficient to use over full matrices, especially if you
+/// have to deal with the decomposed quantities often.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[repr(C)]
+pub struct TypedRigidTransform3D<T, U> {
+    pub rotation: TypedRotation3D<T, U, U>,
+    pub translation: TypedVector3D<T, U>,
+}
+
+pub type RigidTransform3D<T> = TypedRigidTransform3D<T, UnknownUnit>;
+
+impl<T: Float + ApproxEq<T>, U> TypedRigidTransform3D<T, U> {
+    /// Construct a new rigid transformation, where the `rotation` applies first
+    pub fn new(rotation: TypedRotation3D<T, U, U>, translation: TypedVector3D<T, U>) -> Self {
+        Self {
+            rotation,
+            translation,
+        }
+    }
+
+    /// Construct a new rigid transformation, where the `translation` applies first
+    pub fn new_from_reversed(
+        translation: TypedVector3D<T, U>,
+        rotation: TypedRotation3D<T, U, U>,
+    ) -> Self {
+        (Self {
+            rotation,
+            translation,
+        })
+        .reverse()
+    }
+
+    pub fn from_rotation(rotation: TypedRotation3D<T, U, U>) -> Self {
+        Self {
+            rotation,
+            translation: TypedVector3D::zero(),
+        }
+    }
+
+    pub fn from_translation(translation: TypedVector3D<T, U>) -> Self {
+        Self {
+            translation,
+            rotation: TypedRotation3D::identity(),
+        }
+    }
+
+    /// Provide the equivalent rigid transformation obtained by applying self's translation first
+    /// and rotation second
+    pub fn reverse(&self) -> Self {
+        // R * T
+        //   = R * T * (R^-1 * R)
+        //   = (R * T * R^-1) * R
+        //   = T' * R
+        //
+        // T' = (R * T * R^-1) is also a translation matrix
+        // It is equivalent to the translation matrix obtained by rotating the
+        // translation by R
+
+        let translation = self.rotation.rotate_vector3d(&self.translation);
+        Self {
+            rotation: self.rotation,
+            translation,
+        }
+    }
+
+    /// Decompose this into a position and an orientation to be applied in the opposite order
+    pub fn decompose_reversed(&self) -> (TypedVector3D<T, U>, TypedRotation3D<T, U, U>) {
+        // self = T * R
+        //      = R * R^-1 * T * R
+        //      = R * (R^-1 * T * R)
+        //      = R * T'
+        //
+        // T' = (R^-1 * T * R) is T rotated by R^-1
+
+        let translation = self.rotation.inverse().rotate_vector3d(&self.translation);
+        (translation, self.rotation)
+    }
+
+    /// Returns the multiplication of the two transforms such that
+    /// other's transformation applies after self's transformation.
+    ///
+    /// i.e., this produces `other * self`, postmultiplying self to other
+    pub fn post_mul(&self, other: &Self) -> Self {
+        // self = T1 * R1
+        // other = T2 * R2
+        // result = T2 * R2 * T1 * R1
+        //        = T2 * R2 * R1 * R1^-1 * T1 * R1
+        //        = T2 * R2 * R1 * (R1^-1 * T1 * R1)
+        //        = T2 * R' * T'
+        //        = T2 * R' * T' * R'^-1 * R'
+        //        = T2 * (R' * T' * R'^-1) * R'
+        //        = T2 * T'' * R'
+        //        = T'' * R'
+        //
+        // (R1^-1 * T1 * R1) = T' = T1 rotated by R1^-1
+        // R2 * R1  = R'
+        // (R' * T' * R'^-1) = T'' = T' rotated by R'
+        // T2 * T'' = T''' = T2 + T'
+
+        let t_prime = self.rotation.inverse().rotate_vector3d(&self.translation);
+        let r_prime = self.rotation.post_rotate(&other.rotation);
+        let t_prime2 = r_prime.rotate_vector3d(&t_prime);
+        let t_prime3 = t_prime2 + other.translation;
+        Self {
+            rotation: r_prime,
+            translation: t_prime3,
+        }
+    }
+
+    /// Returns the multiplication of the two transforms such that
+    /// self's transformation applies after other's transformation.
+    ///
+    /// i.e., this produces `self * other`, premultiplying self to other
+    pub fn pre_mul(&self, other: &Self) -> Self {
+        other.post_mul(&self)
+    }
+
+    /// Inverts the transformation
+    pub fn inverse(&self) -> Self {
+        // result = (self)^-1
+        //        = (T * R)^-1
+        //        = R^-1 * T^-1
+        //        = R^-1 * T^-1 * R * R^-1
+        //        = (R^-1 * T^-1 * R) * R^-1
+        //        = T' * R'
+        //
+        // T' = (R^-1 * T^-1 * R) = (-T) rotated by R^-1
+        // R' = R^-1
+        //
+        // An easier way of writing this is to use new_from_reversed() with R^-1 and T^-1
+
+        Self::new_from_reversed(-self.translation, self.rotation.inverse())
+    }
+
+    pub fn to_transform(&self) -> TypedTransform3D<T, U, U>
+    where
+        T: Trig,
+    {
+        self.translation
+            .to_transform()
+            .pre_mul(&self.rotation.to_transform())
+    }
+}
+
+impl<T: Float + ApproxEq<T>, U> From<TypedRotation3D<T, U, U>> for TypedRigidTransform3D<T, U> {
+    fn from(rot: TypedRotation3D<T, U, U>) -> Self {
+        Self::from_rotation(rot)
+    }
+}
+
+impl<T: Float + ApproxEq<T>, U> From<TypedVector3D<T, U>> for TypedRigidTransform3D<T, U> {
+    fn from(t: TypedVector3D<T, U>) -> Self {
+        Self::from_translation(t)
+    }
+}

--- a/src/rigid.rs
+++ b/src/rigid.rs
@@ -14,16 +14,17 @@ use {TypedRotation3D, TypedTransform3D, TypedVector3D, UnknownUnit};
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(C)]
-pub struct TypedRigidTransform3D<T, U> {
-    pub rotation: TypedRotation3D<T, U, U>,
-    pub translation: TypedVector3D<T, U>,
+pub struct TypedRigidTransform3D<T, Src, Dst> {
+    pub rotation: TypedRotation3D<T, Src, Dst>,
+    pub translation: TypedVector3D<T, Dst>,
 }
 
-pub type RigidTransform3D<T> = TypedRigidTransform3D<T, UnknownUnit>;
+pub type RigidTransform3D<T> = TypedRigidTransform3D<T, UnknownUnit, UnknownUnit>;
 
-impl<T: Float + ApproxEq<T>, U> TypedRigidTransform3D<T, U> {
+impl<T: Float + ApproxEq<T>, Src, Dst> TypedRigidTransform3D<T, Src, Dst> {
     /// Construct a new rigid transformation, where the `rotation` applies first
-    pub fn new(rotation: TypedRotation3D<T, U, U>, translation: TypedVector3D<T, U>) -> Self {
+    #[inline]
+    pub fn new(rotation: TypedRotation3D<T, Src, Dst>, translation: TypedVector3D<T, Dst>) -> Self {
         Self {
             rotation,
             translation,
@@ -31,6 +32,7 @@ impl<T: Float + ApproxEq<T>, U> TypedRigidTransform3D<T, U> {
     }
 
     /// Construct an identity transform
+    #[inline]
     pub fn identity() -> Self {
         Self {
             rotation: TypedRotation3D::identity(),
@@ -39,34 +41,11 @@ impl<T: Float + ApproxEq<T>, U> TypedRigidTransform3D<T, U> {
     }
 
     /// Construct a new rigid transformation, where the `translation` applies first
+    #[inline]
     pub fn new_from_reversed(
-        translation: TypedVector3D<T, U>,
-        rotation: TypedRotation3D<T, U, U>,
+        translation: TypedVector3D<T, Src>,
+        rotation: TypedRotation3D<T, Src, Dst>,
     ) -> Self {
-        (Self {
-            rotation,
-            translation,
-        })
-        .reverse()
-    }
-
-    pub fn from_rotation(rotation: TypedRotation3D<T, U, U>) -> Self {
-        Self {
-            rotation,
-            translation: TypedVector3D::zero(),
-        }
-    }
-
-    pub fn from_translation(translation: TypedVector3D<T, U>) -> Self {
-        Self {
-            translation,
-            rotation: TypedRotation3D::identity(),
-        }
-    }
-
-    /// Provide the equivalent rigid transformation obtained by applying self's translation first
-    /// and rotation second
-    pub fn reverse(&self) -> Self {
         // R * T
         //   = R * T * (R^-1 * R)
         //   = (R * T * R^-1) * R
@@ -76,15 +55,34 @@ impl<T: Float + ApproxEq<T>, U> TypedRigidTransform3D<T, U> {
         // It is equivalent to the translation matrix obtained by rotating the
         // translation by R
 
-        let translation = self.rotation.rotate_vector3d(&self.translation);
+        let translation = rotation.rotate_vector3d(&translation);
         Self {
-            rotation: self.rotation,
+            rotation,
             translation,
         }
     }
 
-    /// Decompose this into a position and an orientation to be applied in the opposite order
-    pub fn decompose_reversed(&self) -> (TypedVector3D<T, U>, TypedRotation3D<T, U, U>) {
+    #[inline]
+    pub fn from_rotation(rotation: TypedRotation3D<T, Src, Dst>) -> Self {
+        Self {
+            rotation,
+            translation: TypedVector3D::zero(),
+        }
+    }
+
+    #[inline]
+    pub fn from_translation(translation: TypedVector3D<T, Dst>) -> Self {
+        Self {
+            translation,
+            rotation: TypedRotation3D::identity(),
+        }
+    }
+
+    /// Decompose this into a translation and an rotation to be applied in the opposite order
+    ///
+    /// i.e., the translation is applied _first_
+    #[inline]
+    pub fn decompose_reversed(&self) -> (TypedVector3D<T, Src>, TypedRotation3D<T, Src, Dst>) {
         // self = T * R
         //      = R * R^-1 * T * R
         //      = R * (R^-1 * T * R)
@@ -100,7 +98,11 @@ impl<T: Float + ApproxEq<T>, U> TypedRigidTransform3D<T, U> {
     /// other's transformation applies after self's transformation.
     ///
     /// i.e., this produces `other * self`, postmultiplying self to other
-    pub fn post_mul(&self, other: &Self) -> Self {
+    #[inline]
+    pub fn post_mul<Dst2>(
+        &self,
+        other: &TypedRigidTransform3D<T, Dst, Dst2>,
+    ) -> TypedRigidTransform3D<T, Src, Dst2> {
         // self = T1 * R1
         // other = T2 * R2
         // result = T2 * R2 * T1 * R1
@@ -117,11 +119,14 @@ impl<T: Float + ApproxEq<T>, U> TypedRigidTransform3D<T, U> {
         // (R' * T' * R'^-1) = T'' = T' rotated by R'
         // T2 * T'' = T''' = T2 + T'
 
-        let t_prime = self.rotation.inverse().rotate_vector3d(&self.translation);
+        let t_prime = self
+            .rotation
+            .inverse()
+            .rotate_vector3d(&self.translation);
         let r_prime = self.rotation.post_rotate(&other.rotation);
         let t_prime2 = r_prime.rotate_vector3d(&t_prime);
         let t_prime3 = t_prime2 + other.translation;
-        Self {
+        TypedRigidTransform3D {
             rotation: r_prime,
             translation: t_prime3,
         }
@@ -131,12 +136,17 @@ impl<T: Float + ApproxEq<T>, U> TypedRigidTransform3D<T, U> {
     /// self's transformation applies after other's transformation.
     ///
     /// i.e., this produces `self * other`, premultiplying self to other
-    pub fn pre_mul(&self, other: &Self) -> Self {
+    #[inline]
+    pub fn pre_mul<Src2>(
+        &self,
+        other: &TypedRigidTransform3D<T, Src2, Src>,
+    ) -> TypedRigidTransform3D<T, Src2, Dst> {
         other.post_mul(&self)
     }
 
     /// Inverts the transformation
-    pub fn inverse(&self) -> Self {
+    #[inline]
+    pub fn inverse(&self) -> TypedRigidTransform3D<T, Dst, Src> {
         // result = (self)^-1
         //        = (T * R)^-1
         //        = R^-1 * T^-1
@@ -149,10 +159,13 @@ impl<T: Float + ApproxEq<T>, U> TypedRigidTransform3D<T, U> {
         //
         // An easier way of writing this is to use new_from_reversed() with R^-1 and T^-1
 
-        Self::new_from_reversed(-self.translation, self.rotation.inverse())
+        TypedRigidTransform3D::new_from_reversed(
+            -self.translation,
+            self.rotation.inverse(),
+        )
     }
 
-    pub fn to_transform(&self) -> TypedTransform3D<T, U, U>
+    pub fn to_transform(&self) -> TypedTransform3D<T, Src, Dst>
     where
         T: Trig,
     {
@@ -162,14 +175,18 @@ impl<T: Float + ApproxEq<T>, U> TypedRigidTransform3D<T, U> {
     }
 }
 
-impl<T: Float + ApproxEq<T>, U> From<TypedRotation3D<T, U, U>> for TypedRigidTransform3D<T, U> {
-    fn from(rot: TypedRotation3D<T, U, U>) -> Self {
+impl<T: Float + ApproxEq<T>, Src, Dst> From<TypedRotation3D<T, Src, Dst>>
+    for TypedRigidTransform3D<T, Src, Dst>
+{
+    fn from(rot: TypedRotation3D<T, Src, Dst>) -> Self {
         Self::from_rotation(rot)
     }
 }
 
-impl<T: Float + ApproxEq<T>, U> From<TypedVector3D<T, U>> for TypedRigidTransform3D<T, U> {
-    fn from(t: TypedVector3D<T, U>) -> Self {
+impl<T: Float + ApproxEq<T>, Src, Dst> From<TypedVector3D<T, Dst>>
+    for TypedRigidTransform3D<T, Src, Dst>
+{
+    fn from(t: TypedVector3D<T, Dst>) -> Self {
         Self::from_translation(t)
     }
 }

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -560,7 +560,7 @@ where
         self.rotate_point3d(&point.to_3d()).xy()
     }
 
-    /// Returns the given 3d vector transformed by this rotation then projected on the xy plane.
+    /// Returns the given 3d vector transformed by this rotation.
     ///
     /// The input vector must be use the unit Src, and the returned point has the unit Dst.
     #[inline]

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -16,6 +16,7 @@ use point::{TypedPoint2D, TypedPoint3D, point2, point3};
 use size::{TypedSize2D, size2};
 use scale::TypedScale;
 use transform2d::TypedTransform2D;
+use transform3d::TypedTransform3D;
 use trig::Trig;
 use Angle;
 use num::*;
@@ -633,6 +634,25 @@ impl<T: Copy, U> TypedVector3D<T, U> {
     #[inline]
     pub fn to_2d(&self) -> TypedVector2D<T, U> {
         self.xy()
+    }
+}
+
+impl<T, U> TypedVector3D<T, U>
+where
+    T: Copy
+        + Clone
+        + Add<T, Output = T>
+        + Mul<T, Output = T>
+        + Div<T, Output = T>
+        + Sub<T, Output = T>
+        + Trig
+        + PartialOrd
+        + One
+        + Zero
+        + Neg<Output = T> {
+    #[inline]
+    pub fn to_transform(&self) -> TypedTransform3D<T, U, U> {
+        TypedTransform3D::create_translation(self.x, self.y, self.z)
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -15,6 +15,7 @@ use mint;
 use point::{TypedPoint2D, TypedPoint3D, point2, point3};
 use size::{TypedSize2D, size2};
 use scale::TypedScale;
+use transform2d::TypedTransform2D;
 use trig::Trig;
 use Angle;
 use num::*;
@@ -143,6 +144,24 @@ impl<T: Copy, U> TypedVector2D<T, U> {
     #[inline]
     pub fn to_tuple(&self) -> (T, T) {
         (self.x, self.y)
+    }
+}
+
+impl<T, U> TypedVector2D<T, U>
+where
+    T: Copy
+        + Clone
+        + Add<T, Output = T>
+        + Mul<T, Output = T>
+        + Div<T, Output = T>
+        + Sub<T, Output = T>
+        + Trig
+        + PartialOrd
+        + One
+        + Zero {
+    #[inline]
+    pub fn to_transform(&self) -> TypedTransform2D<T, U, U> {
+        TypedTransform2D::create_translation(self.x, self.y)
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -137,6 +137,12 @@ impl<T: Copy, U> TypedVector2D<T, U> {
         vec2(p.x, p.y)
     }
 
+    /// Cast the unit
+    #[inline]
+    pub fn cast_unit<V>(&self) -> TypedVector2D<T, V> {
+        vec2(self.x, self.y)
+    }
+
     #[inline]
     pub fn to_array(&self) -> [T; 2] {
         [self.x, self.y]


### PR DESCRIPTION
I need this for implementing WebXR in Servo. The type can be implemented out-of-tree as well, but it feels appropriate to have it here.

I wasn't quite sure what to name it or if I should have called it `TypedRigidTransform3D`. I haven't written the 2D version because I don't need it, but it should actually be a straightforward copy-paste with the 3s changed to 2s (since the matrix math doesn't change). I'll add it on request.

The tests do help assure me that the math is right, but I would like to have some scrutiny there.

If this is going to take a while to review, let me know and I can try landing a temporary version of this in Servo so I can continue with my work.

r? @pcwalton @nical

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/328)
<!-- Reviewable:end -->
