### PR TITLE
A few non-breaking changes

### DIFF
--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -220,7 +220,7 @@ where
 {
     /// Inflates the box by the specified sizes on each side respectively.
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn inflate(&self, width: T, height: T) -> Self {
         TypedBox2D {
             min: point2(self.min.x - width, self.min.y - height),
@@ -506,7 +506,7 @@ where
     /// avoid pixel rounding errors.
     /// Note that this is *not* rounding to nearest integer if the values are negative.
     /// They are always rounding as floor(n + 0.5).
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn round(&self) -> Self {
         TypedBox2D::new(self.min.round(), self.max.round())
     }
@@ -518,7 +518,7 @@ where
 {
     /// Return a box with faces/edges rounded to integer coordinates, such that
     /// the original box contains the resulting box.
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn round_in(&self) -> Self {
         let min = self.min.ceil();
         let max = self.max.floor();
@@ -527,7 +527,7 @@ where
 
     /// Return a box with faces/edges rounded to integer coordinates, such that
     /// the original box is contained in the resulting box.
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn round_out(&self) -> Self {
         let min = self.min.floor();
         let max = self.max.ceil();

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -162,7 +162,7 @@ where
 {
     /// Returns the same box3d, translated by a vector.
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn translate(&self, by: &TypedVector3D<T, U>) -> Self {
         Self::new(self.min + *by, self.max + *by)
     }
@@ -219,7 +219,7 @@ where
 {
     /// Inflates the box by the specified sizes on each side respectively.
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn inflate(&self, width: T, height: T, depth: T) -> Self {
         TypedBox3D::new(
             TypedPoint3D::new(self.min.x - width, self.min.y - height, self.min.z - depth),
@@ -228,7 +228,7 @@ where
     }
 
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn inflate_typed(&self, width: Length<T, U>, height: Length<T, U>, depth: Length<T, U>) -> Self {
         self.inflate(width.get(), height.get(), depth.get())
     }
@@ -507,7 +507,7 @@ where
     /// avoid pixel rounding errors.
     /// Note that this is *not* rounding to nearest integer if the values are negative.
     /// They are always rounding as floor(n + 0.5).
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn round(&self) -> Self {
         TypedBox3D::new(self.min.round(), self.max.round())
     }
@@ -519,7 +519,7 @@ where
 {
     /// Return a box3d with faces/edges rounded to integer coordinates, such that
     /// the original box3d contains the resulting box3d.
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn round_in(&self) -> Self {
         TypedBox3D {
             min: self.min.ceil(),
@@ -529,7 +529,7 @@ where
 
     /// Return a box3d with faces/edges rounded to integer coordinates, such that
     /// the original box3d is contained in the resulting box3d.
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn round_out(&self) -> Self {
         TypedBox3D {
             min: self.min.floor(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![cfg_attr(feature = "unstable", feature(fn_must_use))]
 #![cfg_attr(not(test), no_std)]
 
 //! A collection of strongly typed math tools for computer graphics with an inclination

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ pub use box3d::{box3d, Box3D, TypedBox3D};
 pub use translation::{TypedTranslation2D, TypedTranslation3D};
 pub use rotation::{Angle, Rotation2D, Rotation3D, TypedRotation2D, TypedRotation3D};
 pub use side_offsets::{SideOffsets2D, TypedSideOffsets2D};
-pub use size::{Size2D, TypedSize2D, size2};
+pub use size::{Size2D, TypedSize2D, TypedSize3D, size2, size3};
 pub use trig::Trig;
 
 #[macro_use]
@@ -137,3 +137,26 @@ pub type ScaleFactor<T, Src, Dst> = TypedScale<T, Src, Dst>;
 /// Temporary alias to facilitate the transition to the new naming scheme
 #[deprecated]
 pub use Angle as Radians;
+
+pub mod default {
+    use super::*;
+
+    pub type Point2D<T> = TypedPoint2D<T, UnknownUnit>;
+    pub type Point3D<T> = TypedPoint3D<T, UnknownUnit>;
+    pub type Vector2D<T> = TypedVector2D<T, UnknownUnit>;
+    pub type Vector3D<T> = TypedVector3D<T, UnknownUnit>;
+    pub type Vector4D<T> = HomogeneousVector<T, UnknownUnit>;
+    pub type Size2D<T> = TypedSize2D<T, UnknownUnit>;
+    pub type Size3D<T> = TypedSize3D<T, UnknownUnit>;
+    pub type Rect<T> = TypedRect<T, UnknownUnit>;
+    pub type Box2D<T> = TypedBox2D<T, UnknownUnit>;
+    pub type Box3D<T> = TypedBox3D<T, UnknownUnit>;
+    pub type SideOffsets2D<T> = TypedSideOffsets2D<T, UnknownUnit>;
+    pub type Tranform2D<T> = TypedTransform2D<T, UnknownUnit, UnknownUnit>;
+    pub type Tranform3D<T> = TypedTransform3D<T, UnknownUnit, UnknownUnit>;
+    pub type Rotation2D<T> = TypedRotation2D<T, UnknownUnit, UnknownUnit>;
+    pub type Rotation3D<T> = TypedRotation3D<T, UnknownUnit, UnknownUnit>;
+    pub type Translation3D<T> = TypedTranslation3D<T, UnknownUnit, UnknownUnit>;
+    pub type Scale<T> = TypedScale<T, UnknownUnit, UnknownUnit>;
+    pub type RigidTransform3D<T> = TypedRigidTransform3D<T, UnknownUnit, UnknownUnit>;
+}

--- a/src/point.rs
+++ b/src/point.rs
@@ -332,7 +332,7 @@ impl<T: Round, U> TypedPoint2D<T, U> {
     /// This behavior is preserved for negative values (unlike the basic cast).
     /// For example `{ -0.1, -0.8 }.round() == { 0.0, -1.0 }`.
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn round(&self) -> Self {
         point2(self.x.round(), self.y.round())
     }
@@ -344,7 +344,7 @@ impl<T: Ceil, U> TypedPoint2D<T, U> {
     /// This behavior is preserved for negative values (unlike the basic cast).
     /// For example `{ -0.1, -0.8 }.ceil() == { 0.0, 0.0 }`.
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn ceil(&self) -> Self {
         point2(self.x.ceil(), self.y.ceil())
     }
@@ -356,7 +356,7 @@ impl<T: Floor, U> TypedPoint2D<T, U> {
     /// This behavior is preserved for negative values (unlike the basic cast).
     /// For example `{ -0.1, -0.8 }.floor() == { -1.0, -1.0 }`.
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn floor(&self) -> Self {
         point2(self.x.floor(), self.y.floor())
     }
@@ -832,7 +832,7 @@ impl<T: Round, U> TypedPoint3D<T, U> {
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn round(&self) -> Self {
         point3(self.x.round(), self.y.round(), self.z.round())
     }
@@ -843,7 +843,7 @@ impl<T: Ceil, U> TypedPoint3D<T, U> {
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn ceil(&self) -> Self {
         point3(self.x.ceil(), self.y.ceil(), self.z.ceil())
     }
@@ -854,7 +854,7 @@ impl<T: Floor, U> TypedPoint3D<T, U> {
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn floor(&self) -> Self {
         point3(self.x.floor(), self.y.floor(), self.z.floor())
     }

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -207,7 +207,7 @@ where
 
     /// Returns the same rectangle, translated by a vector.
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn translate(&self, by: &TypedVector2D<T, U>) -> Self {
         Self::new(self.origin + *by, self.size)
     }
@@ -232,7 +232,7 @@ where
     }
 
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn inflate(&self, width: T, height: T) -> Self {
         TypedRect::new(
             TypedPoint2D::new(self.origin.x - width, self.origin.y - height),
@@ -244,7 +244,7 @@ where
     }
 
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn inflate_typed(&self, width: Length<T, U>, height: Length<T, U>) -> Self {
         self.inflate(width.get(), height.get())
     }
@@ -273,7 +273,7 @@ where
     }
 
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn translate_by_size(&self, size: &TypedSize2D<T, U>) -> Self {
         self.translate(&size.to_vector())
     }
@@ -527,7 +527,7 @@ impl<T: Floor + Ceil + Round + Add<T, Output = T> + Sub<T, Output = T>, U> Typed
     /// avoid pixel rounding errors.
     /// Note that this is *not* rounding to nearest integer if the values are negative.
     /// They are always rounding as floor(n + 0.5).
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn round(&self) -> Self {
         let origin = self.origin.round();
         let size = self.origin.add_size(&self.size).round() - origin;
@@ -536,7 +536,7 @@ impl<T: Floor + Ceil + Round + Add<T, Output = T> + Sub<T, Output = T>, U> Typed
 
     /// Return a rectangle with edges rounded to integer coordinates, such that
     /// the original rectangle contains the resulting rectangle.
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn round_in(&self) -> Self {
         let origin = self.origin.ceil();
         let size = self.origin.add_size(&self.size).floor() - origin;
@@ -545,7 +545,7 @@ impl<T: Floor + Ceil + Round + Add<T, Output = T> + Sub<T, Output = T>, U> Typed
 
     /// Return a rectangle with edges rounded to integer coordinates, such that
     /// the original rectangle is contained in the resulting rectangle.
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn round_out(&self) -> Self {
         let origin = self.origin.floor();
         let size = self.origin.add_size(&self.size).ceil() - origin;

--- a/src/transform2d.rs
+++ b/src/transform2d.rs
@@ -311,6 +311,7 @@ where T: Copy + Clone +
     /// applies after self's transformation.
     ///
     /// Assuming row vectors, this is equivalent to self * mat
+    #[must_use]
     pub fn post_transform<NewDst>(&self, mat: &TypedTransform2D<T, Dst, NewDst>) -> TypedTransform2D<T, Src, NewDst> {
         TypedTransform2D::row_major(
             self.m11 * mat.m11 + self.m12 * mat.m21,
@@ -327,6 +328,7 @@ where T: Copy + Clone +
     ///
     /// Assuming row vectors, this is equivalent to mat * self
     #[inline]
+    #[must_use]
     pub fn pre_transform<NewSrc>(&self, mat: &TypedTransform2D<T, NewSrc, Src>) -> TypedTransform2D<T, NewSrc, Dst> {
         mat.post_transform(self)
     }
@@ -336,6 +338,7 @@ where T: Copy + Clone +
     ///
     /// Assuming row vectors, this is equivalent to self * mat
     #[deprecated]
+    #[must_use]
     pub fn post_mul<NewDst>(&self, mat: &TypedTransform2D<T, Dst, NewDst>) -> TypedTransform2D<T, Src, NewDst> {
         self.post_transform(mat)
     }
@@ -345,6 +348,7 @@ where T: Copy + Clone +
     ///
     /// Assuming row vectors, this is equivalent to mat * self
     #[deprecated]
+    #[must_use]
     pub fn pre_mul<NewSrc>(&self, mat: &TypedTransform2D<T, NewSrc, Src>) -> TypedTransform2D<T, NewSrc, Dst> {
         self.pre_transform(mat)
     }
@@ -361,15 +365,15 @@ where T: Copy + Clone +
     }
 
     /// Applies a translation after self's transformation and returns the resulting transform.
-    #[cfg_attr(feature = "unstable", must_use)]
     #[inline]
+    #[must_use]
     pub fn post_translate(&self, v: TypedVector2D<T, Dst>) -> Self {
         self.post_transform(&TypedTransform2D::create_translation(v.x, v.y))
     }
 
     /// Applies a translation before self's transformation and returns the resulting transform.
-    #[cfg_attr(feature = "unstable", must_use)]
     #[inline]
+    #[must_use]
     pub fn pre_translate(&self, v: TypedVector2D<T, Src>) -> Self {
         self.pre_transform(&TypedTransform2D::create_translation(v.x, v.y))
     }
@@ -385,15 +389,15 @@ where T: Copy + Clone +
     }
 
     /// Applies a scale after self's transformation and returns the resulting transform.
-    #[cfg_attr(feature = "unstable", must_use)]
     #[inline]
+    #[must_use]
     pub fn post_scale(&self, x: T, y: T) -> Self {
         self.post_transform(&TypedTransform2D::create_scale(x, y))
     }
 
     /// Applies a scale before self's transformation and returns the resulting transform.
-    #[cfg_attr(feature = "unstable", must_use)]
     #[inline]
+    #[must_use]
     pub fn pre_scale(&self, x: T, y: T) -> Self {
         TypedTransform2D::row_major(
             self.m11 * x, self.m12,
@@ -417,14 +421,14 @@ where T: Copy + Clone +
 
     /// Applies a rotation after self's transformation and returns the resulting transform.
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn post_rotate(&self, theta: Angle<T>) -> Self {
         self.post_transform(&TypedTransform2D::create_rotation(theta))
     }
 
     /// Applies a rotation after self's transformation and returns the resulting transform.
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn pre_rotate(&self, theta: Angle<T>) -> Self {
         self.pre_transform(&TypedTransform2D::create_rotation(theta))
     }
@@ -433,7 +437,7 @@ where T: Copy + Clone +
     ///
     /// Assuming row vectors, this is equivalent to `p * self`
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn transform_point(&self, point: &TypedPoint2D<T, Src>) -> TypedPoint2D<T, Dst> {
         TypedPoint2D::new(point.x * self.m11 + point.y * self.m21 + self.m31,
                           point.x * self.m12 + point.y * self.m22 + self.m32)
@@ -443,7 +447,7 @@ where T: Copy + Clone +
     ///
     /// Assuming row vectors, this is equivalent to `v * self`
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn transform_vector(&self, vec: &TypedVector2D<T, Src>) -> TypedVector2D<T, Dst> {
         vec2(vec.x * self.m11 + vec.y * self.m21,
              vec.x * self.m12 + vec.y * self.m22)
@@ -452,7 +456,7 @@ where T: Copy + Clone +
     /// Returns a rectangle that encompasses the result of transforming the given rectangle by this
     /// transform.
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn transform_rect(&self, rect: &TypedRect<T, Src>) -> TypedRect<T, Dst> {
         TypedRect::from_points(&[
             self.transform_point(&rect.origin),
@@ -468,7 +472,7 @@ where T: Copy + Clone +
     }
 
     /// Returns the inverse transform if possible.
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn inverse(&self) -> Option<TypedTransform2D<T, Dst, Src>> {
         let det = self.determinant();
 

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -386,7 +386,7 @@ where T: Copy + Clone +
     /// applies after self's transformation.
     ///
     /// Assuming row vectors, this is equivalent to self * mat
-    pub fn post_mul<NewDst>(&self, mat: &TypedTransform3D<T, Dst, NewDst>) -> TypedTransform3D<T, Src, NewDst> {
+    pub fn post_transform<NewDst>(&self, mat: &TypedTransform3D<T, Dst, NewDst>) -> TypedTransform3D<T, Src, NewDst> {
         TypedTransform3D::row_major(
             self.m11 * mat.m11  +  self.m12 * mat.m21  +  self.m13 * mat.m31  +  self.m14 * mat.m41,
             self.m11 * mat.m12  +  self.m12 * mat.m22  +  self.m13 * mat.m32  +  self.m14 * mat.m42,
@@ -411,8 +411,25 @@ where T: Copy + Clone +
     /// applies before self's transformation.
     ///
     /// Assuming row vectors, this is equivalent to mat * self
+    #[inline]
+    pub fn pre_transform<NewSrc>(&self, mat: &TypedTransform3D<T, NewSrc, Src>) -> TypedTransform3D<T, NewSrc, Dst> {
+        mat.post_transform(self)
+    }
+
+    /// Returns the multiplication of the two matrices such that mat's transformation
+    /// applies after self's transformation.
+    ///
+    /// Assuming row vectors, this is equivalent to self * mat
+    pub fn post_mul<NewDst>(&self, mat: &TypedTransform3D<T, Dst, NewDst>) -> TypedTransform3D<T, Src, NewDst> {
+        self.post_transform(mat)
+    }
+
+    /// Returns the multiplication of the two matrices such that mat's transformation
+    /// applies before self's transformation.
+    ///
+    /// Assuming row vectors, this is equivalent to mat * self
     pub fn pre_mul<NewSrc>(&self, mat: &TypedTransform3D<T, NewSrc, Src>) -> TypedTransform3D<T, NewSrc, Dst> {
-        mat.post_mul(self)
+        self.pre_transform(mat)
     }
 
     /// Returns the inverse transform if possible.
@@ -656,13 +673,13 @@ where T: Copy + Clone +
     /// Returns a transform with a translation applied before self's transformation.
     #[cfg_attr(feature = "unstable", must_use)]
     pub fn pre_translate(&self, v: TypedVector3D<T, Src>) -> Self {
-        self.pre_mul(&TypedTransform3D::create_translation(v.x, v.y, v.z))
+        self.pre_transform(&TypedTransform3D::create_translation(v.x, v.y, v.z))
     }
 
     /// Returns a transform with a translation applied after self's transformation.
     #[cfg_attr(feature = "unstable", must_use)]
     pub fn post_translate(&self, v: TypedVector3D<T, Dst>) -> Self {
-        self.post_mul(&TypedTransform3D::create_translation(v.x, v.y, v.z))
+        self.post_transform(&TypedTransform3D::create_translation(v.x, v.y, v.z))
     }
 
     /// Returns a projection of this transform in 2d space.
@@ -726,7 +743,7 @@ where T: Copy + Clone +
     /// Returns a transform with a scale applied after self's transformation.
     #[cfg_attr(feature = "unstable", must_use)]
     pub fn post_scale(&self, x: T, y: T, z: T) -> Self {
-        self.post_mul(&TypedTransform3D::create_scale(x, y, z))
+        self.post_transform(&TypedTransform3D::create_scale(x, y, z))
     }
 
     /// Create a 3d rotation transform from an angle / axis.
@@ -769,13 +786,13 @@ where T: Copy + Clone +
     /// Returns a transform with a rotation applied after self's transformation.
     #[cfg_attr(feature = "unstable", must_use)]
     pub fn post_rotate(&self, x: T, y: T, z: T, theta: Angle<T>) -> Self {
-        self.post_mul(&TypedTransform3D::create_rotation(x, y, z, theta))
+        self.post_transform(&TypedTransform3D::create_rotation(x, y, z, theta))
     }
 
     /// Returns a transform with a rotation applied before self's transformation.
     #[cfg_attr(feature = "unstable", must_use)]
     pub fn pre_rotate(&self, x: T, y: T, z: T, theta: Angle<T>) -> Self {
-        self.pre_mul(&TypedTransform3D::create_rotation(x, y, z, theta))
+        self.pre_transform(&TypedTransform3D::create_rotation(x, y, z, theta))
     }
 
     /// Create a 2d skew transform.
@@ -999,7 +1016,7 @@ mod tests {
         assert_eq!(t1.transform_point3d(&point3(1.0, 1.0, 1.0)), Some(point3(2.0, 3.0, 4.0)));
         assert_eq!(t1.transform_point2d(&point2(1.0, 1.0)), Some(point2(2.0, 3.0)));
 
-        assert_eq!(t1.post_mul(&t1), Mf32::create_translation(2.0, 4.0, 6.0));
+        assert_eq!(t1.post_transform(&t1), Mf32::create_translation(2.0, 4.0, 6.0));
 
         assert!(!t1.is_2d());
         assert_eq!(Mf32::create_translation(1.0, 2.0, 3.0).to_2d(), Transform2D::create_translation(1.0, 2.0));
@@ -1016,7 +1033,7 @@ mod tests {
         assert!(r1.transform_point3d(&point3(1.0, 2.0, 3.0)).unwrap().approx_eq(&point3(2.0, -1.0, 3.0)));
         assert!(r1.transform_point2d(&point2(1.0, 2.0)).unwrap().approx_eq(&point2(2.0, -1.0)));
 
-        assert!(r1.post_mul(&r1).approx_eq(&Mf32::create_rotation(0.0, 0.0, 1.0, rad(FRAC_PI_2*2.0))));
+        assert!(r1.post_transform(&r1).approx_eq(&Mf32::create_rotation(0.0, 0.0, 1.0, rad(FRAC_PI_2*2.0))));
 
         assert!(r1.is_2d());
         assert!(r1.to_2d().approx_eq(&Transform2D::create_rotation(rad(FRAC_PI_2))));
@@ -1033,7 +1050,7 @@ mod tests {
         assert!(s1.transform_point3d(&point3(2.0, 2.0, 2.0)).unwrap().approx_eq(&point3(4.0, 6.0, 8.0)));
         assert!(s1.transform_point2d(&point2(2.0, 2.0)).unwrap().approx_eq(&point2(4.0, 6.0)));
 
-        assert_eq!(s1.post_mul(&s1), Mf32::create_scale(4.0, 9.0, 16.0));
+        assert_eq!(s1.post_transform(&s1), Mf32::create_scale(4.0, 9.0, 16.0));
 
         assert!(!s1.is_2d());
         assert_eq!(Mf32::create_scale(2.0, 3.0, 0.0).to_2d(), Transform2D::create_scale(2.0, 3.0));
@@ -1101,28 +1118,28 @@ mod tests {
     pub fn test_inverse_scale() {
         let m1 = Mf32::create_scale(1.5, 0.3, 2.1);
         let m2 = m1.inverse().unwrap();
-        assert!(m1.pre_mul(&m2).approx_eq(&Mf32::identity()));
+        assert!(m1.pre_transform(&m2).approx_eq(&Mf32::identity()));
     }
 
     #[test]
     pub fn test_inverse_translate() {
         let m1 = Mf32::create_translation(-132.0, 0.3, 493.0);
         let m2 = m1.inverse().unwrap();
-        assert!(m1.pre_mul(&m2).approx_eq(&Mf32::identity()));
+        assert!(m1.pre_transform(&m2).approx_eq(&Mf32::identity()));
     }
 
     #[test]
     pub fn test_inverse_rotate() {
         let m1 = Mf32::create_rotation(0.0, 1.0, 0.0, rad(1.57));
         let m2 = m1.inverse().unwrap();
-        assert!(m1.pre_mul(&m2).approx_eq(&Mf32::identity()));
+        assert!(m1.pre_transform(&m2).approx_eq(&Mf32::identity()));
     }
 
     #[test]
     pub fn test_inverse_transform_point_2d() {
         let m1 = Mf32::create_translation(100.0, 200.0, 0.0);
         let m2 = m1.inverse().unwrap();
-        assert!(m1.pre_mul(&m2).approx_eq(&Mf32::identity()));
+        assert!(m1.pre_transform(&m2).approx_eq(&Mf32::identity()));
 
         let p1 = point2(1000.0, 2000.0);
         let p2 = m1.transform_point2d(&p1);
@@ -1149,13 +1166,13 @@ mod tests {
 
         let a = point3(1.0, 1.0, 1.0);
 
-        assert!(r.post_mul(&t).transform_point3d(&a).unwrap().approx_eq(&point3(3.0, 2.0, 1.0)));
-        assert!(t.post_mul(&r).transform_point3d(&a).unwrap().approx_eq(&point3(4.0, -3.0, 1.0)));
-        assert!(t.post_mul(&r).transform_point3d(&a).unwrap().approx_eq(&r.transform_point3d(&t.transform_point3d(&a).unwrap()).unwrap()));
+        assert!(r.post_transform(&t).transform_point3d(&a).unwrap().approx_eq(&point3(3.0, 2.0, 1.0)));
+        assert!(t.post_transform(&r).transform_point3d(&a).unwrap().approx_eq(&point3(4.0, -3.0, 1.0)));
+        assert!(t.post_transform(&r).transform_point3d(&a).unwrap().approx_eq(&r.transform_point3d(&t.transform_point3d(&a).unwrap()).unwrap()));
 
-        assert!(r.pre_mul(&t).transform_point3d(&a).unwrap().approx_eq(&point3(4.0, -3.0, 1.0)));
-        assert!(t.pre_mul(&r).transform_point3d(&a).unwrap().approx_eq(&point3(3.0, 2.0, 1.0)));
-        assert!(t.pre_mul(&r).transform_point3d(&a).unwrap().approx_eq(&t.transform_point3d(&r.transform_point3d(&a).unwrap()).unwrap()));
+        assert!(r.pre_transform(&t).transform_point3d(&a).unwrap().approx_eq(&point3(4.0, -3.0, 1.0)));
+        assert!(t.pre_transform(&r).transform_point3d(&a).unwrap().approx_eq(&point3(3.0, 2.0, 1.0)));
+        assert!(t.pre_transform(&r).transform_point3d(&a).unwrap().approx_eq(&t.transform_point3d(&r.transform_point3d(&a).unwrap()).unwrap()));
     }
 
     #[test]
@@ -1177,7 +1194,7 @@ mod tests {
                                  -2.5, 6.0, 1.0, 1.0);
 
         let p = point3(1.0, 3.0, 5.0);
-        let p1 = m2.pre_mul(&m1).transform_point3d(&p).unwrap();
+        let p1 = m2.pre_transform(&m1).transform_point3d(&p).unwrap();
         let p2 = m2.transform_point3d(&m1.transform_point3d(&p).unwrap()).unwrap();
         assert!(p1.approx_eq(&p2));
     }

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -386,6 +386,7 @@ where T: Copy + Clone +
     /// applies after self's transformation.
     ///
     /// Assuming row vectors, this is equivalent to self * mat
+    #[must_use]
     pub fn post_transform<NewDst>(&self, mat: &TypedTransform3D<T, Dst, NewDst>) -> TypedTransform3D<T, Src, NewDst> {
         TypedTransform3D::row_major(
             self.m11 * mat.m11  +  self.m12 * mat.m21  +  self.m13 * mat.m31  +  self.m14 * mat.m41,
@@ -412,6 +413,7 @@ where T: Copy + Clone +
     ///
     /// Assuming row vectors, this is equivalent to mat * self
     #[inline]
+    #[must_use]
     pub fn pre_transform<NewSrc>(&self, mat: &TypedTransform3D<T, NewSrc, Src>) -> TypedTransform3D<T, NewSrc, Dst> {
         mat.post_transform(self)
     }
@@ -420,6 +422,7 @@ where T: Copy + Clone +
     /// applies after self's transformation.
     ///
     /// Assuming row vectors, this is equivalent to self * mat
+    #[must_use]
     pub fn post_mul<NewDst>(&self, mat: &TypedTransform3D<T, Dst, NewDst>) -> TypedTransform3D<T, Src, NewDst> {
         self.post_transform(mat)
     }
@@ -428,6 +431,7 @@ where T: Copy + Clone +
     /// applies before self's transformation.
     ///
     /// Assuming row vectors, this is equivalent to mat * self
+    #[must_use]
     pub fn pre_mul<NewSrc>(&self, mat: &TypedTransform3D<T, NewSrc, Src>) -> TypedTransform3D<T, NewSrc, Dst> {
         self.pre_transform(mat)
     }
@@ -541,7 +545,7 @@ where T: Copy + Clone +
     }
 
     /// Multiplies all of the transform's component by a scalar and returns the result.
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn mul_s(&self, x: T) -> Self {
         TypedTransform3D::row_major(
             self.m11 * x, self.m12 * x, self.m13 * x, self.m14 * x,
@@ -671,13 +675,13 @@ where T: Copy + Clone +
     }
 
     /// Returns a transform with a translation applied before self's transformation.
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn pre_translate(&self, v: TypedVector3D<T, Src>) -> Self {
         self.pre_transform(&TypedTransform3D::create_translation(v.x, v.y, v.z))
     }
 
     /// Returns a transform with a translation applied after self's transformation.
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn post_translate(&self, v: TypedVector3D<T, Dst>) -> Self {
         self.post_transform(&TypedTransform3D::create_translation(v.x, v.y, v.z))
     }
@@ -730,7 +734,7 @@ where T: Copy + Clone +
     }
 
     /// Returns a transform with a scale applied before self's transformation.
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn pre_scale(&self, x: T, y: T, z: T) -> Self {
         TypedTransform3D::row_major(
             self.m11 * x, self.m12,     self.m13,     self.m14,
@@ -741,7 +745,7 @@ where T: Copy + Clone +
     }
 
     /// Returns a transform with a scale applied after self's transformation.
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn post_scale(&self, x: T, y: T, z: T) -> Self {
         self.post_transform(&TypedTransform3D::create_scale(x, y, z))
     }
@@ -784,13 +788,13 @@ where T: Copy + Clone +
     }
 
     /// Returns a transform with a rotation applied after self's transformation.
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn post_rotate(&self, x: T, y: T, z: T, theta: Angle<T>) -> Self {
         self.post_transform(&TypedTransform3D::create_rotation(x, y, z, theta))
     }
 
     /// Returns a transform with a rotation applied before self's transformation.
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn pre_rotate(&self, x: T, y: T, z: T, theta: Angle<T>) -> Self {
         self.pre_transform(&TypedTransform3D::create_rotation(x, y, z, theta))
     }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -422,7 +422,7 @@ impl<T: Round, U> TypedVector2D<T, U> {
     /// This behavior is preserved for negative values (unlike the basic cast).
     /// For example `{ -0.1, -0.8 }.round() == { 0.0, -1.0 }`.
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn round(&self) -> Self {
         vec2(self.x.round(), self.y.round())
     }
@@ -434,7 +434,7 @@ impl<T: Ceil, U> TypedVector2D<T, U> {
     /// This behavior is preserved for negative values (unlike the basic cast).
     /// For example `{ -0.1, -0.8 }.ceil() == { 0.0, 0.0 }`.
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn ceil(&self) -> Self {
         vec2(self.x.ceil(), self.y.ceil())
     }
@@ -446,7 +446,7 @@ impl<T: Floor, U> TypedVector2D<T, U> {
     /// This behavior is preserved for negative values (unlike the basic cast).
     /// For example `{ -0.1, -0.8 }.floor() == { -1.0, -1.0 }`.
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn floor(&self) -> Self {
         vec2(self.x.floor(), self.y.floor())
     }
@@ -985,7 +985,7 @@ impl<T: Round, U> TypedVector3D<T, U> {
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn round(&self) -> Self {
         vec3(self.x.round(), self.y.round(), self.z.round())
     }
@@ -996,7 +996,7 @@ impl<T: Ceil, U> TypedVector3D<T, U> {
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn ceil(&self) -> Self {
         vec3(self.x.ceil(), self.y.ceil(), self.z.ceil())
     }
@@ -1007,7 +1007,7 @@ impl<T: Floor, U> TypedVector3D<T, U> {
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
     #[inline]
-    #[cfg_attr(feature = "unstable", must_use)]
+    #[must_use]
     pub fn floor(&self) -> Self {
         vec3(self.x.floor(), self.y.floor(), self.z.floor())
     }


### PR DESCRIPTION
 - Add pre/post_transform, deprecate pre/post_mul. This name is less ambiguous: the meaning of pre and post here is really about the semantics of the tranformation and not about the underlying matrix the latter being currently in a confusing step for a number of people.
 - Add a `default` module with type aliases for the default unit. The goal is to rename all `TypedFoo` types into `Foo` next time we commit to a breaking change and use `default::Foo` for the aliases with unknown units.
 - Remove unstable must_use annotations. They add noise to the code and aren't very useful since they only work with the nightly compiler and the unstable feature.

The first two changes will let us transition some of the names at our leasure rather than having to do it all next time we do the Big Breaking Change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/349)
<!-- Reviewable:end -->
