### PR TITLE
Implement Default trait for Rect and SideOffsets

### DIFF
--- a/src/rect.rs
+++ b/src/rect.rs
@@ -95,6 +95,12 @@ impl<T: fmt::Display, U> fmt::Display for TypedRect<T, U> {
     }
 }
 
+impl<T: Default, U> Default for TypedRect<T, U> {
+    fn default() -> Self {
+        TypedRect::new(Default::default(), Default::default())
+    }
+}
+
 impl<T, U> TypedRect<T, U> {
     /// Constructor.
     pub fn new(origin: TypedPoint2D<T, U>, size: TypedSize2D<T, U>) -> Self {

--- a/src/side_offsets.rs
+++ b/src/side_offsets.rs
@@ -40,6 +40,18 @@ impl<T: fmt::Debug, U> fmt::Debug for TypedSideOffsets2D<T, U> {
     }
 }
 
+impl<T: Default, U> Default for TypedSideOffsets2D<T, U> {
+    fn default() -> Self {
+        TypedSideOffsets2D {
+            top: Default::default(),
+            right: Default::default(),
+            bottom: Default::default(),
+            left: Default::default(),
+            _unit: PhantomData,
+        }
+    }
+}
+
 /// The default 2D side offset type with no unit.
 pub type SideOffsets2D<T> = TypedSideOffsets2D<T, UnknownUnit>;
 


### PR DESCRIPTION
I'm working on WR display list serialization changes and @Gankro asked me implement `Default` trait for WR `DisplayItem`s.  I noticed that of the types that WR uses, implementations of `Default` are missing for these two.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/343)
<!-- Reviewable:end -->
