### PR TITLE
Nudge rustc to inline a few things more aggressively

### DIFF
--- a/src/point.rs
+++ b/src/point.rs
@@ -162,7 +162,11 @@ impl<T: Copy, U> TypedPoint2D<T, U> {
     /// Equivalent to subtracting the origin from this point.
     #[inline]
     pub fn to_vector(&self) -> TypedVector2D<T, U> {
-        vec2(self.x, self.y)
+        TypedVector2D {
+            x: self.x,
+            y: self.y,
+            _unit: PhantomData,
+        }
     }
 
     /// Swap x and y.
@@ -648,7 +652,12 @@ impl<T: Copy, U> TypedPoint3D<T, U> {
     /// Equivalent to subtracting the origin to this point.
     #[inline]
     pub fn to_vector(&self) -> TypedVector3D<T, U> {
-        vec3(self.x, self.y, self.z)
+        TypedVector3D {
+            x: self.x,
+            y: self.y,
+            z: self.z,
+            _unit: PhantomData,
+        }
     }
 
     /// Returns a 2d point using this point's x and y coordinates
@@ -980,12 +989,23 @@ impl<T: Copy, U> From<(T, T, T)> for TypedPoint3D<T, U> {
     }
 }
 
+#[inline]
 pub fn point2<T: Copy, U>(x: T, y: T) -> TypedPoint2D<T, U> {
-    TypedPoint2D::new(x, y)
+    TypedPoint2D {
+        x,
+        y,
+        _unit: PhantomData,
+    }
 }
 
+#[inline]
 pub fn point3<T: Copy, U>(x: T, y: T, z: T) -> TypedPoint3D<T, U> {
-    TypedPoint3D::new(x, y, z)
+    TypedPoint3D {
+        x,
+        y,
+        z,
+        _unit: PhantomData,
+    }
 }
 
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -161,7 +161,11 @@ impl<T: Copy, U> TypedVector2D<T, U> {
     /// Equivalent to adding this vector to the origin.
     #[inline]
     pub fn to_point(&self) -> TypedPoint2D<T, U> {
-        point2(self.x, self.y)
+        TypedPoint2D {
+            x: self.x,
+            y: self.y,
+            _unit: PhantomData,
+        }
     }
 
     /// Swap x and y.
@@ -1385,13 +1389,22 @@ impl<T: PartialEq, U> TypedVector3D<T, U> {
 /// Convenience constructor.
 #[inline]
 pub fn vec2<T, U>(x: T, y: T) -> TypedVector2D<T, U> {
-    TypedVector2D::new(x, y)
+    TypedVector2D {
+        x,
+        y,
+        _unit: PhantomData,
+    }
 }
 
 /// Convenience constructor.
 #[inline]
 pub fn vec3<T, U>(x: T, y: T, z: T) -> TypedVector3D<T, U> {
-    TypedVector3D::new(x, y, z)
+    TypedVector3D {
+        x,
+        y,
+        z,
+        _unit: PhantomData,
+    }
 }
 
 #[inline]


### PR DESCRIPTION
Rustc seems to be a bit shy about cross-crate inlining. It looks like even with thin lto inlined functions inside of inlined functions don't necessarily get inlined even for trivial things like `to_vector()` calling `vec2()` calling `TypedVector2D::new`.

This patch removes a bunch of instructions in a piece of code I was profiling earlier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/347)
<!-- Reviewable:end -->
