### PR TITLE
From/Into implementation for tuples

### DIFF
--- a/src/point.rs
+++ b/src/point.rs
@@ -416,6 +416,18 @@ impl<T: Copy, U> From<[T; 2]> for TypedPoint2D<T, U> {
     }
 }
 
+impl<T: Copy, U> Into<(T, T)> for TypedPoint2D<T, U> {
+    fn into(self) -> (T, T) {
+        self.to_tuple()
+    }
+}
+
+impl<T: Copy, U> From<(T, T)> for TypedPoint2D<T, U> {
+    fn from(tuple: (T, T)) -> Self {
+        point2(tuple.0, tuple.1)
+    }
+}
+
 /// A 3d Point tagged with a unit.
 #[derive(EuclidMatrix)]
 #[repr(C)]
@@ -801,6 +813,18 @@ impl<T: Copy, U> Into<[T; 3]> for TypedPoint3D<T, U> {
 impl<T: Copy, U> From<[T; 3]> for TypedPoint3D<T, U> {
     fn from(array: [T; 3]) -> Self {
         point3(array[0], array[1], array[2])
+    }
+}
+
+impl<T: Copy, U> Into<(T, T, T)> for TypedPoint3D<T, U> {
+    fn into(self) -> (T, T, T) {
+        self.to_tuple()
+    }
+}
+
+impl<T: Copy, U> From<(T, T, T)> for TypedPoint3D<T, U> {
+    fn from(tuple: (T, T, T)) -> Self {
+        point3(tuple.0, tuple.1, tuple.2)
     }
 }
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -385,6 +385,29 @@ impl<T, U> Into<mint::Vector2<T>> for TypedSize2D<T, U> {
     }
 }
 
+impl<T: Copy, U> Into<[T; 2]> for TypedSize2D<T, U> {
+    fn into(self) -> [T; 2] {
+        self.to_array()
+    }
+}
+
+impl<T: Copy, U> From<[T; 2]> for TypedSize2D<T, U> {
+    fn from(array: [T; 2]) -> Self {
+        size2(array[0], array[1])
+    }
+}
+
+impl<T: Copy, U> Into<(T, T)> for TypedSize2D<T, U> {
+    fn into(self) -> (T, T) {
+        self.to_tuple()
+    }
+}
+
+impl<T: Copy, U> From<(T, T)> for TypedSize2D<T, U> {
+    fn from(tuple: (T, T)) -> Self {
+        size2(tuple.0, tuple.1)
+    }
+}
 
 #[cfg(test)]
 mod size2d {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -467,6 +467,18 @@ impl<T: Copy, U> From<[T; 2]> for TypedVector2D<T, U> {
     }
 }
 
+impl<T: Copy, U> Into<(T, T)> for TypedVector2D<T, U> {
+    fn into(self) -> (T, T) {
+        self.to_tuple()
+    }
+}
+
+impl<T: Copy, U> From<(T, T)> for TypedVector2D<T, U> {
+    fn from(tuple: (T, T)) -> Self {
+        vec2(tuple.0, tuple.1)
+    }
+}
+
 impl<T, U> TypedVector2D<T, U>
 where
     T: Signed,
@@ -942,6 +954,18 @@ impl<T: Copy, U> Into<[T; 3]> for TypedVector3D<T, U> {
 impl<T: Copy, U> From<[T; 3]> for TypedVector3D<T, U> {
     fn from(array: [T; 3]) -> Self {
         vec3(array[0], array[1], array[2])
+    }
+}
+
+impl<T: Copy, U> Into<(T, T, T)> for TypedVector3D<T, U> {
+    fn into(self) -> (T, T, T) {
+        self.to_tuple()
+    }
+}
+
+impl<T: Copy, U> From<(T, T, T)> for TypedVector3D<T, U> {
+    fn from(tuple: (T, T, T)) -> Self {
+        vec3(tuple.0, tuple.1, tuple.2)
     }
 }
 


### PR DESCRIPTION
This PR adds implementations of the From and Into trait, to convert between tuples and euclid's size/point/vector types.

From/Into array was also implemented for TypedSize for consistency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/336)
<!-- Reviewable:end -->
