### PR TITLE
Relax the threshold when testing whether a quaternion is normalized

### DIFF
--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -8,7 +8,7 @@
 // except according to those terms.
 
 use approxeq::ApproxEq;
-use num_traits::{Float, FloatConst, One, Zero};
+use num_traits::{Float, FloatConst, One, Zero, NumCast};
 use core::fmt;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, Sub, SubAssign};
 use core::marker::PhantomData;
@@ -475,8 +475,8 @@ where
     where
         T: ApproxEq<T>,
     {
-        // TODO: we might need to relax the threshold here, because of floating point imprecision.
-        self.square_norm().approx_eq(&T::one())
+        let eps = NumCast::from(1.0e-5).unwrap();
+        self.square_norm().approx_eq_eps(&T::one(), &eps)
     }
 
     /// Spherical linear interpolation between this rotation and another rotation.


### PR DESCRIPTION
Supposedly fixes #341 Unfortunately since this depends on how much numerical precision was lost from previous operations I don't have a good recipe for choosing a constant that fits all workloads. This changes it from `1e-6` to `1e-5` which I think is still small enough to easily detect cases where the quaternion is obviously not normalized while being less sensitive to precision errors than the previous threshold.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/342)
<!-- Reviewable:end -->
