### PR TITLE
Rename TypedFoo types into Foo

### DIFF
--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -8,13 +8,13 @@
 // except according to those terms.
 
 use super::UnknownUnit;
-use scale::TypedScale;
+use scale::Scale;
 use num::*;
-use rect::TypedRect;
-use point::{point2, TypedPoint2D};
-use vector::{vec2, TypedVector2D};
-use side_offsets::TypedSideOffsets2D;
-use size::TypedSize2D;
+use rect::Rect;
+use point::{point2, Point2D};
+use vector::{vec2, Vector2D};
+use side_offsets::SideOffsets2D;
+use size::Size2D;
 use approxord::{min, max};
 
 use num_traits::NumCast;
@@ -32,73 +32,70 @@ use core::ops::{Add, Div, Mul, Sub};
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(bound(serialize = "T: Serialize", deserialize = "T: Deserialize<'de>")))]
-pub struct TypedBox2D<T, U> {
-    pub min: TypedPoint2D<T, U>,
-    pub max: TypedPoint2D<T, U>,
+pub struct Box2D<T, U> {
+    pub min: Point2D<T, U>,
+    pub max: Point2D<T, U>,
 }
 
-/// The default box 2d type with no unit.
-pub type Box2D<T> = TypedBox2D<T, UnknownUnit>;
-
-impl<T: Hash, U> Hash for TypedBox2D<T, U> {
+impl<T: Hash, U> Hash for Box2D<T, U> {
     fn hash<H: Hasher>(&self, h: &mut H) {
         self.min.hash(h);
         self.max.hash(h);
     }
 }
 
-impl<T: Copy, U> Copy for TypedBox2D<T, U> {}
+impl<T: Copy, U> Copy for Box2D<T, U> {}
 
-impl<T: Copy, U> Clone for TypedBox2D<T, U> {
+impl<T: Copy, U> Clone for Box2D<T, U> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<T: PartialEq, U> PartialEq<TypedBox2D<T, U>> for TypedBox2D<T, U> {
+impl<T: PartialEq, U> PartialEq<Box2D<T, U>> for Box2D<T, U> {
     fn eq(&self, other: &Self) -> bool {
         self.min.eq(&other.min) && self.max.eq(&other.max)
     }
 }
 
-impl<T: Eq, U> Eq for TypedBox2D<T, U> {}
+impl<T: Eq, U> Eq for Box2D<T, U> {}
 
-impl<T: fmt::Debug, U> fmt::Debug for TypedBox2D<T, U> {
+impl<T: fmt::Debug, U> fmt::Debug for Box2D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "TypedBox2D({:?}, {:?})", self.min, self.max)
+        write!(f, "Box2D({:?}, {:?})", self.min, self.max)
     }
 }
 
-impl<T: fmt::Display, U> fmt::Display for TypedBox2D<T, U> {
+impl<T: fmt::Display, U> fmt::Display for Box2D<T, U> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(formatter, "Box2D({}, {})", self.min, self.max)
     }
 }
 
-impl<T, U> TypedBox2D<T, U> {
+impl<T, U> Box2D<T, U> {
     /// Constructor.
-    pub fn new(min: TypedPoint2D<T, U>, max: TypedPoint2D<T, U>) -> Self {
-        TypedBox2D {
+    pub fn new(min: Point2D<T, U>, max: Point2D<T, U>) -> Self {
+        Box2D {
             min,
             max,
         }
     }
 }
 
-impl<T, U> TypedBox2D<T, U>
+impl<T, U> Box2D<T, U>
 where
     T: Copy + Zero + PartialOrd,
 {
     /// Creates a Box2D of the given size, at offset zero.
     #[inline]
-    pub fn from_size(size: TypedSize2D<T, U>) -> Self {
-        let zero = TypedPoint2D::zero();
+    pub fn from_size(size: Size2D<T, U>) -> Self {
+        let zero = Point2D::zero();
         let point = size.to_vector().to_point();
-        TypedBox2D::from_points(&[zero, point])
+        Box2D::from_points(&[zero, point])
     }
 }
 
-impl<T, U> TypedBox2D<T, U>
+impl<T, U> Box2D<T, U>
 where
     T: Copy + PartialOrd,
 {
@@ -131,7 +128,7 @@ where
     /// The result is a negative box if the boxes do not intersect.
     #[inline]
     pub fn intersection(&self, other: &Self) -> Self {
-        TypedBox2D {
+        Box2D {
             min: point2(
                 max(self.min.x, other.min.x),
                 max(self.min.y, other.min.y),
@@ -156,18 +153,18 @@ where
     }
 }
 
-impl<T, U> TypedBox2D<T, U>
+impl<T, U> Box2D<T, U>
 where
     T: Copy + Add<T, Output = T>,
 {
     /// Returns the same box, translated by a vector.
     #[inline]
-    pub fn translate(&self, by: &TypedVector2D<T, U>) -> Self {
+    pub fn translate(&self, by: &Vector2D<T, U>) -> Self {
         Self::new(self.min + *by, self.max + *by)
     }
 }
 
-impl<T, U> TypedBox2D<T, U>
+impl<T, U> Box2D<T, U>
 where
     T: Copy + PartialOrd + Zero,
 {
@@ -175,13 +172,13 @@ where
     /// in the box if they are on the front, left or top faces, but outside if they
     /// are on the back, right or bottom faces.
     #[inline]
-    pub fn contains(&self, p: &TypedPoint2D<T, U>) -> bool {
+    pub fn contains(&self, p: &Point2D<T, U>) -> bool {
         self.min.x <= p.x && p.x < self.max.x
             && self.min.y <= p.y && p.y < self.max.y
     }
 }
 
-impl<T, U> TypedBox2D<T, U>
+impl<T, U> Box2D<T, U>
 where
     T: Copy + PartialOrd + Zero + Sub<T, Output = T>,
 {
@@ -196,25 +193,25 @@ where
     }
 }
 
-impl<T, U> TypedBox2D<T, U>
+impl<T, U> Box2D<T, U>
 where
     T: Copy + Sub<T, Output = T>,
 {
     #[inline]
-    pub fn size(&self)-> TypedSize2D<T, U> {
+    pub fn size(&self)-> Size2D<T, U> {
         (self.max - self.min).to_size()
     }
 
     #[inline]
-    pub fn to_rect(&self) -> TypedRect<T, U> {
-        TypedRect {
+    pub fn to_rect(&self) -> Rect<T, U> {
+        Rect {
             origin: self.min,
             size: self.size(),
         }
     }
 }
 
-impl<T, U> TypedBox2D<T, U>
+impl<T, U> Box2D<T, U>
 where
     T: Copy + PartialEq + Add<T, Output = T> + Sub<T, Output = T>,
 {
@@ -222,14 +219,14 @@ where
     #[inline]
     #[must_use]
     pub fn inflate(&self, width: T, height: T) -> Self {
-        TypedBox2D {
+        Box2D {
             min: point2(self.min.x - width, self.min.y - height),
             max: point2(self.max.x + width, self.max.y + height),
         }
     }
 }
 
-impl<T, U> TypedBox2D<T, U>
+impl<T, U> Box2D<T, U>
 where
     T: Copy + Zero + PartialOrd + Add<T, Output = T> + Sub<T, Output = T>,
 {
@@ -237,8 +234,8 @@ where
     ///
     /// Subtracts the side offsets from all sides. The horizontal, vertical
     /// and applicate offsets must not be larger than the original side length.
-    pub fn inner_box(&self, offsets: TypedSideOffsets2D<T, U>) -> Self {
-        TypedBox2D {
+    pub fn inner_box(&self, offsets: SideOffsets2D<T, U>) -> Self {
+        Box2D {
             min: self.min + vec2(offsets.left, offsets.top),
             max: self.max - vec2(offsets.right, offsets.bottom),
         }
@@ -247,8 +244,8 @@ where
     /// Calculate the b and position of an outer box.
     ///
     /// Add the offsets to all sides. The expanded box is returned.
-    pub fn outer_box(&self, offsets: TypedSideOffsets2D<T, U>) -> Self {
-        TypedBox2D {
+    pub fn outer_box(&self, offsets: SideOffsets2D<T, U>) -> Self {
+        Box2D {
             min: self.min - vec2(offsets.left, offsets.top),
             max: self.max + vec2(offsets.right, offsets.bottom),
         }
@@ -256,7 +253,7 @@ where
 }
 
 
-impl<T, U> TypedBox2D<T, U>
+impl<T, U> Box2D<T, U>
 where
     T: Copy + Zero + PartialOrd,
 {
@@ -264,14 +261,14 @@ where
     pub fn from_points<I>(points: I) -> Self
     where
         I: IntoIterator,
-        I::Item: Borrow<TypedPoint2D<T, U>>,
+        I::Item: Borrow<Point2D<T, U>>,
     {
         let mut points = points.into_iter();
 
         // Need at least 2 different points for a valid box (ie: volume > 0).
         let (mut min_x, mut min_y) = match points.next() {
             Some(first) => (first.borrow().x, first.borrow().y),
-            None => return TypedBox2D::zero(),
+            None => return Box2D::zero(),
         };
         let (mut max_x, mut max_y) = (min_x, min_y);
 
@@ -294,7 +291,7 @@ where
 
             match points.next() {
                 Some(second) => assign_min_max(second),
-                None => return TypedBox2D::zero(),
+                None => return Box2D::zero(),
             }
 
             for point in points {
@@ -302,14 +299,14 @@ where
             }
         }
 
-        TypedBox2D {
+        Box2D {
             min: point2(min_x, min_y),
             max: point2(max_x, max_y),
         }
     }
 }
 
-impl<T, U> TypedBox2D<T, U>
+impl<T, U> Box2D<T, U>
 where
     T: Copy + One + Add<Output = T> + Sub<Output = T> + Mul<Output = T>,
 {
@@ -325,23 +322,23 @@ where
     }
 }
 
-impl<T, U> TypedBox2D<T, U>
+impl<T, U> Box2D<T, U>
 where
     T: Copy + One + Add<Output = T> + Div<Output = T>,
 {
-    pub fn center(&self) -> TypedPoint2D<T, U> {
+    pub fn center(&self) -> Point2D<T, U> {
         let two = T::one() + T::one();
         (self.min + self.max.to_vector()) / two
     }
 }
 
-impl<T, U> TypedBox2D<T, U>
+impl<T, U> Box2D<T, U>
 where
     T: Copy + PartialOrd,
 {
     #[inline]
     pub fn union(&self, other: &Self) -> Self {
-        TypedBox2D {
+        Box2D {
             min: point2(
                 min(self.min.x, other.min.x),
                 min(self.min.y, other.min.y),
@@ -354,7 +351,7 @@ where
     }
 }
 
-impl<T, U> TypedBox2D<T, U>
+impl<T, U> Box2D<T, U>
 where
     T: Copy,
 {
@@ -363,14 +360,14 @@ where
     where
         T: Mul<S, Output = T>
     {
-        TypedBox2D {
+        Box2D {
             min: point2(self.min.x * x, self.min.y * y),
             max: point2(self.max.x * x, self.max.y * y),
         }
     }
 }
 
-impl<T, U> TypedBox2D<T, U>
+impl<T, U> Box2D<T, U>
 where
     T: Copy + Mul<T, Output = T> + Sub<T, Output = T>,
 {
@@ -381,17 +378,17 @@ where
     }
 }
 
-impl<T, U> TypedBox2D<T, U>
+impl<T, U> Box2D<T, U>
 where
     T: Copy + Zero,
 {
     /// Constructor, setting all sides to zero.
     pub fn zero() -> Self {
-        TypedBox2D::new(TypedPoint2D::zero(), TypedPoint2D::zero())
+        Box2D::new(Point2D::zero(), Point2D::zero())
     }
 }
 
-impl<T, U> TypedBox2D<T, U>
+impl<T, U> Box2D<T, U>
 where
     T: PartialEq,
 {
@@ -402,69 +399,69 @@ where
     }
 }
 
-impl<T, U> Mul<T> for TypedBox2D<T, U>
+impl<T, U> Mul<T> for Box2D<T, U>
 where
     T: Copy + Mul<T, Output = T>,
 {
     type Output = Self;
     #[inline]
     fn mul(self, scale: T) -> Self {
-        TypedBox2D::new(self.min * scale, self.max * scale)
+        Box2D::new(self.min * scale, self.max * scale)
     }
 }
 
-impl<T, U> Div<T> for TypedBox2D<T, U>
+impl<T, U> Div<T> for Box2D<T, U>
 where
     T: Copy + Div<T, Output = T>,
 {
     type Output = Self;
     #[inline]
     fn div(self, scale: T) -> Self {
-        TypedBox2D::new(self.min / scale, self.max / scale)
+        Box2D::new(self.min / scale, self.max / scale)
     }
 }
 
-impl<T, U1, U2> Mul<TypedScale<T, U1, U2>> for TypedBox2D<T, U1>
+impl<T, U1, U2> Mul<Scale<T, U1, U2>> for Box2D<T, U1>
 where
     T: Copy + Mul<T, Output = T>,
 {
-    type Output = TypedBox2D<T, U2>;
+    type Output = Box2D<T, U2>;
     #[inline]
-    fn mul(self, scale: TypedScale<T, U1, U2>) -> TypedBox2D<T, U2> {
-        TypedBox2D::new(self.min * scale, self.max * scale)
+    fn mul(self, scale: Scale<T, U1, U2>) -> Box2D<T, U2> {
+        Box2D::new(self.min * scale, self.max * scale)
     }
 }
 
-impl<T, U1, U2> Div<TypedScale<T, U1, U2>> for TypedBox2D<T, U2>
+impl<T, U1, U2> Div<Scale<T, U1, U2>> for Box2D<T, U2>
 where
     T: Copy + Div<T, Output = T>,
 {
-    type Output = TypedBox2D<T, U1>;
+    type Output = Box2D<T, U1>;
     #[inline]
-    fn div(self, scale: TypedScale<T, U1, U2>) -> TypedBox2D<T, U1> {
-        TypedBox2D::new(self.min / scale, self.max / scale)
+    fn div(self, scale: Scale<T, U1, U2>) -> Box2D<T, U1> {
+        Box2D::new(self.min / scale, self.max / scale)
     }
 }
 
-impl<T, Unit> TypedBox2D<T, Unit>
+impl<T, Unit> Box2D<T, Unit>
 where
     T: Copy,
 {
     /// Drop the units, preserving only the numeric value.
-    pub fn to_untyped(&self) -> Box2D<T> {
-        TypedBox2D::new(self.min.to_untyped(), self.max.to_untyped())
+    pub fn to_untyped(&self) -> Box2D<T, UnknownUnit> {
+        Box2D::new(self.min.to_untyped(), self.max.to_untyped())
     }
 
     /// Tag a unitless value with units.
-    pub fn from_untyped(c: &Box2D<T>) -> TypedBox2D<T, Unit> {
-        TypedBox2D::new(
-            TypedPoint2D::from_untyped(&c.min),
-            TypedPoint2D::from_untyped(&c.max),
+    pub fn from_untyped(c: &Box2D<T, UnknownUnit>) -> Box2D<T, Unit> {
+        Box2D::new(
+            Point2D::from_untyped(&c.min),
+            Point2D::from_untyped(&c.max),
         )
     }
 }
 
-impl<T0, Unit> TypedBox2D<T0, Unit>
+impl<T0, Unit> Box2D<T0, Unit>
 where
     T0: NumCast + Copy,
 {
@@ -473,8 +470,8 @@ where
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using round(), round_in or round_out() before casting.
-    pub fn cast<T1: NumCast + Copy>(&self) -> TypedBox2D<T1, Unit> {
-        TypedBox2D::new(
+    pub fn cast<T1: NumCast + Copy>(&self) -> Box2D<T1, Unit> {
+        Box2D::new(
             self.min.cast(),
             self.max.cast(),
         )
@@ -485,15 +482,15 @@ where
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using round(), round_in or round_out() before casting.
-    pub fn try_cast<T1: NumCast + Copy>(&self) -> Option<TypedBox2D<T1, Unit>> {
+    pub fn try_cast<T1: NumCast + Copy>(&self) -> Option<Box2D<T1, Unit>> {
         match (self.min.try_cast(), self.max.try_cast()) {
-            (Some(a), Some(b)) => Some(TypedBox2D::new(a, b)),
+            (Some(a), Some(b)) => Some(Box2D::new(a, b)),
             _ => None,
         }
     }
 }
 
-impl<T, U> TypedBox2D<T, U>
+impl<T, U> Box2D<T, U>
 where
     T: Round,
 {
@@ -508,11 +505,11 @@ where
     /// They are always rounding as floor(n + 0.5).
     #[must_use]
     pub fn round(&self) -> Self {
-        TypedBox2D::new(self.min.round(), self.max.round())
+        Box2D::new(self.min.round(), self.max.round())
     }
 }
 
-impl<T, U> TypedBox2D<T, U>
+impl<T, U> Box2D<T, U>
 where
     T: Floor + Ceil,
 {
@@ -522,7 +519,7 @@ where
     pub fn round_in(&self) -> Self {
         let min = self.min.ceil();
         let max = self.max.floor();
-        TypedBox2D { min, max }
+        Box2D { min, max }
     }
 
     /// Return a box with faces/edges rounded to integer coordinates, such that
@@ -531,19 +528,19 @@ where
     pub fn round_out(&self) -> Self {
         let min = self.min.floor();
         let max = self.max.ceil();
-        TypedBox2D { min, max }
+        Box2D { min, max }
     }
 }
 
 // Convenience functions for common casts
-impl<T: NumCast + Copy, Unit> TypedBox2D<T, Unit> {
+impl<T: NumCast + Copy, Unit> Box2D<T, Unit> {
     /// Cast into an `f32` box.
-    pub fn to_f32(&self) -> TypedBox2D<f32, Unit> {
+    pub fn to_f32(&self) -> Box2D<f32, Unit> {
         self.cast()
     }
 
     /// Cast into an `f64` box.
-    pub fn to_f64(&self) -> TypedBox2D<f64, Unit> {
+    pub fn to_f64(&self) -> Box2D<f64, Unit> {
         self.cast()
     }
 
@@ -552,7 +549,7 @@ impl<T: NumCast + Copy, Unit> TypedBox2D<T, Unit> {
     /// When casting from floating point boxes, it is worth considering whether
     /// to `round()`, `round_in()` or `round_out()` before the cast in order to
     /// obtain the desired conversion behavior.
-    pub fn to_usize(&self) -> TypedBox2D<usize, Unit> {
+    pub fn to_usize(&self) -> Box2D<usize, Unit> {
         self.cast()
     }
 
@@ -561,7 +558,7 @@ impl<T: NumCast + Copy, Unit> TypedBox2D<T, Unit> {
     /// When casting from floating point boxes, it is worth considering whether
     /// to `round()`, `round_in()` or `round_out()` before the cast in order to
     /// obtain the desired conversion behavior.
-    pub fn to_u32(&self) -> TypedBox2D<u32, Unit> {
+    pub fn to_u32(&self) -> Box2D<u32, Unit> {
         self.cast()
     }
 
@@ -570,7 +567,7 @@ impl<T: NumCast + Copy, Unit> TypedBox2D<T, Unit> {
     /// When casting from floating point boxes, it is worth considering whether
     /// to `round()`, `round_in()` or `round_out()` before the cast in order to
     /// obtain the desired conversion behavior.
-    pub fn to_i32(&self) -> TypedBox2D<i32, Unit> {
+    pub fn to_i32(&self) -> Box2D<i32, Unit> {
         self.cast()
     }
 
@@ -579,16 +576,16 @@ impl<T: NumCast + Copy, Unit> TypedBox2D<T, Unit> {
     /// When casting from floating point boxes, it is worth considering whether
     /// to `round()`, `round_in()` or `round_out()` before the cast in order to
     /// obtain the desired conversion behavior.
-    pub fn to_i64(&self) -> TypedBox2D<i64, Unit> {
+    pub fn to_i64(&self) -> Box2D<i64, Unit> {
         self.cast()
     }
 }
 
-impl<T, U> From<TypedSize2D<T, U>> for TypedBox2D<T, U>
+impl<T, U> From<Size2D<T, U>> for Box2D<T, U>
 where
     T: Copy + Zero + PartialOrd,
 {
-    fn from(b: TypedSize2D<T, U>) -> Self {
+    fn from(b: Size2D<T, U>) -> Self {
         Self::from_size(b)
     }
 }
@@ -596,9 +593,9 @@ where
 #[cfg(test)]
 mod tests {
     use side_offsets::SideOffsets2D;
-    use size::size2;
-    use point::Point2D;
-    use super::*;
+    use {Point2D, point2, vec2, size2};
+    use default::Box2D;
+    //use super::*;
 
     #[test]
     fn test_size() {

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -9,11 +9,11 @@
 
 use super::UnknownUnit;
 use length::Length;
-use scale::TypedScale;
+use scale::Scale;
 use num::*;
-use point::TypedPoint3D;
-use vector::TypedVector3D;
-use size::TypedSize3D;
+use point::Point3D;
+use vector::Vector3D;
+use size::Size3D;
 use approxord::{min, max};
 
 use num_traits::NumCast;
@@ -31,73 +31,70 @@ use core::ops::{Add, Div, Mul, Sub};
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(bound(serialize = "T: Serialize", deserialize = "T: Deserialize<'de>")))]
-pub struct TypedBox3D<T, U> {
-    pub min: TypedPoint3D<T, U>, 
-    pub max: TypedPoint3D<T, U>,
+pub struct Box3D<T, U> {
+    pub min: Point3D<T, U>, 
+    pub max: Point3D<T, U>,
 }
 
-/// The default box 3d type with no unit.
-pub type Box3D<T> = TypedBox3D<T, UnknownUnit>;
-
-impl<T: Hash, U> Hash for TypedBox3D<T, U> {
+impl<T: Hash, U> Hash for Box3D<T, U> {
     fn hash<H: Hasher>(&self, h: &mut H) {
         self.min.hash(h);
         self.max.hash(h);
     }
 }
 
-impl<T: Copy, U> Copy for TypedBox3D<T, U> {}
+impl<T: Copy, U> Copy for Box3D<T, U> {}
 
-impl<T: Copy, U> Clone for TypedBox3D<T, U> {
+impl<T: Copy, U> Clone for Box3D<T, U> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<T: PartialEq, U> PartialEq<TypedBox3D<T, U>> for TypedBox3D<T, U> {
+impl<T: PartialEq, U> PartialEq<Box3D<T, U>> for Box3D<T, U> {
     fn eq(&self, other: &Self) -> bool {
         self.min.eq(&other.min) && self.max.eq(&other.max)
     }
 }
 
-impl<T: Eq, U> Eq for TypedBox3D<T, U> {}
+impl<T: Eq, U> Eq for Box3D<T, U> {}
 
-impl<T: fmt::Debug, U> fmt::Debug for TypedBox3D<T, U> {
+impl<T: fmt::Debug, U> fmt::Debug for Box3D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "TypedBox3D({:?}, {:?})", self.min, self.max)
+        write!(f, "Box3D({:?}, {:?})", self.min, self.max)
     }
 }
 
-impl<T: fmt::Display, U> fmt::Display for TypedBox3D<T, U> {
+impl<T: fmt::Display, U> fmt::Display for Box3D<T, U> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(formatter, "Box3D({}, {})", self.min, self.max)
     }
 }
 
-impl<T, U> TypedBox3D<T, U> {
+impl<T, U> Box3D<T, U> {
     /// Constructor.
-    pub fn new(min: TypedPoint3D<T, U>, max: TypedPoint3D<T, U>) -> Self {
-        TypedBox3D {
+    pub fn new(min: Point3D<T, U>, max: Point3D<T, U>) -> Self {
+        Box3D {
             min,
             max,
         }
     }
 }
 
-impl<T, U> TypedBox3D<T, U>
+impl<T, U> Box3D<T, U>
 where
     T: Copy + Zero + PartialOrd,
 {
     /// Creates a Box3D of the given size, at offset zero.
     #[inline]
-    pub fn from_size(size: TypedSize3D<T, U>) -> Self {
-        let zero = TypedPoint3D::zero();
+    pub fn from_size(size: Size3D<T, U>) -> Self {
+        let zero = Point3D::zero();
         let point = size.to_vector().to_point();
-        TypedBox3D::from_points(&[zero, point])
+        Box3D::from_points(&[zero, point])
     }
 }
 
-impl<T, U> TypedBox3D<T, U>
+impl<T, U> Box3D<T, U>
 where
     T: Copy + PartialOrd,
 {
@@ -137,38 +134,38 @@ where
     }
 
     pub fn intersection(&self, other: &Self) -> Self {
-        let intersection_min = TypedPoint3D::new(
+        let intersection_min = Point3D::new(
             max(self.min.x, other.min.x),
             max(self.min.y, other.min.y),
             max(self.min.z, other.min.z),
         );
 
-        let intersection_max = TypedPoint3D::new(
+        let intersection_max = Point3D::new(
             min(self.max.x, other.max.x),
             min(self.max.y, other.max.y),
             min(self.max.z, other.max.z),
         );
 
-        TypedBox3D::new(
+        Box3D::new(
             intersection_min, 
             intersection_max,
         )
     }
 }
 
-impl<T, U> TypedBox3D<T, U>
+impl<T, U> Box3D<T, U>
 where
     T: Copy + Add<T, Output = T>,
 {
     /// Returns the same box3d, translated by a vector.
     #[inline]
     #[must_use]
-    pub fn translate(&self, by: &TypedVector3D<T, U>) -> Self {
+    pub fn translate(&self, by: &Vector3D<T, U>) -> Self {
         Self::new(self.min + *by, self.max + *by)
     }
 }
 
-impl<T, U> TypedBox3D<T, U>
+impl<T, U> Box3D<T, U>
 where
     T: Copy + PartialOrd + Zero,
 {
@@ -176,14 +173,14 @@ where
     /// in the box3d if they are on the front, left or top faces, but outside if they
     /// are on the back, right or bottom faces.
     #[inline]
-    pub fn contains(&self, other: &TypedPoint3D<T, U>) -> bool {
+    pub fn contains(&self, other: &Point3D<T, U>) -> bool {
         self.min.x <= other.x && other.x < self.max.x
             && self.min.y <= other.y && other.y < self.max.y
             && self.min.z <= other.z && other.z < self.max.z
     }
 }
 
-impl<T, U> TypedBox3D<T, U>
+impl<T, U> Box3D<T, U>
 where
     T: Copy + PartialOrd + Zero + Sub<T, Output = T>,
 {
@@ -199,13 +196,13 @@ where
     }
 }
 
-impl<T, U> TypedBox3D<T, U>
+impl<T, U> Box3D<T, U>
 where
     T: Copy + Sub<T, Output = T>,
 {
     #[inline]
-    pub fn size(&self)-> TypedSize3D<T, U> {
-        TypedSize3D::new(
+    pub fn size(&self)-> Size3D<T, U> {
+        Size3D::new(
             self.max.x - self.min.x,
             self.max.y - self.min.y,
             self.max.z - self.min.z,
@@ -213,7 +210,7 @@ where
     }
 }
 
-impl<T, U> TypedBox3D<T, U>
+impl<T, U> Box3D<T, U>
 where
     T: Copy + PartialEq + Add<T, Output = T> + Sub<T, Output = T>,
 {
@@ -221,9 +218,9 @@ where
     #[inline]
     #[must_use]
     pub fn inflate(&self, width: T, height: T, depth: T) -> Self {
-        TypedBox3D::new(
-            TypedPoint3D::new(self.min.x - width, self.min.y - height, self.min.z - depth),
-            TypedPoint3D::new(self.max.x + width, self.max.y + height, self.max.z + depth),
+        Box3D::new(
+            Point3D::new(self.min.x - width, self.min.y - height, self.min.z - depth),
+            Point3D::new(self.max.x + width, self.max.y + height, self.max.z + depth),
         )
     }
 
@@ -234,7 +231,7 @@ where
     }
 }
 
-impl<T, U> TypedBox3D<T, U>
+impl<T, U> Box3D<T, U>
 where
     T: Copy + Zero + PartialOrd,
 {
@@ -242,14 +239,14 @@ where
     pub fn from_points<I>(points: I) -> Self
     where
         I: IntoIterator,
-        I::Item: Borrow<TypedPoint3D<T, U>>,
+        I::Item: Borrow<Point3D<T, U>>,
     {
         let mut points = points.into_iter();
 
         // Need at least 2 different points for a valid box3d (ie: volume > 0).
         let (mut min_x, mut min_y, mut min_z) = match points.next() {
             Some(first) => (first.borrow().x, first.borrow().y, first.borrow().z),
-            None => return TypedBox3D::zero(),
+            None => return Box3D::zero(),
         };
         let (mut max_x, mut max_y, mut max_z) = (min_x, min_y, min_z);
 
@@ -278,7 +275,7 @@ where
                     
             match points.next() {
                 Some(second) => assign_min_max(second),
-                None => return TypedBox3D::zero(),
+                None => return Box3D::zero(),
             }
 
             for point in points {
@@ -286,11 +283,11 @@ where
             }
         }
 
-        Self::new(TypedPoint3D::new(min_x, min_y, min_z), TypedPoint3D::new(max_x, max_y, max_z))
+        Self::new(Point3D::new(min_x, min_y, min_z), Point3D::new(max_x, max_y, max_z))
     }
 }
 
-impl<T, U> TypedBox3D<T, U>
+impl<T, U> Box3D<T, U>
 where
     T: Copy + One + Add<Output = T> + Sub<Output = T> + Mul<Output = T>,
 {
@@ -306,29 +303,29 @@ where
     }
 }
 
-impl<T, U> TypedBox3D<T, U>
+impl<T, U> Box3D<T, U>
 where
     T: Copy + One + Add<Output = T> + Div<Output = T>,
 {
-    pub fn center(&self) -> TypedPoint3D<T, U> {
+    pub fn center(&self) -> Point3D<T, U> {
         let two = T::one() + T::one();
         (self.min + self.max.to_vector()) / two
     }
 }
 
-impl<T, U> TypedBox3D<T, U>
+impl<T, U> Box3D<T, U>
 where
     T: Copy + Clone + PartialOrd + Add<T, Output = T> + Sub<T, Output = T> + Zero,
 {
     #[inline]
     pub fn union(&self, other: &Self) -> Self {
-        TypedBox3D::new(
-            TypedPoint3D::new(
+        Box3D::new(
+            Point3D::new(
                 min(self.min.x, other.min.x),
                 min(self.min.y, other.min.y),
                 min(self.min.z, other.min.z),
             ),
-            TypedPoint3D::new(
+            Point3D::new(
                 max(self.max.x, other.max.x),
                 max(self.max.y, other.max.y),
                 max(self.max.z, other.max.z),
@@ -337,7 +334,7 @@ where
     }
 }
 
-impl<T, U> TypedBox3D<T, U>
+impl<T, U> Box3D<T, U>
 where
     T: Copy,
 {
@@ -346,14 +343,14 @@ where
     where
         T: Mul<S, Output = T>
     {
-        TypedBox3D::new(
-            TypedPoint3D::new(self.min.x * x, self.min.y * y, self.min.z * z),
-            TypedPoint3D::new(self.max.x * x, self.max.y * y, self.max.z * z),
+        Box3D::new(
+            Point3D::new(self.min.x * x, self.min.y * y, self.min.z * z),
+            Point3D::new(self.max.x * x, self.max.y * y, self.max.z * z),
         )
     }
 }
 
-impl<T, U> TypedBox3D<T, U>
+impl<T, U> Box3D<T, U>
 where
     T: Copy + Mul<T, Output = T> + Sub<T, Output = T>,
 {
@@ -382,17 +379,17 @@ where
     }
 }
 
-impl<T, U> TypedBox3D<T, U> 
+impl<T, U> Box3D<T, U> 
 where
     T: Copy + Zero,
 {
     /// Constructor, setting all sides to zero.
     pub fn zero() -> Self {
-        TypedBox3D::new(TypedPoint3D::zero(), TypedPoint3D::zero())
+        Box3D::new(Point3D::zero(), Point3D::zero())
     }
 }
 
-impl<T, U> TypedBox3D<T, U>
+impl<T, U> Box3D<T, U>
 where
     T: PartialEq,
 {
@@ -403,69 +400,69 @@ where
     }
 }
 
-impl<T, U> Mul<T> for TypedBox3D<T, U> 
+impl<T, U> Mul<T> for Box3D<T, U>
 where
     T: Copy + Mul<T, Output = T>,
 {
     type Output = Self;
     #[inline]
     fn mul(self, scale: T) -> Self {
-        TypedBox3D::new(self.min * scale, self.max * scale)
+        Box3D::new(self.min * scale, self.max * scale)
     }
 }
 
-impl<T, U> Div<T> for TypedBox3D<T, U> 
+impl<T, U> Div<T> for Box3D<T, U>
 where
     T: Copy + Div<T, Output = T>,
 {
     type Output = Self;
     #[inline]
     fn div(self, scale: T) -> Self {
-        TypedBox3D::new(self.min / scale, self.max / scale)
+        Box3D::new(self.min / scale, self.max / scale)
     }
 }
 
-impl<T, U1, U2> Mul<TypedScale<T, U1, U2>> for TypedBox3D<T, U1> 
+impl<T, U1, U2> Mul<Scale<T, U1, U2>> for Box3D<T, U1>
 where
     T: Copy + Mul<T, Output = T>,
 {
-    type Output = TypedBox3D<T, U2>;
+    type Output = Box3D<T, U2>;
     #[inline]
-    fn mul(self, scale: TypedScale<T, U1, U2>) -> TypedBox3D<T, U2> {
-        TypedBox3D::new(self.min * scale, self.max * scale)
+    fn mul(self, scale: Scale<T, U1, U2>) -> Box3D<T, U2> {
+        Box3D::new(self.min * scale, self.max * scale)
     }
 }
 
-impl<T, U1, U2> Div<TypedScale<T, U1, U2>> for TypedBox3D<T, U2> 
+impl<T, U1, U2> Div<Scale<T, U1, U2>> for Box3D<T, U2>
 where
     T: Copy + Div<T, Output = T>,
 {
-    type Output = TypedBox3D<T, U1>;
+    type Output = Box3D<T, U1>;
     #[inline]
-    fn div(self, scale: TypedScale<T, U1, U2>) -> TypedBox3D<T, U1> {
-        TypedBox3D::new(self.min / scale, self.max / scale)
+    fn div(self, scale: Scale<T, U1, U2>) -> Box3D<T, U1> {
+        Box3D::new(self.min / scale, self.max / scale)
     }
 }
 
-impl<T, Unit> TypedBox3D<T, Unit> 
+impl<T, Unit> Box3D<T, Unit>
 where
     T: Copy,
 {
     /// Drop the units, preserving only the numeric value.
-    pub fn to_untyped(&self) -> Box3D<T> {
-        TypedBox3D::new(self.min.to_untyped(), self.max.to_untyped())
+    pub fn to_untyped(&self) -> Box3D<T, UnknownUnit> {
+        Box3D::new(self.min.to_untyped(), self.max.to_untyped())
     }
 
     /// Tag a unitless value with units.
-    pub fn from_untyped(c: &Box3D<T>) -> TypedBox3D<T, Unit> {
-        TypedBox3D::new(
-            TypedPoint3D::from_untyped(&c.min),
-            TypedPoint3D::from_untyped(&c.max),
+    pub fn from_untyped(c: &Box3D<T, UnknownUnit>) -> Box3D<T, Unit> {
+        Box3D::new(
+            Point3D::from_untyped(&c.min),
+            Point3D::from_untyped(&c.max),
         )
     }
 }
 
-impl<T0, Unit> TypedBox3D<T0, Unit> 
+impl<T0, Unit> Box3D<T0, Unit>
 where
     T0: NumCast + Copy,
 {
@@ -474,8 +471,8 @@ where
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using round(), round_in or round_out() before casting.
-    pub fn cast<T1: NumCast + Copy>(&self) -> TypedBox3D<T1, Unit> {
-        TypedBox3D::new(
+    pub fn cast<T1: NumCast + Copy>(&self) -> Box3D<T1, Unit> {
+        Box3D::new(
             self.min.cast(),
             self.max.cast(),
         )
@@ -486,15 +483,15 @@ where
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using round(), round_in or round_out() before casting.
-    pub fn try_cast<T1: NumCast + Copy>(&self) -> Option<TypedBox3D<T1, Unit>> {
+    pub fn try_cast<T1: NumCast + Copy>(&self) -> Option<Box3D<T1, Unit>> {
         match (self.min.try_cast(), self.max.try_cast()) {
-            (Some(a), Some(b)) => Some(TypedBox3D::new(a, b)),
+            (Some(a), Some(b)) => Some(Box3D::new(a, b)),
             _ => None,
         }
     }
 }
 
-impl<T, U> TypedBox3D<T, U> 
+impl<T, U> Box3D<T, U>
 where
     T: Round,
 {
@@ -509,11 +506,11 @@ where
     /// They are always rounding as floor(n + 0.5).
     #[must_use]
     pub fn round(&self) -> Self {
-        TypedBox3D::new(self.min.round(), self.max.round())
+        Box3D::new(self.min.round(), self.max.round())
     }
 }
 
-impl<T, U> TypedBox3D<T, U> 
+impl<T, U> Box3D<T, U>
 where
     T: Floor + Ceil,
 {
@@ -521,7 +518,7 @@ where
     /// the original box3d contains the resulting box3d.
     #[must_use]
     pub fn round_in(&self) -> Self {
-        TypedBox3D {
+        Box3D {
             min: self.min.ceil(),
             max: self.max.floor(),
         }
@@ -531,7 +528,7 @@ where
     /// the original box3d is contained in the resulting box3d.
     #[must_use]
     pub fn round_out(&self) -> Self {
-        TypedBox3D {
+        Box3D {
             min: self.min.floor(),
             max: self.max.ceil(),
         }
@@ -539,14 +536,14 @@ where
 }
 
 // Convenience functions for common casts
-impl<T: NumCast + Copy, Unit> TypedBox3D<T, Unit> {
+impl<T: NumCast + Copy, Unit> Box3D<T, Unit> {
     /// Cast into an `f32` box3d.
-    pub fn to_f32(&self) -> TypedBox3D<f32, Unit> {
+    pub fn to_f32(&self) -> Box3D<f32, Unit> {
         self.cast()
     }
 
     /// Cast into an `f64` box3d.
-    pub fn to_f64(&self) -> TypedBox3D<f64, Unit> {
+    pub fn to_f64(&self) -> Box3D<f64, Unit> {
         self.cast()
     }
 
@@ -555,7 +552,7 @@ impl<T: NumCast + Copy, Unit> TypedBox3D<T, Unit> {
     /// When casting from floating point cuboids, it is worth considering whether
     /// to `round()`, `round_in()` or `round_out()` before the cast in order to
     /// obtain the desired conversion behavior.
-    pub fn to_usize(&self) -> TypedBox3D<usize, Unit> {
+    pub fn to_usize(&self) -> Box3D<usize, Unit> {
         self.cast()
     }
 
@@ -564,7 +561,7 @@ impl<T: NumCast + Copy, Unit> TypedBox3D<T, Unit> {
     /// When casting from floating point cuboids, it is worth considering whether
     /// to `round()`, `round_in()` or `round_out()` before the cast in order to
     /// obtain the desired conversion behavior.
-    pub fn to_u32(&self) -> TypedBox3D<u32, Unit> {
+    pub fn to_u32(&self) -> Box3D<u32, Unit> {
         self.cast()
     }
 
@@ -573,7 +570,7 @@ impl<T: NumCast + Copy, Unit> TypedBox3D<T, Unit> {
     /// When casting from floating point cuboids, it is worth considering whether
     /// to `round()`, `round_in()` or `round_out()` before the cast in order to
     /// obtain the desired conversion behavior.
-    pub fn to_i32(&self) -> TypedBox3D<i32, Unit> {
+    pub fn to_i32(&self) -> Box3D<i32, Unit> {
         self.cast()
     }
 
@@ -582,31 +579,29 @@ impl<T: NumCast + Copy, Unit> TypedBox3D<T, Unit> {
     /// When casting from floating point cuboids, it is worth considering whether
     /// to `round()`, `round_in()` or `round_out()` before the cast in order to
     /// obtain the desired conversion behavior.
-    pub fn to_i64(&self) -> TypedBox3D<i64, Unit> {
+    pub fn to_i64(&self) -> Box3D<i64, Unit> {
         self.cast()
     }
 }
 
-impl<T, U> From<TypedSize3D<T, U>> for TypedBox3D<T, U>
+impl<T, U> From<Size3D<T, U>> for Box3D<T, U>
 where 
     T: Copy + Zero + PartialOrd,
 {
-    fn from(b: TypedSize3D<T, U>) -> Self {
+    fn from(b: Size3D<T, U>) -> Self {
         Self::from_size(b)
     }
 }
 
-/// Shorthand for `TypedBox3D::new(TypedPoint3D::new(x1, y1, z1), TypedPoint3D::new(x2, y2, z2))`.
-pub fn box3d<T: Copy, U>(min_x: T, min_y: T, min_z: T, max_x: T, max_y: T, max_z: T) -> TypedBox3D<T, U> {
-    TypedBox3D::new(TypedPoint3D::new(min_x, min_y, min_z), TypedPoint3D::new(max_x, max_y, max_z))
+/// Shorthand for `Box3D::new(Point3D::new(x1, y1, z1), Point3D::new(x2, y2, z2))`.
+pub fn box3d<T: Copy, U>(min_x: T, min_y: T, min_z: T, max_x: T, max_y: T, max_z: T) -> Box3D<T, U> {
+    Box3D::new(Point3D::new(min_x, min_y, min_z), Point3D::new(max_x, max_y, max_z))
 }
 
 #[cfg(test)]
 mod tests {
-    use vector::vec3;
-    use size::size3;
-    use point::{point3, Point3D};
-    use super::*;
+    use {point3, size3, vec3};
+    use default::{Box3D, Point3D};
 
     #[test]
     fn test_new() {

--- a/src/homogen.rs
+++ b/src/homogen.rs
@@ -7,8 +7,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use point::{TypedPoint2D, TypedPoint3D};
-use vector::{TypedVector2D, TypedVector3D};
+use point::{Point2D, Point3D};
+use vector::{Vector2D, Vector3D};
 
 use num::{One, Zero};
 
@@ -104,9 +104,9 @@ impl<T: Copy + Div<T, Output=T> + Zero + PartialOrd, U> HomogeneousVector<T, U> 
     ///
     /// Returns None if the point is on or behind the W=0 hemisphere.
     #[inline]
-    pub fn to_point2d(&self) -> Option<TypedPoint2D<T, U>> {
+    pub fn to_point2d(&self) -> Option<Point2D<T, U>> {
         if self.w > T::zero() {
-            Some(TypedPoint2D::new(self.x / self.w, self.y / self.w))
+            Some(Point2D::new(self.x / self.w, self.y / self.w))
         } else {
             None
         }
@@ -116,39 +116,39 @@ impl<T: Copy + Div<T, Output=T> + Zero + PartialOrd, U> HomogeneousVector<T, U> 
     ///
     /// Returns None if the point is on or behind the W=0 hemisphere.
     #[inline]
-    pub fn to_point3d(&self) -> Option<TypedPoint3D<T, U>> {
+    pub fn to_point3d(&self) -> Option<Point3D<T, U>> {
         if self.w > T::zero() {
-            Some(TypedPoint3D::new(self.x / self.w, self.y / self.w, self.z / self.w))
+            Some(Point3D::new(self.x / self.w, self.y / self.w, self.z / self.w))
         } else {
             None
         }
     }
 }
 
-impl<T: Zero, U> From<TypedVector2D<T, U>> for HomogeneousVector<T, U> {
+impl<T: Zero, U> From<Vector2D<T, U>> for HomogeneousVector<T, U> {
     #[inline]
-    fn from(v: TypedVector2D<T, U>) -> Self {
+    fn from(v: Vector2D<T, U>) -> Self {
         HomogeneousVector::new(v.x, v.y, T::zero(), T::zero())
     }
 }
 
-impl<T: Zero, U> From<TypedVector3D<T, U>> for HomogeneousVector<T, U> {
+impl<T: Zero, U> From<Vector3D<T, U>> for HomogeneousVector<T, U> {
     #[inline]
-    fn from(v: TypedVector3D<T, U>) -> Self {
+    fn from(v: Vector3D<T, U>) -> Self {
         HomogeneousVector::new(v.x, v.y, v.z, T::zero())
     }
 }
 
-impl<T: Zero + One, U> From<TypedPoint2D<T, U>> for HomogeneousVector<T, U> {
+impl<T: Zero + One, U> From<Point2D<T, U>> for HomogeneousVector<T, U> {
     #[inline]
-    fn from(p: TypedPoint2D<T, U>) -> Self {
+    fn from(p: Point2D<T, U>) -> Self {
         HomogeneousVector::new(p.x, p.y, T::zero(), T::one())
     }
 }
 
-impl<T: One, U> From<TypedPoint3D<T, U>> for HomogeneousVector<T, U> {
+impl<T: One, U> From<Point3D<T, U>> for HomogeneousVector<T, U> {
     #[inline]
-    fn from(p: TypedPoint3D<T, U>) -> Self {
+    fn from(p: Point3D<T, U>) -> Self {
         HomogeneousVector::new(p.x, p.y, p.z, T::one())
     }
 }
@@ -169,7 +169,7 @@ impl<T: fmt::Display, U> fmt::Display for HomogeneousVector<T, U> {
 #[cfg(test)]
 mod homogeneous {
     use super::HomogeneousVector;
-    use point::{Point2D, Point3D};
+    use default::{Point2D, Point3D};
 
     #[test]
     fn roundtrip() {

--- a/src/length.rs
+++ b/src/length.rs
@@ -8,7 +8,7 @@
 // except according to those terms.
 //! A one-dimensional length, tagged with its units.
 
-use scale::TypedScale;
+use scale::Scale;
 use num::Zero;
 
 use num_traits::{NumCast, Saturating};
@@ -30,10 +30,10 @@ use core::fmt;
 /// expression that requires a different unit.  It may be a type without values, such as an empty
 /// enum.
 ///
-/// You can multiply a `Length` by a `scale::TypedScale` to convert it from one unit to
-/// another. See the [`TypedScale`] docs for an example.
+/// You can multiply a `Length` by a `scale::Scale` to convert it from one unit to
+/// another. See the [`Scale`] docs for an example.
 ///
-/// [`TypedScale`]: struct.TypedScale.html
+/// [`Scale`]: struct.Scale.html
 #[repr(C)]
 pub struct Length<T, Unit>(pub T, #[doc(hidden)] pub PhantomData<Unit>);
 
@@ -141,10 +141,10 @@ impl<U, T: Clone + Saturating> Saturating for Length<T, U> {
 
 // length / length
 impl<Src, Dst, T: Clone + Div<T, Output = T>> Div<Length<T, Src>> for Length<T, Dst> {
-    type Output = TypedScale<T, Src, Dst>;
+    type Output = Scale<T, Src, Dst>;
     #[inline]
-    fn div(self, other: Length<T, Src>) -> TypedScale<T, Src, Dst> {
-        TypedScale::new(self.get() / other.get())
+    fn div(self, other: Length<T, Src>) -> Scale<T, Src, Dst> {
+        Scale::new(self.get() / other.get())
     }
 }
 
@@ -183,19 +183,19 @@ impl<T: Copy + Div<T, Output = T>, U> DivAssign<T> for Length<T, U> {
 }
 
 // length * scaleFactor
-impl<Src, Dst, T: Clone + Mul<T, Output = T>> Mul<TypedScale<T, Src, Dst>> for Length<T, Src> {
+impl<Src, Dst, T: Clone + Mul<T, Output = T>> Mul<Scale<T, Src, Dst>> for Length<T, Src> {
     type Output = Length<T, Dst>;
     #[inline]
-    fn mul(self, scale: TypedScale<T, Src, Dst>) -> Length<T, Dst> {
+    fn mul(self, scale: Scale<T, Src, Dst>) -> Length<T, Dst> {
         Length::new(self.get() * scale.get())
     }
 }
 
 // length / scaleFactor
-impl<Src, Dst, T: Clone + Div<T, Output = T>> Div<TypedScale<T, Src, Dst>> for Length<T, Dst> {
+impl<Src, Dst, T: Clone + Div<T, Output = T>> Div<Scale<T, Src, Dst>> for Length<T, Dst> {
     type Output = Length<T, Src>;
     #[inline]
-    fn div(self, scale: TypedScale<T, Src, Dst>) -> Length<T, Src> {
+    fn div(self, scale: Scale<T, Src, Dst>) -> Length<T, Src> {
         Length::new(self.get() / scale.get())
     }
 }
@@ -267,7 +267,7 @@ mod tests {
     use num::Zero;
 
     use num_traits::Saturating;
-    use scale::TypedScale;
+    use scale::Scale;
     use core::f32::INFINITY;
 
     enum Inch {}
@@ -379,21 +379,21 @@ mod tests {
 
     #[test]
     fn test_division_by_length() {
-        // Division results in a TypedScale from denominator units
+        // Division results in a Scale from denominator units
         // to numerator units.
         let length: Length<f32, Cm> = Length::new(5.0);
         let duration: Length<f32, Second> = Length::new(10.0);
 
         let result = length / duration;
 
-        let expected: TypedScale<f32, Second, Cm> = TypedScale::new(0.5);
+        let expected: Scale<f32, Second, Cm> = Scale::new(0.5);
         assert_eq!(result, expected);
     }
 
     #[test]
     fn test_multiplication() {
         let length_mm: Length<f32, Mm> = Length::new(10.0);
-        let cm_per_mm: TypedScale<f32, Mm, Cm> = TypedScale::new(0.1);
+        let cm_per_mm: Scale<f32, Mm, Cm> = Scale::new(0.1);
 
         let result = length_mm * cm_per_mm;
 
@@ -424,7 +424,7 @@ mod tests {
     #[test]
     fn test_division_by_scalefactor() {
         let length: Length<f32, Cm> = Length::new(5.0);
-        let cm_per_second: TypedScale<f32, Second, Cm> = TypedScale::new(10.0);
+        let cm_per_second: Scale<f32, Second, Cm> = Scale::new(10.0);
 
         let result = length / cm_per_second;
 
@@ -514,7 +514,7 @@ mod tests {
 
         let result = length / length_zero;
 
-        let expected: TypedScale<f32, Cm, Cm> = TypedScale::new(INFINITY);
+        let expected: Scale<f32, Cm, Cm> = Scale::new(INFINITY);
         assert_eq!(result, expected);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,20 +18,20 @@
 //! a screen-space position by a world-space vector and this can be expressed using
 //! the generic Unit parameter.
 //!
-//! This unit system is not mandatory and all Typed* structures have an alias
+//! This unit system is not mandatory and all * structures have an alias
 //! with the default unit: `UnknownUnit`.
-//! for example ```Point2D<T>``` is equivalent to ```TypedPoint2D<T, UnknownUnit>```.
+//! for example ```Point2D<T>``` is equivalent to ```Point2D<T, UnknownUnit>```.
 //! Client code typically creates a set of aliases for each type and doesn't need
 //! to deal with the specifics of typed units further. For example:
 //!
 //! ```rust
 //! use euclid::*;
 //! pub struct ScreenSpace;
-//! pub type ScreenPoint = TypedPoint2D<f32, ScreenSpace>;
-//! pub type ScreenSize = TypedSize2D<f32, ScreenSpace>;
+//! pub type ScreenPoint = Point2D<f32, ScreenSpace>;
+//! pub type ScreenSize = Size2D<f32, ScreenSpace>;
 //! pub struct WorldSpace;
-//! pub type WorldPoint = TypedPoint3D<f32, WorldSpace>;
-//! pub type ProjectionMatrix = TypedTransform3D<f32, WorldSpace, ScreenSpace>;
+//! pub type WorldPoint = Point3D<f32, WorldSpace>;
+//! pub type ProjectionMatrix = Transform3D<f32, WorldSpace, ScreenSpace>;
 //! // etc...
 //! ```
 //!
@@ -45,7 +45,7 @@
 //! ```rust
 //! # use euclid::*;
 //! # pub struct WorldSpace;
-//! # pub type WorldPoint = TypedPoint3D<f32, WorldSpace>;
+//! # pub type WorldPoint = Point3D<f32, WorldSpace>;
 //! let p = WorldPoint::new(0.0, 1.0, 1.0);
 //! // p.x is an f32.
 //! println!("p.x = {:?} ", p.x);
@@ -67,23 +67,23 @@ extern crate rand;
 #[cfg(test)]
 use std as core;
 
-pub use box2d::{TypedBox2D, Box2D};
+pub use box2d::Box2D;
 pub use length::Length;
-pub use scale::TypedScale;
-pub use transform2d::{Transform2D, TypedTransform2D};
-pub use transform3d::{Transform3D, TypedTransform3D};
-pub use point::{Point2D, Point3D, TypedPoint2D, TypedPoint3D, point2, point3};
-pub use vector::{TypedVector2D, TypedVector3D, Vector2D, Vector3D, vec2, vec3};
+pub use scale::Scale;
+pub use transform2d::Transform2D;
+pub use transform3d::Transform3D;
+pub use point::{Point2D, Point3D, point2, point3};
+pub use vector::{Vector2D, Vector3D, vec2, vec3};
 pub use vector::{BoolVector2D, BoolVector3D, bvec2, bvec3};
 pub use homogen::HomogeneousVector;
 
-pub use rect::{rect, Rect, TypedRect};
-pub use rigid::{RigidTransform3D, TypedRigidTransform3D};
-pub use box3d::{box3d, Box3D, TypedBox3D};
-pub use translation::{TypedTranslation2D, TypedTranslation3D};
-pub use rotation::{Angle, Rotation2D, Rotation3D, TypedRotation2D, TypedRotation3D};
-pub use side_offsets::{SideOffsets2D, TypedSideOffsets2D};
-pub use size::{Size2D, TypedSize2D, TypedSize3D, size2, size3};
+pub use rect::{rect, Rect};
+pub use rigid::{RigidTransform3D};
+pub use box3d::{box3d, Box3D};
+pub use translation::{Translation2D, Translation3D};
+pub use rotation::{Angle, Rotation2D, Rotation3D};
+pub use side_offsets::SideOffsets2D;
+pub use size::{Size2D, Size3D, size2, size3};
 pub use trig::Trig;
 
 #[macro_use]
@@ -114,24 +114,23 @@ mod box3d;
 pub struct UnknownUnit;
 
 pub mod default {
-    use super::*;
-
-    pub type Point2D<T> = TypedPoint2D<T, UnknownUnit>;
-    pub type Point3D<T> = TypedPoint3D<T, UnknownUnit>;
-    pub type Vector2D<T> = TypedVector2D<T, UnknownUnit>;
-    pub type Vector3D<T> = TypedVector3D<T, UnknownUnit>;
-    pub type Vector4D<T> = HomogeneousVector<T, UnknownUnit>;
-    pub type Size2D<T> = TypedSize2D<T, UnknownUnit>;
-    pub type Size3D<T> = TypedSize3D<T, UnknownUnit>;
-    pub type Rect<T> = TypedRect<T, UnknownUnit>;
-    pub type Box2D<T> = TypedBox2D<T, UnknownUnit>;
-    pub type Box3D<T> = TypedBox3D<T, UnknownUnit>;
-    pub type SideOffsets2D<T> = TypedSideOffsets2D<T, UnknownUnit>;
-    pub type Tranform2D<T> = TypedTransform2D<T, UnknownUnit, UnknownUnit>;
-    pub type Tranform3D<T> = TypedTransform3D<T, UnknownUnit, UnknownUnit>;
-    pub type Rotation2D<T> = TypedRotation2D<T, UnknownUnit, UnknownUnit>;
-    pub type Rotation3D<T> = TypedRotation3D<T, UnknownUnit, UnknownUnit>;
-    pub type Translation3D<T> = TypedTranslation3D<T, UnknownUnit, UnknownUnit>;
-    pub type Scale<T> = TypedScale<T, UnknownUnit, UnknownUnit>;
-    pub type RigidTransform3D<T> = TypedRigidTransform3D<T, UnknownUnit, UnknownUnit>;
+    use super::UnknownUnit;
+    pub type Point2D<T> = super::Point2D<T, UnknownUnit>;
+    pub type Point3D<T> = super::Point3D<T, UnknownUnit>;
+    pub type Vector2D<T> = super::Vector2D<T, UnknownUnit>;
+    pub type Vector3D<T> = super::Vector3D<T, UnknownUnit>;
+    pub type Vector4D<T> = super::HomogeneousVector<T, UnknownUnit>;
+    pub type Size2D<T> = super::Size2D<T, UnknownUnit>;
+    pub type Size3D<T> = super::Size3D<T, UnknownUnit>;
+    pub type Rect<T> = super::Rect<T, UnknownUnit>;
+    pub type Box2D<T> = super::Box2D<T, UnknownUnit>;
+    pub type Box3D<T> = super::Box3D<T, UnknownUnit>;
+    pub type SideOffsets2D<T> = super::SideOffsets2D<T, UnknownUnit>;
+    pub type Transform2D<T> = super::Transform2D<T, UnknownUnit, UnknownUnit>;
+    pub type Transform3D<T> = super::Transform3D<T, UnknownUnit, UnknownUnit>;
+    pub type Rotation2D<T> = super::Rotation2D<T, UnknownUnit, UnknownUnit>;
+    pub type Rotation3D<T> = super::Rotation3D<T, UnknownUnit, UnknownUnit>;
+    pub type Translation3D<T> = super::Translation3D<T, UnknownUnit, UnknownUnit>;
+    pub type Scale<T> = super::Scale<T, UnknownUnit, UnknownUnit>;
+    pub type RigidTransform3D<T> = super::RigidTransform3D<T, UnknownUnit, UnknownUnit>;
 }

--- a/src/point.rs
+++ b/src/point.rs
@@ -10,13 +10,13 @@
 use super::UnknownUnit;
 use approxeq::ApproxEq;
 use length::Length;
-use scale::TypedScale;
-use size::{TypedSize2D, TypedSize3D};
+use scale::Scale;
+use size::{Size2D, Size3D};
 #[cfg(feature = "mint")]
 use mint;
 use num::*;
 use num_traits::{Float, NumCast};
-use vector::{TypedVector2D, TypedVector3D, vec2, vec3};
+use vector::{Vector2D, Vector3D, vec2, vec3};
 use core::fmt;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
 use core::marker::PhantomData;
@@ -27,18 +27,18 @@ use serde;
 
 /// A 2d Point tagged with a unit.
 #[repr(C)]
-pub struct TypedPoint2D<T, U> {
+pub struct Point2D<T, U> {
     pub x: T,
     pub y: T,
     #[doc(hidden)]
     pub _unit: PhantomData<U>,
 }
 
-impl<T: Copy, U> Copy for TypedPoint2D<T, U> {}
+impl<T: Copy, U> Copy for Point2D<T, U> {}
 
-impl<T: Clone, U> Clone for TypedPoint2D<T, U> {
+impl<T: Clone, U> Clone for Point2D<T, U> {
     fn clone(&self) -> Self {
-        TypedPoint2D {
+        Point2D {
             x: self.x.clone(),
             y: self.y.clone(),
             _unit: PhantomData,
@@ -47,19 +47,19 @@ impl<T: Clone, U> Clone for TypedPoint2D<T, U> {
 }
 
 #[cfg(feature = "serde")]
-impl<'de, T, U> serde::Deserialize<'de> for TypedPoint2D<T, U>
+impl<'de, T, U> serde::Deserialize<'de> for Point2D<T, U>
     where T: serde::Deserialize<'de>
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where D: serde::Deserializer<'de>
     {
         let (x, y) = try!(serde::Deserialize::deserialize(deserializer));
-        Ok(TypedPoint2D { x, y, _unit: PhantomData })
+        Ok(Point2D { x, y, _unit: PhantomData })
     }
 }
 
 #[cfg(feature = "serde")]
-impl<T, U> serde::Serialize for TypedPoint2D<T, U>
+impl<T, U> serde::Serialize for Point2D<T, U>
     where T: serde::Serialize
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -69,9 +69,9 @@ impl<T, U> serde::Serialize for TypedPoint2D<T, U>
     }
 }
 
-impl<T, U> Eq for TypedPoint2D<T, U> where T: Eq {}
+impl<T, U> Eq for Point2D<T, U> where T: Eq {}
 
-impl<T, U> PartialEq for TypedPoint2D<T, U>
+impl<T, U> PartialEq for Point2D<T, U>
     where T: PartialEq
 {
     fn eq(&self, other: &Self) -> bool {
@@ -79,7 +79,7 @@ impl<T, U> PartialEq for TypedPoint2D<T, U>
     }
 }
 
-impl<T, U> Hash for TypedPoint2D<T, U>
+impl<T, U> Hash for Point2D<T, U>
     where T: Hash
 {
     fn hash<H: ::core::hash::Hasher>(&self, h: &mut H) {
@@ -88,14 +88,9 @@ impl<T, U> Hash for TypedPoint2D<T, U>
     }
 }
 
-mint_vec!(TypedPoint2D[x, y] = Point2);
+mint_vec!(Point2D[x, y] = Point2);
 
-/// Default 2d point type with no unit.
-///
-/// `Point2D` provides the same methods as `TypedPoint2D`.
-pub type Point2D<T> = TypedPoint2D<T, UnknownUnit>;
-
-impl<T: Copy + Zero, U> TypedPoint2D<T, U> {
+impl<T: Copy + Zero, U> Point2D<T, U> {
     /// Constructor, setting all components to zero.
     #[inline]
     pub fn origin() -> Self {
@@ -109,34 +104,34 @@ impl<T: Copy + Zero, U> TypedPoint2D<T, U> {
 
     /// Convert into a 3d point.
     #[inline]
-    pub fn to_3d(&self) -> TypedPoint3D<T, U> {
+    pub fn to_3d(&self) -> Point3D<T, U> {
         point3(self.x, self.y, Zero::zero())
     }
 }
 
-impl<T: fmt::Debug, U> fmt::Debug for TypedPoint2D<T, U> {
+impl<T: fmt::Debug, U> fmt::Debug for Point2D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "({:?},{:?})", self.x, self.y)
     }
 }
 
-impl<T: fmt::Display, U> fmt::Display for TypedPoint2D<T, U> {
+impl<T: fmt::Display, U> fmt::Display for Point2D<T, U> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(formatter, "({},{})", self.x, self.y)
     }
 }
 
-impl<T: Default, U> Default for TypedPoint2D<T, U> {
+impl<T: Default, U> Default for Point2D<T, U> {
     fn default() -> Self {
-        TypedPoint2D::new(Default::default(), Default::default())
+        Point2D::new(Default::default(), Default::default())
     }
 }
 
-impl<T, U> TypedPoint2D<T, U> {
+impl<T, U> Point2D<T, U> {
     /// Constructor taking scalar values directly.
     #[inline]
     pub fn new(x: T, y: T) -> Self {
-        TypedPoint2D {
+        Point2D {
             x,
             y,
             _unit: PhantomData,
@@ -144,8 +139,8 @@ impl<T, U> TypedPoint2D<T, U> {
     }
 }
 
-impl<T: Copy, U> TypedPoint2D<T, U> {
-    /// Constructor taking properly typed Lengths instead of scalar values.
+impl<T: Copy, U> Point2D<T, U> {
+    /// Constructor taking properly  Lengths instead of scalar values.
     #[inline]
     pub fn from_lengths(x: Length<T, U>, y: Length<T, U>) -> Self {
         point2(x.0, y.0)
@@ -153,7 +148,7 @@ impl<T: Copy, U> TypedPoint2D<T, U> {
 
     /// Create a 3d point from this one, using the specified z value.
     #[inline]
-    pub fn extend(&self, z: T) -> TypedPoint3D<T, U> {
+    pub fn extend(&self, z: T) -> Point3D<T, U> {
         point3(self.x, self.y, z)
     }
 
@@ -161,8 +156,8 @@ impl<T: Copy, U> TypedPoint2D<T, U> {
     ///
     /// Equivalent to subtracting the origin from this point.
     #[inline]
-    pub fn to_vector(&self) -> TypedVector2D<T, U> {
-        TypedVector2D {
+    pub fn to_vector(&self) -> Vector2D<T, U> {
+        Vector2D {
             x: self.x,
             y: self.y,
             _unit: PhantomData,
@@ -189,13 +184,13 @@ impl<T: Copy, U> TypedPoint2D<T, U> {
 
     /// Drop the units, preserving only the numeric value.
     #[inline]
-    pub fn to_untyped(&self) -> Point2D<T> {
+    pub fn to_untyped(&self) -> Point2D<T, UnknownUnit> {
         point2(self.x, self.y)
     }
 
     /// Tag a unitless value with units.
     #[inline]
-    pub fn from_untyped(p: &Point2D<T>) -> Self {
+    pub fn from_untyped(p: &Point2D<T, UnknownUnit>) -> Self {
         point2(p.x, p.y)
     }
 
@@ -210,60 +205,60 @@ impl<T: Copy, U> TypedPoint2D<T, U> {
     }
 }
 
-impl<T: Copy + Add<T, Output = T>, U> TypedPoint2D<T, U> {
+impl<T: Copy + Add<T, Output = T>, U> Point2D<T, U> {
     #[inline]
-    pub fn add_size(&self, other: &TypedSize2D<T, U>) -> Self {
+    pub fn add_size(&self, other: &Size2D<T, U>) -> Self {
         point2(self.x + other.width, self.y + other.height)
     }
 }
 
-impl<T: Copy + Add<T, Output = T>, U> Add<TypedSize2D<T, U>> for TypedPoint2D<T, U> {
+impl<T: Copy + Add<T, Output = T>, U> Add<Size2D<T, U>> for Point2D<T, U> {
     type Output = Self;
     #[inline]
-    fn add(self, other: TypedSize2D<T, U>) -> Self {
+    fn add(self, other: Size2D<T, U>) -> Self {
         point2(self.x + other.width, self.y + other.height)
     }
 }
 
-impl<T: Copy + Add<T, Output = T>, U> AddAssign<TypedVector2D<T, U>> for TypedPoint2D<T, U> {
+impl<T: Copy + Add<T, Output = T>, U> AddAssign<Vector2D<T, U>> for Point2D<T, U> {
     #[inline]
-    fn add_assign(&mut self, other: TypedVector2D<T, U>) {
+    fn add_assign(&mut self, other: Vector2D<T, U>) {
         *self = *self + other
     }
 }
 
-impl<T: Copy + Sub<T, Output = T>, U> SubAssign<TypedVector2D<T, U>> for TypedPoint2D<T, U> {
+impl<T: Copy + Sub<T, Output = T>, U> SubAssign<Vector2D<T, U>> for Point2D<T, U> {
     #[inline]
-    fn sub_assign(&mut self, other: TypedVector2D<T, U>) {
+    fn sub_assign(&mut self, other: Vector2D<T, U>) {
         *self = *self - other
     }
 }
 
-impl<T: Copy + Add<T, Output = T>, U> Add<TypedVector2D<T, U>> for TypedPoint2D<T, U> {
+impl<T: Copy + Add<T, Output = T>, U> Add<Vector2D<T, U>> for Point2D<T, U> {
     type Output = Self;
     #[inline]
-    fn add(self, other: TypedVector2D<T, U>) -> Self {
+    fn add(self, other: Vector2D<T, U>) -> Self {
         point2(self.x + other.x, self.y + other.y)
     }
 }
 
-impl<T: Copy + Sub<T, Output = T>, U> Sub for TypedPoint2D<T, U> {
-    type Output = TypedVector2D<T, U>;
+impl<T: Copy + Sub<T, Output = T>, U> Sub for Point2D<T, U> {
+    type Output = Vector2D<T, U>;
     #[inline]
-    fn sub(self, other: Self) -> TypedVector2D<T, U> {
+    fn sub(self, other: Self) -> Vector2D<T, U> {
         vec2(self.x - other.x, self.y - other.y)
     }
 }
 
-impl<T: Copy + Sub<T, Output = T>, U> Sub<TypedVector2D<T, U>> for TypedPoint2D<T, U> {
+impl<T: Copy + Sub<T, Output = T>, U> Sub<Vector2D<T, U>> for Point2D<T, U> {
     type Output = Self;
     #[inline]
-    fn sub(self, other: TypedVector2D<T, U>) -> Self {
+    fn sub(self, other: Vector2D<T, U>) -> Self {
         point2(self.x - other.x, self.y - other.y)
     }
 }
 
-impl<T: Float, U> TypedPoint2D<T, U> {
+impl<T: Float, U> Point2D<T, U> {
     #[inline]
     pub fn min(self, other: Self) -> Self {
         point2(self.x.min(other.x), self.y.min(other.y))
@@ -280,7 +275,7 @@ impl<T: Float, U> TypedPoint2D<T, U> {
     }
 }
 
-impl<T: Copy + Mul<T, Output = T>, U> Mul<T> for TypedPoint2D<T, U> {
+impl<T: Copy + Mul<T, Output = T>, U> Mul<T> for Point2D<T, U> {
     type Output = Self;
     #[inline]
     fn mul(self, scale: T) -> Self {
@@ -288,14 +283,14 @@ impl<T: Copy + Mul<T, Output = T>, U> Mul<T> for TypedPoint2D<T, U> {
     }
 }
 
-impl<T: Copy + Mul<T, Output = T>, U> MulAssign<T> for TypedPoint2D<T, U> {
+impl<T: Copy + Mul<T, Output = T>, U> MulAssign<T> for Point2D<T, U> {
     #[inline]
     fn mul_assign(&mut self, scale: T) {
         *self = *self * scale
     }
 }
 
-impl<T: Copy + Div<T, Output = T>, U> Div<T> for TypedPoint2D<T, U> {
+impl<T: Copy + Div<T, Output = T>, U> Div<T> for Point2D<T, U> {
     type Output = Self;
     #[inline]
     fn div(self, scale: T) -> Self {
@@ -303,30 +298,30 @@ impl<T: Copy + Div<T, Output = T>, U> Div<T> for TypedPoint2D<T, U> {
     }
 }
 
-impl<T: Copy + Div<T, Output = T>, U> DivAssign<T> for TypedPoint2D<T, U> {
+impl<T: Copy + Div<T, Output = T>, U> DivAssign<T> for Point2D<T, U> {
     #[inline]
     fn div_assign(&mut self, scale: T) {
         *self = *self / scale
     }
 }
 
-impl<T: Copy + Mul<T, Output = T>, U1, U2> Mul<TypedScale<T, U1, U2>> for TypedPoint2D<T, U1> {
-    type Output = TypedPoint2D<T, U2>;
+impl<T: Copy + Mul<T, Output = T>, U1, U2> Mul<Scale<T, U1, U2>> for Point2D<T, U1> {
+    type Output = Point2D<T, U2>;
     #[inline]
-    fn mul(self, scale: TypedScale<T, U1, U2>) -> TypedPoint2D<T, U2> {
+    fn mul(self, scale: Scale<T, U1, U2>) -> Point2D<T, U2> {
         point2(self.x * scale.get(), self.y * scale.get())
     }
 }
 
-impl<T: Copy + Div<T, Output = T>, U1, U2> Div<TypedScale<T, U1, U2>> for TypedPoint2D<T, U2> {
-    type Output = TypedPoint2D<T, U1>;
+impl<T: Copy + Div<T, Output = T>, U1, U2> Div<Scale<T, U1, U2>> for Point2D<T, U2> {
+    type Output = Point2D<T, U1>;
     #[inline]
-    fn div(self, scale: TypedScale<T, U1, U2>) -> TypedPoint2D<T, U1> {
+    fn div(self, scale: Scale<T, U1, U2>) -> Point2D<T, U1> {
         point2(self.x / scale.get(), self.y / scale.get())
     }
 }
 
-impl<T: Round, U> TypedPoint2D<T, U> {
+impl<T: Round, U> Point2D<T, U> {
     /// Rounds each component to the nearest integer value.
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
@@ -338,7 +333,7 @@ impl<T: Round, U> TypedPoint2D<T, U> {
     }
 }
 
-impl<T: Ceil, U> TypedPoint2D<T, U> {
+impl<T: Ceil, U> Point2D<T, U> {
     /// Rounds each component to the smallest integer equal or greater than the original value.
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
@@ -350,7 +345,7 @@ impl<T: Ceil, U> TypedPoint2D<T, U> {
     }
 }
 
-impl<T: Floor, U> TypedPoint2D<T, U> {
+impl<T: Floor, U> Point2D<T, U> {
     /// Rounds each component to the biggest integer equal or lower than the original value.
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
@@ -362,14 +357,14 @@ impl<T: Floor, U> TypedPoint2D<T, U> {
     }
 }
 
-impl<T: NumCast + Copy, U> TypedPoint2D<T, U> {
+impl<T: NumCast + Copy, U> Point2D<T, U> {
     /// Cast from one numeric representation to another, preserving the units.
     ///
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
     #[inline]
-    pub fn cast<NewT: NumCast + Copy>(&self) -> TypedPoint2D<NewT, U> {
+    pub fn cast<NewT: NumCast + Copy>(&self) -> Point2D<NewT, U> {
         self.try_cast().unwrap()
     }
 
@@ -378,7 +373,7 @@ impl<T: NumCast + Copy, U> TypedPoint2D<T, U> {
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
-    pub fn try_cast<NewT: NumCast + Copy>(&self) -> Option<TypedPoint2D<NewT, U>> {
+    pub fn try_cast<NewT: NumCast + Copy>(&self) -> Option<Point2D<NewT, U>> {
         match (NumCast::from(self.x), NumCast::from(self.y)) {
             (Some(x), Some(y)) => Some(point2(x, y)),
             _ => None,
@@ -389,13 +384,13 @@ impl<T: NumCast + Copy, U> TypedPoint2D<T, U> {
 
     /// Cast into an `f32` point.
     #[inline]
-    pub fn to_f32(&self) -> TypedPoint2D<f32, U> {
+    pub fn to_f32(&self) -> Point2D<f32, U> {
         self.cast()
     }
 
     /// Cast into an `f64` point.
     #[inline]
-    pub fn to_f64(&self) -> TypedPoint2D<f64, U> {
+    pub fn to_f64(&self) -> Point2D<f64, U> {
         self.cast()
     }
 
@@ -405,7 +400,7 @@ impl<T: NumCast + Copy, U> TypedPoint2D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_usize(&self) -> TypedPoint2D<usize, U> {
+    pub fn to_usize(&self) -> Point2D<usize, U> {
         self.cast()
     }
 
@@ -415,7 +410,7 @@ impl<T: NumCast + Copy, U> TypedPoint2D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_u32(&self) -> TypedPoint2D<u32, U> {
+    pub fn to_u32(&self) -> Point2D<u32, U> {
         self.cast()
     }
 
@@ -425,7 +420,7 @@ impl<T: NumCast + Copy, U> TypedPoint2D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_i32(&self) -> TypedPoint2D<i32, U> {
+    pub fn to_i32(&self) -> Point2D<i32, U> {
         self.cast()
     }
 
@@ -435,12 +430,12 @@ impl<T: NumCast + Copy, U> TypedPoint2D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_i64(&self) -> TypedPoint2D<i64, U> {
+    pub fn to_i64(&self) -> Point2D<i64, U> {
         self.cast()
     }
 }
 
-impl<T, U> TypedPoint2D<T, U>
+impl<T, U> Point2D<T, U>
 where
     T: Copy + One + Add<Output = T> + Sub<Output = T> + Mul<Output = T>,
 {
@@ -454,7 +449,7 @@ where
     }
 }
 
-impl<T: Copy + ApproxEq<T>, U> ApproxEq<TypedPoint2D<T, U>> for TypedPoint2D<T, U> {
+impl<T: Copy + ApproxEq<T>, U> ApproxEq<Point2D<T, U>> for Point2D<T, U> {
     #[inline]
     fn approx_epsilon() -> Self {
         point2(T::approx_epsilon(), T::approx_epsilon())
@@ -471,25 +466,25 @@ impl<T: Copy + ApproxEq<T>, U> ApproxEq<TypedPoint2D<T, U>> for TypedPoint2D<T, 
     }
 }
 
-impl<T: Copy, U> Into<[T; 2]> for TypedPoint2D<T, U> {
+impl<T: Copy, U> Into<[T; 2]> for Point2D<T, U> {
     fn into(self) -> [T; 2] {
         self.to_array()
     }
 }
 
-impl<T: Copy, U> From<[T; 2]> for TypedPoint2D<T, U> {
+impl<T: Copy, U> From<[T; 2]> for Point2D<T, U> {
     fn from(array: [T; 2]) -> Self {
         point2(array[0], array[1])
     }
 }
 
-impl<T: Copy, U> Into<(T, T)> for TypedPoint2D<T, U> {
+impl<T: Copy, U> Into<(T, T)> for Point2D<T, U> {
     fn into(self) -> (T, T) {
         self.to_tuple()
     }
 }
 
-impl<T: Copy, U> From<(T, T)> for TypedPoint2D<T, U> {
+impl<T: Copy, U> From<(T, T)> for Point2D<T, U> {
     fn from(tuple: (T, T)) -> Self {
         point2(tuple.0, tuple.1)
     }
@@ -497,7 +492,7 @@ impl<T: Copy, U> From<(T, T)> for TypedPoint2D<T, U> {
 
 /// A 3d Point tagged with a unit.
 #[repr(C)]
-pub struct TypedPoint3D<T, U> {
+pub struct Point3D<T, U> {
     pub x: T,
     pub y: T,
     pub z: T,
@@ -505,13 +500,13 @@ pub struct TypedPoint3D<T, U> {
     pub _unit: PhantomData<U>,
 }
 
-mint_vec!(TypedPoint3D[x, y, z] = Point3);
+mint_vec!(Point3D[x, y, z] = Point3);
 
-impl<T: Copy, U> Copy for TypedPoint3D<T, U> {}
+impl<T: Copy, U> Copy for Point3D<T, U> {}
 
-impl<T: Clone, U> Clone for TypedPoint3D<T, U> {
+impl<T: Clone, U> Clone for Point3D<T, U> {
     fn clone(&self) -> Self {
-        TypedPoint3D {
+        Point3D {
             x: self.x.clone(),
             y: self.y.clone(),
             z: self.z.clone(),
@@ -521,19 +516,19 @@ impl<T: Clone, U> Clone for TypedPoint3D<T, U> {
 }
 
 #[cfg(feature = "serde")]
-impl<'de, T, U> serde::Deserialize<'de> for TypedPoint3D<T, U>
+impl<'de, T, U> serde::Deserialize<'de> for Point3D<T, U>
     where T: serde::Deserialize<'de>
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where D: serde::Deserializer<'de>
     {
         let (x, y, z) = try!(serde::Deserialize::deserialize(deserializer));
-        Ok(TypedPoint3D { x, y, z, _unit: PhantomData })
+        Ok(Point3D { x, y, z, _unit: PhantomData })
     }
 }
 
 #[cfg(feature = "serde")]
-impl<T, U> serde::Serialize for TypedPoint3D<T, U>
+impl<T, U> serde::Serialize for Point3D<T, U>
     where T: serde::Serialize
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -543,9 +538,9 @@ impl<T, U> serde::Serialize for TypedPoint3D<T, U>
     }
 }
 
-impl<T, U> Eq for TypedPoint3D<T, U> where T: Eq {}
+impl<T, U> Eq for Point3D<T, U> where T: Eq {}
 
-impl<T, U> PartialEq for TypedPoint3D<T, U>
+impl<T, U> PartialEq for Point3D<T, U>
     where T: PartialEq
 {
     fn eq(&self, other: &Self) -> bool {
@@ -553,7 +548,7 @@ impl<T, U> PartialEq for TypedPoint3D<T, U>
     }
 }
 
-impl<T, U> Hash for TypedPoint3D<T, U>
+impl<T, U> Hash for Point3D<T, U>
     where T: Hash
 {
     fn hash<H: ::core::hash::Hasher>(&self, h: &mut H) {
@@ -563,12 +558,7 @@ impl<T, U> Hash for TypedPoint3D<T, U>
     }
 }
 
-/// Default 3d point type with no unit.
-///
-/// `Point3D` provides the same methods as `TypedPoint3D`.
-pub type Point3D<T> = TypedPoint3D<T, UnknownUnit>;
-
-impl<T: Copy + Zero, U> TypedPoint3D<T, U> {
+impl<T: Copy + Zero, U> Point3D<T, U> {
     /// Constructor, setting all components to zero.
     #[inline]
     pub fn origin() -> Self {
@@ -581,7 +571,7 @@ impl<T: Copy + Zero, U> TypedPoint3D<T, U> {
     }
 }
 
-impl<T: Copy + One, U> TypedPoint3D<T, U> {
+impl<T: Copy + One, U> Point3D<T, U> {
     #[inline]
     pub fn to_array_4d(&self) -> [T; 4] {
         [self.x, self.y, self.z, One::one()]
@@ -593,7 +583,7 @@ impl<T: Copy + One, U> TypedPoint3D<T, U> {
     }
 }
 
-impl<T, U> TypedPoint3D<T, U>
+impl<T, U> Point3D<T, U>
 where
     T: Copy + One + Add<Output = T> + Sub<Output = T> + Mul<Output = T>,
 {
@@ -611,29 +601,29 @@ where
     }
 }
 
-impl<T: fmt::Debug, U> fmt::Debug for TypedPoint3D<T, U> {
+impl<T: fmt::Debug, U> fmt::Debug for Point3D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "({:?},{:?},{:?})", self.x, self.y, self.z)
     }
 }
 
-impl<T: fmt::Display, U> fmt::Display for TypedPoint3D<T, U> {
+impl<T: fmt::Display, U> fmt::Display for Point3D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "({},{},{})", self.x, self.y, self.z)
     }
 }
 
-impl<T: Copy + Default, U> Default for TypedPoint3D<T, U> {
+impl<T: Copy + Default, U> Default for Point3D<T, U> {
     fn default() -> Self {
-        TypedPoint3D::new(Default::default(), Default::default(), Default::default())
+        Point3D::new(Default::default(), Default::default(), Default::default())
     }
 }
 
-impl<T: Copy, U> TypedPoint3D<T, U> {
+impl<T: Copy, U> Point3D<T, U> {
     /// Constructor taking scalar values directly.
     #[inline]
     pub fn new(x: T, y: T, z: T) -> Self {
-        TypedPoint3D {
+        Point3D {
             x,
             y,
             z,
@@ -641,7 +631,7 @@ impl<T: Copy, U> TypedPoint3D<T, U> {
         }
     }
 
-    /// Constructor taking properly typed Lengths instead of scalar values.
+    /// Constructor taking properly  Lengths instead of scalar values.
     #[inline]
     pub fn from_lengths(x: Length<T, U>, y: Length<T, U>, z: Length<T, U>) -> Self {
         point3(x.0, y.0, z.0)
@@ -651,8 +641,8 @@ impl<T: Copy, U> TypedPoint3D<T, U> {
     ///
     /// Equivalent to subtracting the origin to this point.
     #[inline]
-    pub fn to_vector(&self) -> TypedVector3D<T, U> {
-        TypedVector3D {
+    pub fn to_vector(&self) -> Vector3D<T, U> {
+        Vector3D {
             x: self.x,
             y: self.y,
             z: self.z,
@@ -662,19 +652,19 @@ impl<T: Copy, U> TypedPoint3D<T, U> {
 
     /// Returns a 2d point using this point's x and y coordinates
     #[inline]
-    pub fn xy(&self) -> TypedPoint2D<T, U> {
+    pub fn xy(&self) -> Point2D<T, U> {
         point2(self.x, self.y)
     }
 
     /// Returns a 2d point using this point's x and z coordinates
     #[inline]
-    pub fn xz(&self) -> TypedPoint2D<T, U> {
+    pub fn xz(&self) -> Point2D<T, U> {
         point2(self.x, self.z)
     }
 
     /// Returns a 2d point using this point's x and z coordinates
     #[inline]
-    pub fn yz(&self) -> TypedPoint2D<T, U> {
+    pub fn yz(&self) -> Point2D<T, U> {
         point2(self.y, self.z)
     }
 
@@ -708,69 +698,69 @@ impl<T: Copy, U> TypedPoint3D<T, U> {
 
     /// Drop the units, preserving only the numeric value.
     #[inline]
-    pub fn to_untyped(&self) -> Point3D<T> {
+    pub fn to_untyped(&self) -> Point3D<T, UnknownUnit> {
         point3(self.x, self.y, self.z)
     }
 
     /// Tag a unitless value with units.
     #[inline]
-    pub fn from_untyped(p: &Point3D<T>) -> Self {
+    pub fn from_untyped(p: &Point3D<T, UnknownUnit>) -> Self {
         point3(p.x, p.y, p.z)
     }
 
     /// Convert into a 2d point.
     #[inline]
-    pub fn to_2d(&self) -> TypedPoint2D<T, U> {
+    pub fn to_2d(&self) -> Point2D<T, U> {
         self.xy()
     }
 }
 
-impl<T: Copy + Add<T, Output = T>, U> TypedPoint3D<T, U> {
+impl<T: Copy + Add<T, Output = T>, U> Point3D<T, U> {
     #[inline]
-    pub fn add_size(&self, other: &TypedSize3D<T, U>) -> Self {
+    pub fn add_size(&self, other: &Size3D<T, U>) -> Self {
         point3(self.x + other.width, self.y + other.height, self.z + other.depth)
     }
 }
 
-impl<T: Copy + Add<T, Output = T>, U> AddAssign<TypedVector3D<T, U>> for TypedPoint3D<T, U> {
+impl<T: Copy + Add<T, Output = T>, U> AddAssign<Vector3D<T, U>> for Point3D<T, U> {
     #[inline]
-    fn add_assign(&mut self, other: TypedVector3D<T, U>) {
+    fn add_assign(&mut self, other: Vector3D<T, U>) {
         *self = *self + other
     }
 }
 
-impl<T: Copy + Sub<T, Output = T>, U> SubAssign<TypedVector3D<T, U>> for TypedPoint3D<T, U> {
+impl<T: Copy + Sub<T, Output = T>, U> SubAssign<Vector3D<T, U>> for Point3D<T, U> {
     #[inline]
-    fn sub_assign(&mut self, other: TypedVector3D<T, U>) {
+    fn sub_assign(&mut self, other: Vector3D<T, U>) {
         *self = *self - other
     }
 }
 
-impl<T: Copy + Add<T, Output = T>, U> Add<TypedVector3D<T, U>> for TypedPoint3D<T, U> {
+impl<T: Copy + Add<T, Output = T>, U> Add<Vector3D<T, U>> for Point3D<T, U> {
     type Output = Self;
     #[inline]
-    fn add(self, other: TypedVector3D<T, U>) -> Self {
+    fn add(self, other: Vector3D<T, U>) -> Self {
         point3(self.x + other.x, self.y + other.y, self.z + other.z)
     }
 }
 
-impl<T: Copy + Sub<T, Output = T>, U> Sub for TypedPoint3D<T, U> {
-    type Output = TypedVector3D<T, U>;
+impl<T: Copy + Sub<T, Output = T>, U> Sub for Point3D<T, U> {
+    type Output = Vector3D<T, U>;
     #[inline]
-    fn sub(self, other: Self) -> TypedVector3D<T, U> {
+    fn sub(self, other: Self) -> Vector3D<T, U> {
         vec3(self.x - other.x, self.y - other.y, self.z - other.z)
     }
 }
 
-impl<T: Copy + Sub<T, Output = T>, U> Sub<TypedVector3D<T, U>> for TypedPoint3D<T, U> {
+impl<T: Copy + Sub<T, Output = T>, U> Sub<Vector3D<T, U>> for Point3D<T, U> {
     type Output = Self;
     #[inline]
-    fn sub(self, other: TypedVector3D<T, U>) -> Self {
+    fn sub(self, other: Vector3D<T, U>) -> Self {
         point3(self.x - other.x, self.y - other.y, self.z - other.z)
     }
 }
 
-impl<T: Copy + Mul<T, Output = T>, U> Mul<T> for TypedPoint3D<T, U> {
+impl<T: Copy + Mul<T, Output = T>, U> Mul<T> for Point3D<T, U> {
     type Output = Self;
     #[inline]
     fn mul(self, scale: T) -> Self {
@@ -778,15 +768,15 @@ impl<T: Copy + Mul<T, Output = T>, U> Mul<T> for TypedPoint3D<T, U> {
     }
 }
 
-impl<T: Copy + Mul<T, Output = T>, U1, U2> Mul<TypedScale<T, U1, U2>> for TypedPoint3D<T, U1> {
-    type Output = TypedPoint3D<T, U2>;
+impl<T: Copy + Mul<T, Output = T>, U1, U2> Mul<Scale<T, U1, U2>> for Point3D<T, U1> {
+    type Output = Point3D<T, U2>;
     #[inline]
-    fn mul(self, scale: TypedScale<T, U1, U2>) -> TypedPoint3D<T, U2> {
+    fn mul(self, scale: Scale<T, U1, U2>) -> Point3D<T, U2> {
         point3(self.x * scale.get(), self.y * scale.get(), self.z * scale.get())
     }
 }
 
-impl<T: Copy + Div<T, Output = T>, U> Div<T> for TypedPoint3D<T, U> {
+impl<T: Copy + Div<T, Output = T>, U> Div<T> for Point3D<T, U> {
     type Output = Self;
     #[inline]
     fn div(self, scale: T) -> Self {
@@ -794,15 +784,15 @@ impl<T: Copy + Div<T, Output = T>, U> Div<T> for TypedPoint3D<T, U> {
     }
 }
 
-impl<T: Copy + Div<T, Output = T>, U1, U2> Div<TypedScale<T, U1, U2>> for TypedPoint3D<T, U2> {
-    type Output = TypedPoint3D<T, U1>;
+impl<T: Copy + Div<T, Output = T>, U1, U2> Div<Scale<T, U1, U2>> for Point3D<T, U2> {
+    type Output = Point3D<T, U1>;
     #[inline]
-    fn div(self, scale: TypedScale<T, U1, U2>) -> TypedPoint3D<T, U1> {
+    fn div(self, scale: Scale<T, U1, U2>) -> Point3D<T, U1> {
         point3(self.x / scale.get(), self.y / scale.get(), self.z / scale.get())
     }
 }
 
-impl<T: Float, U> TypedPoint3D<T, U> {
+impl<T: Float, U> Point3D<T, U> {
     #[inline]
     pub fn min(self, other: Self) -> Self {
         point3(
@@ -827,7 +817,7 @@ impl<T: Float, U> TypedPoint3D<T, U> {
     }
 }
 
-impl<T: Round, U> TypedPoint3D<T, U> {
+impl<T: Round, U> Point3D<T, U> {
     /// Rounds each component to the nearest integer value.
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
@@ -838,7 +828,7 @@ impl<T: Round, U> TypedPoint3D<T, U> {
     }
 }
 
-impl<T: Ceil, U> TypedPoint3D<T, U> {
+impl<T: Ceil, U> Point3D<T, U> {
     /// Rounds each component to the smallest integer equal or greater than the original value.
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
@@ -849,7 +839,7 @@ impl<T: Ceil, U> TypedPoint3D<T, U> {
     }
 }
 
-impl<T: Floor, U> TypedPoint3D<T, U> {
+impl<T: Floor, U> Point3D<T, U> {
     /// Rounds each component to the biggest integer equal or lower than the original value.
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
@@ -860,14 +850,14 @@ impl<T: Floor, U> TypedPoint3D<T, U> {
     }
 }
 
-impl<T: NumCast + Copy, U> TypedPoint3D<T, U> {
+impl<T: NumCast + Copy, U> Point3D<T, U> {
     /// Cast from one numeric representation to another, preserving the units.
     ///
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
     #[inline]
-    pub fn cast<NewT: NumCast + Copy>(&self) -> TypedPoint3D<NewT, U> {
+    pub fn cast<NewT: NumCast + Copy>(&self) -> Point3D<NewT, U> {
         self.try_cast().unwrap()
     }
 
@@ -877,7 +867,7 @@ impl<T: NumCast + Copy, U> TypedPoint3D<T, U> {
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
     #[inline]
-    pub fn try_cast<NewT: NumCast + Copy>(&self) -> Option<TypedPoint3D<NewT, U>> {
+    pub fn try_cast<NewT: NumCast + Copy>(&self) -> Option<Point3D<NewT, U>> {
         match (
             NumCast::from(self.x),
             NumCast::from(self.y),
@@ -892,13 +882,13 @@ impl<T: NumCast + Copy, U> TypedPoint3D<T, U> {
 
     /// Cast into an `f32` point.
     #[inline]
-    pub fn to_f32(&self) -> TypedPoint3D<f32, U> {
+    pub fn to_f32(&self) -> Point3D<f32, U> {
         self.cast()
     }
 
     /// Cast into an `f64` point.
     #[inline]
-    pub fn to_f64(&self) -> TypedPoint3D<f64, U> {
+    pub fn to_f64(&self) -> Point3D<f64, U> {
         self.cast()
     }
 
@@ -908,7 +898,7 @@ impl<T: NumCast + Copy, U> TypedPoint3D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_usize(&self) -> TypedPoint3D<usize, U> {
+    pub fn to_usize(&self) -> Point3D<usize, U> {
         self.cast()
     }
 
@@ -918,7 +908,7 @@ impl<T: NumCast + Copy, U> TypedPoint3D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_u32(&self) -> TypedPoint3D<u32, U> {
+    pub fn to_u32(&self) -> Point3D<u32, U> {
         self.cast()
     }
 
@@ -928,7 +918,7 @@ impl<T: NumCast + Copy, U> TypedPoint3D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_i32(&self) -> TypedPoint3D<i32, U> {
+    pub fn to_i32(&self) -> Point3D<i32, U> {
         self.cast()
     }
 
@@ -938,12 +928,12 @@ impl<T: NumCast + Copy, U> TypedPoint3D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_i64(&self) -> TypedPoint3D<i64, U> {
+    pub fn to_i64(&self) -> Point3D<i64, U> {
         self.cast()
     }
 }
 
-impl<T: Copy + ApproxEq<T>, U> ApproxEq<TypedPoint3D<T, U>> for TypedPoint3D<T, U> {
+impl<T: Copy + ApproxEq<T>, U> ApproxEq<Point3D<T, U>> for Point3D<T, U> {
     #[inline]
     fn approx_epsilon() -> Self {
         point3(
@@ -965,33 +955,33 @@ impl<T: Copy + ApproxEq<T>, U> ApproxEq<TypedPoint3D<T, U>> for TypedPoint3D<T, 
     }
 }
 
-impl<T: Copy, U> Into<[T; 3]> for TypedPoint3D<T, U> {
+impl<T: Copy, U> Into<[T; 3]> for Point3D<T, U> {
     fn into(self) -> [T; 3] {
         self.to_array()
     }
 }
 
-impl<T: Copy, U> From<[T; 3]> for TypedPoint3D<T, U> {
+impl<T: Copy, U> From<[T; 3]> for Point3D<T, U> {
     fn from(array: [T; 3]) -> Self {
         point3(array[0], array[1], array[2])
     }
 }
 
-impl<T: Copy, U> Into<(T, T, T)> for TypedPoint3D<T, U> {
+impl<T: Copy, U> Into<(T, T, T)> for Point3D<T, U> {
     fn into(self) -> (T, T, T) {
         self.to_tuple()
     }
 }
 
-impl<T: Copy, U> From<(T, T, T)> for TypedPoint3D<T, U> {
+impl<T: Copy, U> From<(T, T, T)> for Point3D<T, U> {
     fn from(tuple: (T, T, T)) -> Self {
         point3(tuple.0, tuple.1, tuple.2)
     }
 }
 
 #[inline]
-pub fn point2<T: Copy, U>(x: T, y: T) -> TypedPoint2D<T, U> {
-    TypedPoint2D {
+pub fn point2<T: Copy, U>(x: T, y: T) -> Point2D<T, U> {
+    Point2D {
         x,
         y,
         _unit: PhantomData,
@@ -999,8 +989,8 @@ pub fn point2<T: Copy, U>(x: T, y: T) -> TypedPoint2D<T, U> {
 }
 
 #[inline]
-pub fn point3<T: Copy, U>(x: T, y: T, z: T) -> TypedPoint3D<T, U> {
-    TypedPoint3D {
+pub fn point3<T: Copy, U>(x: T, y: T, z: T) -> Point3D<T, U> {
+    Point3D {
         x,
         y,
         z,
@@ -1011,7 +1001,10 @@ pub fn point3<T: Copy, U>(x: T, y: T, z: T) -> TypedPoint3D<T, U> {
 
 #[cfg(test)]
 mod point2d {
-    use super::Point2D;
+    use default::Point2D;
+    use {point2, vec2};
+    use scale::Scale;
+
     #[cfg(feature = "mint")]
     use mint;
 
@@ -1053,19 +1046,12 @@ mod point2d {
 
         assert_eq!(p1, p2);
     }
-}
-
-#[cfg(test)]
-mod typedpoint2d {
-    use super::{Point2D, TypedPoint2D, point2};
-    use scale::TypedScale;
-    use vector::vec2;
 
     pub enum Mm {}
     pub enum Cm {}
 
-    pub type Point2DMm<T> = TypedPoint2D<T, Mm>;
-    pub type Point2DCm<T> = TypedPoint2D<T, Cm>;
+    pub type Point2DMm<T> = super::Point2D<T, Mm>;
+    pub type Point2DCm<T> = super::Point2D<T, Cm>;
 
     #[test]
     pub fn test_add() {
@@ -1086,9 +1072,9 @@ mod typedpoint2d {
     }
 
     #[test]
-    pub fn test_scalar_mul() {
+    pub fn test_typed_scalar_mul() {
         let p1 = Point2DMm::new(1.0, 2.0);
-        let cm_per_mm: TypedScale<f32, Mm, Cm> = TypedScale::new(0.1);
+        let cm_per_mm: Scale<f32, Mm, Cm> = Scale::new(0.1);
 
         let result = p1 * cm_per_mm;
 
@@ -1097,8 +1083,6 @@ mod typedpoint2d {
 
     #[test]
     pub fn test_conv_vector() {
-        use {Point2D, point2};
-
         for i in 0..100 {
             // We don't care about these values as long as they are not the same.
             let x = i as f32 * 0.012345;
@@ -1117,7 +1101,9 @@ mod typedpoint2d {
 
 #[cfg(test)]
 mod point3d {
-    use super::{Point3D, point2, point3};
+    use default;
+    use default::Point3D;
+    use {point2, point3};
     #[cfg(feature = "mint")]
     use mint;
 
@@ -1156,7 +1142,7 @@ mod point3d {
 
     #[test]
     pub fn test_swizzling() {
-        let p: Point3D<i32> = point3(1, 2, 3);
+        let p: default::Point3D<i32> = point3(1, 2, 3);
         assert_eq!(p.xy(), point2(1, 2));
         assert_eq!(p.xz(), point2(1, 3));
         assert_eq!(p.yz(), point2(2, 3));
@@ -1171,5 +1157,4 @@ mod point3d {
 
         assert_eq!(p1, p2);
     }
-
 }

--- a/src/rigid.rs
+++ b/src/rigid.rs
@@ -1,7 +1,7 @@
 use approxeq::ApproxEq;
 use num_traits::Float;
 use trig::Trig;
-use {TypedRotation3D, TypedTransform3D, TypedVector3D, UnknownUnit};
+use {Rotation3D, Transform3D, Vector3D};
 
 /// A rigid transformation. All lengths are preserved under such a transformation.
 ///
@@ -14,21 +14,19 @@ use {TypedRotation3D, TypedTransform3D, TypedVector3D, UnknownUnit};
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(C)]
-pub struct TypedRigidTransform3D<T, Src, Dst> {
-    pub rotation: TypedRotation3D<T, Src, Dst>,
-    pub translation: TypedVector3D<T, Dst>,
+pub struct RigidTransform3D<T, Src, Dst> {
+    pub rotation: Rotation3D<T, Src, Dst>,
+    pub translation: Vector3D<T, Dst>,
 }
-
-pub type RigidTransform3D<T> = TypedRigidTransform3D<T, UnknownUnit, UnknownUnit>;
 
 // All matrix multiplication in this file is in row-vector notation,
 // i.e. a vector `v` is transformed with `v * T`, and if you want to apply `T1`
 // before `T2` you use `T1 * T2`
 
-impl<T: Float + ApproxEq<T>, Src, Dst> TypedRigidTransform3D<T, Src, Dst> {
+impl<T: Float + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
     /// Construct a new rigid transformation, where the `rotation` applies first
     #[inline]
-    pub fn new(rotation: TypedRotation3D<T, Src, Dst>, translation: TypedVector3D<T, Dst>) -> Self {
+    pub fn new(rotation: Rotation3D<T, Src, Dst>, translation: Vector3D<T, Dst>) -> Self {
         Self {
             rotation,
             translation,
@@ -39,16 +37,16 @@ impl<T: Float + ApproxEq<T>, Src, Dst> TypedRigidTransform3D<T, Src, Dst> {
     #[inline]
     pub fn identity() -> Self {
         Self {
-            rotation: TypedRotation3D::identity(),
-            translation: TypedVector3D::zero(),
+            rotation: Rotation3D::identity(),
+            translation: Vector3D::zero(),
         }
     }
 
     /// Construct a new rigid transformation, where the `translation` applies first
     #[inline]
     pub fn new_from_reversed(
-        translation: TypedVector3D<T, Src>,
-        rotation: TypedRotation3D<T, Src, Dst>,
+        translation: Vector3D<T, Src>,
+        rotation: Rotation3D<T, Src, Dst>,
     ) -> Self {
         // T * R
         //   = (R * R^-1) * T * R
@@ -67,18 +65,18 @@ impl<T: Float + ApproxEq<T>, Src, Dst> TypedRigidTransform3D<T, Src, Dst> {
     }
 
     #[inline]
-    pub fn from_rotation(rotation: TypedRotation3D<T, Src, Dst>) -> Self {
+    pub fn from_rotation(rotation: Rotation3D<T, Src, Dst>) -> Self {
         Self {
             rotation,
-            translation: TypedVector3D::zero(),
+            translation: Vector3D::zero(),
         }
     }
 
     #[inline]
-    pub fn from_translation(translation: TypedVector3D<T, Dst>) -> Self {
+    pub fn from_translation(translation: Vector3D<T, Dst>) -> Self {
         Self {
             translation,
-            rotation: TypedRotation3D::identity(),
+            rotation: Rotation3D::identity(),
         }
     }
 
@@ -86,7 +84,7 @@ impl<T: Float + ApproxEq<T>, Src, Dst> TypedRigidTransform3D<T, Src, Dst> {
     ///
     /// i.e., the translation is applied _first_
     #[inline]
-    pub fn decompose_reversed(&self) -> (TypedVector3D<T, Src>, TypedRotation3D<T, Src, Dst>) {
+    pub fn decompose_reversed(&self) -> (Vector3D<T, Src>, Rotation3D<T, Src, Dst>) {
         // self = R * T
         //      = R * T * (R^-1 * R)
         //      = (R * T * R^-1) * R)
@@ -105,8 +103,8 @@ impl<T: Float + ApproxEq<T>, Src, Dst> TypedRigidTransform3D<T, Src, Dst> {
     #[inline]
     pub fn post_mul<Dst2>(
         &self,
-        other: &TypedRigidTransform3D<T, Dst, Dst2>,
-    ) -> TypedRigidTransform3D<T, Src, Dst2> {
+        other: &RigidTransform3D<T, Dst, Dst2>,
+    ) -> RigidTransform3D<T, Src, Dst2> {
         // self = R1 * T1
         // other = R2 * T2
         // result = R1 * T1 * R2 * T2
@@ -124,7 +122,7 @@ impl<T: Float + ApproxEq<T>, Src, Dst> TypedRigidTransform3D<T, Src, Dst> {
             .rotate_vector3d(&self.translation);
         let r_prime = self.rotation.post_rotate(&other.rotation);
         let t_prime2 = t_prime + other.translation;
-        TypedRigidTransform3D {
+        RigidTransform3D {
             rotation: r_prime,
             translation: t_prime2,
         }
@@ -137,14 +135,14 @@ impl<T: Float + ApproxEq<T>, Src, Dst> TypedRigidTransform3D<T, Src, Dst> {
     #[inline]
     pub fn pre_mul<Src2>(
         &self,
-        other: &TypedRigidTransform3D<T, Src2, Src>,
-    ) -> TypedRigidTransform3D<T, Src2, Dst> {
+        other: &RigidTransform3D<T, Src2, Src>,
+    ) -> RigidTransform3D<T, Src2, Dst> {
         other.post_mul(&self)
     }
 
     /// Inverts the transformation
     #[inline]
-    pub fn inverse(&self) -> TypedRigidTransform3D<T, Dst, Src> {
+    pub fn inverse(&self) -> RigidTransform3D<T, Dst, Src> {
         // result = (self)^-1
         //        = (R * T)^-1
         //        = T^-1 * R^-1
@@ -157,13 +155,13 @@ impl<T: Float + ApproxEq<T>, Src, Dst> TypedRigidTransform3D<T, Src, Dst> {
         //
         // An easier way of writing this is to use new_from_reversed() with R^-1 and T^-1
 
-        TypedRigidTransform3D::new_from_reversed(
+        RigidTransform3D::new_from_reversed(
             -self.translation,
             self.rotation.inverse(),
         )
     }
 
-    pub fn to_transform(&self) -> TypedTransform3D<T, Src, Dst>
+    pub fn to_transform(&self) -> Transform3D<T, Src, Dst>
     where
         T: Trig,
     {
@@ -173,18 +171,18 @@ impl<T: Float + ApproxEq<T>, Src, Dst> TypedRigidTransform3D<T, Src, Dst> {
     }
 }
 
-impl<T: Float + ApproxEq<T>, Src, Dst> From<TypedRotation3D<T, Src, Dst>>
-    for TypedRigidTransform3D<T, Src, Dst>
+impl<T: Float + ApproxEq<T>, Src, Dst> From<Rotation3D<T, Src, Dst>>
+    for RigidTransform3D<T, Src, Dst>
 {
-    fn from(rot: TypedRotation3D<T, Src, Dst>) -> Self {
+    fn from(rot: Rotation3D<T, Src, Dst>) -> Self {
         Self::from_rotation(rot)
     }
 }
 
-impl<T: Float + ApproxEq<T>, Src, Dst> From<TypedVector3D<T, Dst>>
-    for TypedRigidTransform3D<T, Src, Dst>
+impl<T: Float + ApproxEq<T>, Src, Dst> From<Vector3D<T, Dst>>
+    for RigidTransform3D<T, Src, Dst>
 {
-    fn from(t: TypedVector3D<T, Dst>) -> Self {
+    fn from(t: Vector3D<T, Dst>) -> Self {
         Self::from_translation(t)
     }
 }
@@ -192,7 +190,7 @@ impl<T: Float + ApproxEq<T>, Src, Dst> From<TypedVector3D<T, Dst>>
 #[cfg(test)]
 mod test {
     use super::RigidTransform3D;
-    use {Rotation3D, TypedTransform3D, Vector3D};
+    use default::{Rotation3D, Transform3D, Vector3D};
 
     #[test]
     fn test_rigid_construction() {
@@ -234,7 +232,7 @@ mod test {
         assert!(rigid
             .post_mul(&inverse)
             .to_transform()
-            .approx_eq(&TypedTransform3D::identity()));
+            .approx_eq(&Transform3D::identity()));
         assert!(inverse
             .to_transform()
             .approx_eq(&rigid.to_transform().inverse().unwrap()));

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -16,40 +16,40 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use core::fmt;
 use core::ops::{Add, Div, Mul, Neg, Sub};
 use core::marker::PhantomData;
-use {TypedPoint2D, TypedRect, TypedSize2D, TypedVector2D};
+use {Point2D, Rect, Size2D, Vector2D};
 
 /// A scaling factor between two different units of measurement.
 ///
 /// This is effectively a type-safe float, intended to be used in combination with other types like
 /// `length::Length` to enforce conversion between systems of measurement at compile time.
 ///
-/// `Src` and `Dst` represent the units before and after multiplying a value by a `TypedScale`. They
+/// `Src` and `Dst` represent the units before and after multiplying a value by a `Scale`. They
 /// may be types without values, such as empty enums.  For example:
 ///
 /// ```rust
-/// use euclid::TypedScale;
+/// use euclid::Scale;
 /// use euclid::Length;
 /// enum Mm {};
 /// enum Inch {};
 ///
-/// let mm_per_inch: TypedScale<f32, Inch, Mm> = TypedScale::new(25.4);
+/// let mm_per_inch: Scale<f32, Inch, Mm> = Scale::new(25.4);
 ///
 /// let one_foot: Length<f32, Inch> = Length::new(12.0);
 /// let one_foot_in_mm: Length<f32, Mm> = one_foot * mm_per_inch;
 /// ```
 #[repr(C)]
-pub struct TypedScale<T, Src, Dst>(pub T, #[doc(hidden)] pub PhantomData<(Src, Dst)>);
+pub struct Scale<T, Src, Dst>(pub T, #[doc(hidden)] pub PhantomData<(Src, Dst)>);
 
 #[cfg(feature = "serde")]
-impl<'de, T, Src, Dst> Deserialize<'de> for TypedScale<T, Src, Dst>
+impl<'de, T, Src, Dst> Deserialize<'de> for Scale<T, Src, Dst>
 where
     T: Deserialize<'de>,
 {
-    fn deserialize<D>(deserializer: D) -> Result<TypedScale<T, Src, Dst>, D::Error>
+    fn deserialize<D>(deserializer: D) -> Result<Scale<T, Src, Dst>, D::Error>
     where
         D: Deserializer<'de>,
     {
-        Ok(TypedScale(
+        Ok(Scale(
             try!(Deserialize::deserialize(deserializer)),
             PhantomData,
         ))
@@ -57,7 +57,7 @@ where
 }
 
 #[cfg(feature = "serde")]
-impl<T, Src, Dst> Serialize for TypedScale<T, Src, Dst>
+impl<T, Src, Dst> Serialize for Scale<T, Src, Dst>
 where
     T: Serialize,
 {
@@ -69,96 +69,96 @@ where
     }
 }
 
-impl<T, Src, Dst> TypedScale<T, Src, Dst> {
+impl<T, Src, Dst> Scale<T, Src, Dst> {
     pub fn new(x: T) -> Self {
-        TypedScale(x, PhantomData)
+        Scale(x, PhantomData)
     }
 }
 
-impl<T: Clone, Src, Dst> TypedScale<T, Src, Dst> {
+impl<T: Clone, Src, Dst> Scale<T, Src, Dst> {
     pub fn get(&self) -> T {
         self.0.clone()
     }
 }
 
-impl<Src, Dst> TypedScale<f32, Src, Dst> {
+impl<Src, Dst> Scale<f32, Src, Dst> {
     /// Identity scaling, could be used to safely transit from one space to another.
-    pub const ONE: Self = TypedScale(1.0, PhantomData);
+    pub const ONE: Self = Scale(1.0, PhantomData);
 }
 
-impl<T: Clone + One + Div<T, Output = T>, Src, Dst> TypedScale<T, Src, Dst> {
-    /// The inverse TypedScale (1.0 / self).
-    pub fn inv(&self) -> TypedScale<T, Dst, Src> {
+impl<T: Clone + One + Div<T, Output = T>, Src, Dst> Scale<T, Src, Dst> {
+    /// The inverse Scale (1.0 / self).
+    pub fn inv(&self) -> Scale<T, Dst, Src> {
         let one: T = One::one();
-        TypedScale::new(one / self.get())
+        Scale::new(one / self.get())
     }
 }
 
 // scale0 * scale1
-impl<T: Clone + Mul<T, Output = T>, A, B, C> Mul<TypedScale<T, B, C>> for TypedScale<T, A, B> {
-    type Output = TypedScale<T, A, C>;
+impl<T: Clone + Mul<T, Output = T>, A, B, C> Mul<Scale<T, B, C>> for Scale<T, A, B> {
+    type Output = Scale<T, A, C>;
     #[inline]
-    fn mul(self, other: TypedScale<T, B, C>) -> TypedScale<T, A, C> {
-        TypedScale::new(self.get() * other.get())
+    fn mul(self, other: Scale<T, B, C>) -> Scale<T, A, C> {
+        Scale::new(self.get() * other.get())
     }
 }
 
 // scale0 + scale1
-impl<T: Clone + Add<T, Output = T>, Src, Dst> Add for TypedScale<T, Src, Dst> {
-    type Output = TypedScale<T, Src, Dst>;
+impl<T: Clone + Add<T, Output = T>, Src, Dst> Add for Scale<T, Src, Dst> {
+    type Output = Scale<T, Src, Dst>;
     #[inline]
-    fn add(self, other: TypedScale<T, Src, Dst>) -> TypedScale<T, Src, Dst> {
-        TypedScale::new(self.get() + other.get())
+    fn add(self, other: Scale<T, Src, Dst>) -> Scale<T, Src, Dst> {
+        Scale::new(self.get() + other.get())
     }
 }
 
 // scale0 - scale1
-impl<T: Clone + Sub<T, Output = T>, Src, Dst> Sub for TypedScale<T, Src, Dst> {
-    type Output = TypedScale<T, Src, Dst>;
+impl<T: Clone + Sub<T, Output = T>, Src, Dst> Sub for Scale<T, Src, Dst> {
+    type Output = Scale<T, Src, Dst>;
     #[inline]
-    fn sub(self, other: TypedScale<T, Src, Dst>) -> TypedScale<T, Src, Dst> {
-        TypedScale::new(self.get() - other.get())
+    fn sub(self, other: Scale<T, Src, Dst>) -> Scale<T, Src, Dst> {
+        Scale::new(self.get() - other.get())
     }
 }
 
-impl<T: NumCast + Clone, Src, Dst0> TypedScale<T, Src, Dst0> {
+impl<T: NumCast + Clone, Src, Dst0> Scale<T, Src, Dst0> {
     /// Cast from one numeric representation to another, preserving the units.
-    pub fn cast<T1: NumCast + Clone>(&self) -> TypedScale<T1, Src, Dst0> {
+    pub fn cast<T1: NumCast + Clone>(&self) -> Scale<T1, Src, Dst0> {
         self.try_cast().unwrap()
     }
 
     /// Fallible cast from one numeric representation to another, preserving the units.
-    pub fn try_cast<T1: NumCast + Clone>(&self) -> Option<TypedScale<T1, Src, Dst0>> {
-        NumCast::from(self.get()).map(TypedScale::new)
+    pub fn try_cast<T1: NumCast + Clone>(&self) -> Option<Scale<T1, Src, Dst0>> {
+        NumCast::from(self.get()).map(Scale::new)
     }
 }
 
-impl<T, Src, Dst> TypedScale<T, Src, Dst>
+impl<T, Src, Dst> Scale<T, Src, Dst>
 where
     T: Copy + Clone + Mul<T, Output = T> + Neg<Output = T> + PartialEq + One,
 {
     /// Returns the given point transformed by this scale.
     #[inline]
-    pub fn transform_point(&self, point: &TypedPoint2D<T, Src>) -> TypedPoint2D<T, Dst> {
-        TypedPoint2D::new(point.x * self.get(), point.y * self.get())
+    pub fn transform_point(&self, point: &Point2D<T, Src>) -> Point2D<T, Dst> {
+        Point2D::new(point.x * self.get(), point.y * self.get())
     }
 
     /// Returns the given vector transformed by this scale.
     #[inline]
-    pub fn transform_vector(&self, vec: &TypedVector2D<T, Src>) -> TypedVector2D<T, Dst> {
-        TypedVector2D::new(vec.x * self.get(), vec.y * self.get())
+    pub fn transform_vector(&self, vec: &Vector2D<T, Src>) -> Vector2D<T, Dst> {
+        Vector2D::new(vec.x * self.get(), vec.y * self.get())
     }
 
     /// Returns the given vector transformed by this scale.
     #[inline]
-    pub fn transform_size(&self, size: &TypedSize2D<T, Src>) -> TypedSize2D<T, Dst> {
-        TypedSize2D::new(size.width * self.get(), size.height * self.get())
+    pub fn transform_size(&self, size: &Size2D<T, Src>) -> Size2D<T, Dst> {
+        Size2D::new(size.width * self.get(), size.height * self.get())
     }
 
     /// Returns the given rect transformed by this scale.
     #[inline]
-    pub fn transform_rect(&self, rect: &TypedRect<T, Src>) -> TypedRect<T, Dst> {
-        TypedRect::new(
+    pub fn transform_rect(&self, rect: &Rect<T, Src>) -> Rect<T, Dst> {
+        Rect::new(
             self.transform_point(&rect.origin),
             self.transform_size(&rect.size),
         )
@@ -166,8 +166,8 @@ where
 
     /// Returns the inverse of this scale.
     #[inline]
-    pub fn inverse(&self) -> TypedScale<T, Dst, Src> {
-        TypedScale::new(-self.get())
+    pub fn inverse(&self) -> Scale<T, Dst, Src> {
+        Scale::new(-self.get())
     }
 
     /// Returns true if this scale has no effect.
@@ -180,27 +180,27 @@ where
 // FIXME: Switch to `derive(PartialEq, Clone)` after this Rust issue is fixed:
 // https://github.com/mozilla/rust/issues/7671
 
-impl<T: PartialEq, Src, Dst> PartialEq for TypedScale<T, Src, Dst> {
-    fn eq(&self, other: &TypedScale<T, Src, Dst>) -> bool {
+impl<T: PartialEq, Src, Dst> PartialEq for Scale<T, Src, Dst> {
+    fn eq(&self, other: &Scale<T, Src, Dst>) -> bool {
         self.0 == other.0
     }
 }
 
-impl<T: Clone, Src, Dst> Clone for TypedScale<T, Src, Dst> {
-    fn clone(&self) -> TypedScale<T, Src, Dst> {
-        TypedScale::new(self.get())
+impl<T: Clone, Src, Dst> Clone for Scale<T, Src, Dst> {
+    fn clone(&self) -> Scale<T, Src, Dst> {
+        Scale::new(self.get())
     }
 }
 
-impl<T: Copy, Src, Dst> Copy for TypedScale<T, Src, Dst> {}
+impl<T: Copy, Src, Dst> Copy for Scale<T, Src, Dst> {}
 
-impl<T: fmt::Debug, Src, Dst> fmt::Debug for TypedScale<T, Src, Dst> {
+impl<T: fmt::Debug, Src, Dst> fmt::Debug for Scale<T, Src, Dst> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
     }
 }
 
-impl<T: fmt::Display, Src, Dst> fmt::Display for TypedScale<T, Src, Dst> {
+impl<T: fmt::Display, Src, Dst> fmt::Display for Scale<T, Src, Dst> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
     }
@@ -208,7 +208,7 @@ impl<T: fmt::Display, Src, Dst> fmt::Display for TypedScale<T, Src, Dst> {
 
 #[cfg(test)]
 mod tests {
-    use super::TypedScale;
+    use super::Scale;
 
     enum Inch {}
     enum Cm {}
@@ -216,20 +216,20 @@ mod tests {
 
     #[test]
     fn test_scale() {
-        let mm_per_inch: TypedScale<f32, Inch, Mm> = TypedScale::new(25.4);
-        let cm_per_mm: TypedScale<f32, Mm, Cm> = TypedScale::new(0.1);
+        let mm_per_inch: Scale<f32, Inch, Mm> = Scale::new(25.4);
+        let cm_per_mm: Scale<f32, Mm, Cm> = Scale::new(0.1);
 
-        let mm_per_cm: TypedScale<f32, Cm, Mm> = cm_per_mm.inv();
+        let mm_per_cm: Scale<f32, Cm, Mm> = cm_per_mm.inv();
         assert_eq!(mm_per_cm.get(), 10.0);
 
-        let cm_per_inch: TypedScale<f32, Inch, Cm> = mm_per_inch * cm_per_mm;
-        assert_eq!(cm_per_inch, TypedScale::new(2.54));
+        let cm_per_inch: Scale<f32, Inch, Cm> = mm_per_inch * cm_per_mm;
+        assert_eq!(cm_per_inch, Scale::new(2.54));
 
-        let a: TypedScale<isize, Inch, Inch> = TypedScale::new(2);
-        let b: TypedScale<isize, Inch, Inch> = TypedScale::new(3);
+        let a: Scale<isize, Inch, Inch> = Scale::new(2);
+        let b: Scale<isize, Inch, Inch> = Scale::new(3);
         assert!(a != b);
         assert_eq!(a, a.clone());
-        assert_eq!(a.clone() + b.clone(), TypedScale::new(5));
-        assert_eq!(a - b, TypedScale::new(-1));
+        assert_eq!(a.clone() + b.clone(), Scale::new(5));
+        assert_eq!(a - b, Scale::new(-1));
     }
 }

--- a/src/side_offsets.rs
+++ b/src/side_offsets.rs
@@ -10,7 +10,6 @@
 //! A group of side offsets, which correspond to top/left/bottom/right for borders, padding,
 //! and margins in CSS.
 
-use super::UnknownUnit;
 use length::Length;
 use num::Zero;
 use core::fmt;
@@ -24,7 +23,7 @@ use serde;
 /// A group of 2D side offsets, which correspond to top/left/bottom/right for borders, padding,
 /// and margins in CSS, optionally tagged with a unit.
 #[repr(C)]
-pub struct TypedSideOffsets2D<T, U> {
+pub struct SideOffsets2D<T, U> {
     pub top: T,
     pub right: T,
     pub bottom: T,
@@ -33,11 +32,11 @@ pub struct TypedSideOffsets2D<T, U> {
     pub _unit: PhantomData<U>,
 }
 
-impl<T: Copy, U> Copy for TypedSideOffsets2D<T, U> {}
+impl<T: Copy, U> Copy for SideOffsets2D<T, U> {}
 
-impl<T: Clone, U> Clone for TypedSideOffsets2D<T, U> {
+impl<T: Clone, U> Clone for SideOffsets2D<T, U> {
     fn clone(&self) -> Self {
-        TypedSideOffsets2D {
+        SideOffsets2D {
             top: self.top.clone(),
             right: self.right.clone(),
             bottom: self.bottom.clone(),
@@ -48,19 +47,19 @@ impl<T: Clone, U> Clone for TypedSideOffsets2D<T, U> {
 }
 
 #[cfg(feature = "serde")]
-impl<'de, T, U> serde::Deserialize<'de> for TypedSideOffsets2D<T, U>
+impl<'de, T, U> serde::Deserialize<'de> for SideOffsets2D<T, U>
     where T: serde::Deserialize<'de>
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where D: serde::Deserializer<'de>
     {
         let (top, right, bottom, left) = try!(serde::Deserialize::deserialize(deserializer));
-        Ok(TypedSideOffsets2D { top, right, bottom, left, _unit: PhantomData })
+        Ok(SideOffsets2D { top, right, bottom, left, _unit: PhantomData })
     }
 }
 
 #[cfg(feature = "serde")]
-impl<T, U> serde::Serialize for TypedSideOffsets2D<T, U>
+impl<T, U> serde::Serialize for SideOffsets2D<T, U>
     where T: serde::Serialize
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -70,9 +69,9 @@ impl<T, U> serde::Serialize for TypedSideOffsets2D<T, U>
     }
 }
 
-impl<T, U> Eq for TypedSideOffsets2D<T, U> where T: Eq {}
+impl<T, U> Eq for SideOffsets2D<T, U> where T: Eq {}
 
-impl<T, U> PartialEq for TypedSideOffsets2D<T, U>
+impl<T, U> PartialEq for SideOffsets2D<T, U>
     where T: PartialEq
 {
     fn eq(&self, other: &Self) -> bool {
@@ -83,7 +82,7 @@ impl<T, U> PartialEq for TypedSideOffsets2D<T, U>
     }
 }
 
-impl<T, U> Hash for TypedSideOffsets2D<T, U>
+impl<T, U> Hash for SideOffsets2D<T, U>
     where T: Hash
 {
     fn hash<H: ::core::hash::Hasher>(&self, h: &mut H) {
@@ -94,7 +93,7 @@ impl<T, U> Hash for TypedSideOffsets2D<T, U>
     }
 }
 
-impl<T: fmt::Debug, U> fmt::Debug for TypedSideOffsets2D<T, U> {
+impl<T: fmt::Debug, U> fmt::Debug for SideOffsets2D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -104,9 +103,9 @@ impl<T: fmt::Debug, U> fmt::Debug for TypedSideOffsets2D<T, U> {
     }
 }
 
-impl<T: Default, U> Default for TypedSideOffsets2D<T, U> {
+impl<T: Default, U> Default for SideOffsets2D<T, U> {
     fn default() -> Self {
-        TypedSideOffsets2D {
+        SideOffsets2D {
             top: Default::default(),
             right: Default::default(),
             bottom: Default::default(),
@@ -116,13 +115,10 @@ impl<T: Default, U> Default for TypedSideOffsets2D<T, U> {
     }
 }
 
-/// The default 2D side offset type with no unit.
-pub type SideOffsets2D<T> = TypedSideOffsets2D<T, UnknownUnit>;
-
-impl<T: Copy, U> TypedSideOffsets2D<T, U> {
+impl<T: Copy, U> SideOffsets2D<T, U> {
     /// Constructor taking a scalar for each side.
     pub fn new(top: T, right: T, bottom: T, left: T) -> Self {
-        TypedSideOffsets2D {
+        SideOffsets2D {
             top,
             right,
             bottom,
@@ -138,7 +134,7 @@ impl<T: Copy, U> TypedSideOffsets2D<T, U> {
         bottom: Length<T, U>,
         left: Length<T, U>,
     ) -> Self {
-        TypedSideOffsets2D::new(top.0, right.0, bottom.0, left.0)
+        SideOffsets2D::new(top.0, right.0, bottom.0, left.0)
     }
 
     /// Access self.top as a typed Length instead of a scalar value.
@@ -163,16 +159,16 @@ impl<T: Copy, U> TypedSideOffsets2D<T, U> {
 
     /// Constructor setting the same value to all sides, taking a scalar value directly.
     pub fn new_all_same(all: T) -> Self {
-        TypedSideOffsets2D::new(all, all, all, all)
+        SideOffsets2D::new(all, all, all, all)
     }
 
     /// Constructor setting the same value to all sides, taking a typed Length.
     pub fn from_length_all_same(all: Length<T, U>) -> Self {
-        TypedSideOffsets2D::new_all_same(all.0)
+        SideOffsets2D::new_all_same(all.0)
     }
 }
 
-impl<T, U> TypedSideOffsets2D<T, U>
+impl<T, U> SideOffsets2D<T, U>
 where
     T: Add<T, Output = T> + Copy,
 {
@@ -193,13 +189,13 @@ where
     }
 }
 
-impl<T, U> Add for TypedSideOffsets2D<T, U>
+impl<T, U> Add for SideOffsets2D<T, U>
 where
     T: Copy + Add<T, Output = T>,
 {
     type Output = Self;
     fn add(self, other: Self) -> Self {
-        TypedSideOffsets2D::new(
+        SideOffsets2D::new(
             self.top + other.top,
             self.right + other.right,
             self.bottom + other.bottom,
@@ -208,9 +204,9 @@ where
     }
 }
 
-impl<T: Copy + Zero, U> TypedSideOffsets2D<T, U> {
+impl<T: Copy + Zero, U> SideOffsets2D<T, U> {
     /// Constructor, setting all sides to zero.
     pub fn zero() -> Self {
-        TypedSideOffsets2D::new(Zero::zero(), Zero::zero(), Zero::zero(), Zero::zero())
+        SideOffsets2D::new(Zero::zero(), Zero::zero(), Zero::zero(), Zero::zero())
     }
 }

--- a/src/size.rs
+++ b/src/size.rs
@@ -11,9 +11,9 @@ use super::UnknownUnit;
 #[cfg(feature = "mint")]
 use mint;
 use length::Length;
-use scale::TypedScale;
-use vector::{TypedVector2D, vec2, BoolVector2D};
-use vector::{TypedVector3D, vec3, BoolVector3D};
+use scale::Scale;
+use vector::{Vector2D, vec2, BoolVector2D};
+use vector::{Vector3D, vec3, BoolVector3D};
 use num::*;
 
 use num_traits::{Float, NumCast, Signed};
@@ -27,18 +27,18 @@ use serde;
 
 /// A 2d size tagged with a unit.
 #[repr(C)]
-pub struct TypedSize2D<T, U> {
+pub struct Size2D<T, U> {
     pub width: T,
     pub height: T,
     #[doc(hidden)]
     pub _unit: PhantomData<U>,
 }
 
-impl<T: Copy, U> Copy for TypedSize2D<T, U> {}
+impl<T: Copy, U> Copy for Size2D<T, U> {}
 
-impl<T: Clone, U> Clone for TypedSize2D<T, U> {
+impl<T: Clone, U> Clone for Size2D<T, U> {
     fn clone(&self) -> Self {
-        TypedSize2D {
+        Size2D {
             width: self.width.clone(),
             height: self.height.clone(),
             _unit: PhantomData,
@@ -47,19 +47,19 @@ impl<T: Clone, U> Clone for TypedSize2D<T, U> {
 }
 
 #[cfg(feature = "serde")]
-impl<'de, T, U> serde::Deserialize<'de> for TypedSize2D<T, U>
+impl<'de, T, U> serde::Deserialize<'de> for Size2D<T, U>
     where T: serde::Deserialize<'de>
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where D: serde::Deserializer<'de>
     {
         let (width, height) = try!(serde::Deserialize::deserialize(deserializer));
-        Ok(TypedSize2D { width, height, _unit: PhantomData })
+        Ok(Size2D { width, height, _unit: PhantomData })
     }
 }
 
 #[cfg(feature = "serde")]
-impl<T, U> serde::Serialize for TypedSize2D<T, U>
+impl<T, U> serde::Serialize for Size2D<T, U>
     where T: serde::Serialize
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -69,9 +69,9 @@ impl<T, U> serde::Serialize for TypedSize2D<T, U>
     }
 }
 
-impl<T, U> Eq for TypedSize2D<T, U> where T: Eq {}
+impl<T, U> Eq for Size2D<T, U> where T: Eq {}
 
-impl<T, U> PartialEq for TypedSize2D<T, U>
+impl<T, U> PartialEq for Size2D<T, U>
     where T: PartialEq
 {
     fn eq(&self, other: &Self) -> bool {
@@ -79,7 +79,7 @@ impl<T, U> PartialEq for TypedSize2D<T, U>
     }
 }
 
-impl<T, U> Hash for TypedSize2D<T, U>
+impl<T, U> Hash for Size2D<T, U>
     where T: Hash
 {
     fn hash<H: ::core::hash::Hasher>(&self, h: &mut H) {
@@ -88,33 +88,28 @@ impl<T, U> Hash for TypedSize2D<T, U>
     }
 }
 
-/// Default 2d size type with no unit.
-///
-/// `Size2D` provides the same methods as `TypedSize2D`.
-pub type Size2D<T> = TypedSize2D<T, UnknownUnit>;
-
-impl<T: fmt::Debug, U> fmt::Debug for TypedSize2D<T, U> {
+impl<T: fmt::Debug, U> fmt::Debug for Size2D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}×{:?}", self.width, self.height)
     }
 }
 
-impl<T: fmt::Display, U> fmt::Display for TypedSize2D<T, U> {
+impl<T: fmt::Display, U> fmt::Display for Size2D<T, U> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(formatter, "({}x{})", self.width, self.height)
     }
 }
 
-impl<T: Default, U> Default for TypedSize2D<T, U> {
+impl<T: Default, U> Default for Size2D<T, U> {
     fn default() -> Self {
-        TypedSize2D::new(Default::default(), Default::default())
+        Size2D::new(Default::default(), Default::default())
     }
 }
 
-impl<T, U> TypedSize2D<T, U> {
+impl<T, U> Size2D<T, U> {
     /// Constructor taking scalar values.
     pub fn new(width: T, height: T) -> Self {
-        TypedSize2D {
+        Size2D {
             width,
             height,
             _unit: PhantomData,
@@ -122,61 +117,61 @@ impl<T, U> TypedSize2D<T, U> {
     }
 }
 
-impl<T: Clone, U> TypedSize2D<T, U> {
+impl<T: Clone, U> Size2D<T, U> {
     /// Constructor taking scalar strongly typed lengths.
     pub fn from_lengths(width: Length<T, U>, height: Length<T, U>) -> Self {
-        TypedSize2D::new(width.get(), height.get())
+        Size2D::new(width.get(), height.get())
     }
 }
 
-impl<T: Round, U> TypedSize2D<T, U> {
+impl<T: Round, U> Size2D<T, U> {
     /// Rounds each component to the nearest integer value.
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
     pub fn round(&self) -> Self {
-        TypedSize2D::new(self.width.round(), self.height.round())
+        Size2D::new(self.width.round(), self.height.round())
     }
 }
 
-impl<T: Ceil, U> TypedSize2D<T, U> {
+impl<T: Ceil, U> Size2D<T, U> {
     /// Rounds each component to the smallest integer equal or greater than the original value.
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
     pub fn ceil(&self) -> Self {
-        TypedSize2D::new(self.width.ceil(), self.height.ceil())
+        Size2D::new(self.width.ceil(), self.height.ceil())
     }
 }
 
-impl<T: Floor, U> TypedSize2D<T, U> {
+impl<T: Floor, U> Size2D<T, U> {
     /// Rounds each component to the biggest integer equal or lower than the original value.
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
     pub fn floor(&self) -> Self {
-        TypedSize2D::new(self.width.floor(), self.height.floor())
+        Size2D::new(self.width.floor(), self.height.floor())
     }
 }
 
-impl<T: Copy + Add<T, Output = T>, U> Add for TypedSize2D<T, U> {
+impl<T: Copy + Add<T, Output = T>, U> Add for Size2D<T, U> {
     type Output = Self;
     fn add(self, other: Self) -> Self {
-        TypedSize2D::new(self.width + other.width, self.height + other.height)
+        Size2D::new(self.width + other.width, self.height + other.height)
     }
 }
 
-impl<T: Copy + Sub<T, Output = T>, U> Sub for TypedSize2D<T, U> {
+impl<T: Copy + Sub<T, Output = T>, U> Sub for Size2D<T, U> {
     type Output = Self;
     fn sub(self, other: Self) -> Self {
-        TypedSize2D::new(self.width - other.width, self.height - other.height)
+        Size2D::new(self.width - other.width, self.height - other.height)
     }
 }
 
-impl<T: Copy + Clone + Mul<T>, U> TypedSize2D<T, U> {
+impl<T: Copy + Clone + Mul<T>, U> Size2D<T, U> {
     pub fn area(&self) -> T::Output {
         self.width * self.height
     }
 }
 
-impl<T, U> TypedSize2D<T, U>
+impl<T, U> Size2D<T, U>
 where
     T: Copy + One + Add<Output = T> + Sub<Output = T> + Mul<Output = T>,
 {
@@ -193,58 +188,58 @@ where
     }
 }
 
-impl<T: Zero + PartialOrd, U> TypedSize2D<T, U> {
+impl<T: Zero + PartialOrd, U> Size2D<T, U> {
     pub fn is_empty_or_negative(&self) -> bool {
         let zero = T::zero();
         self.width <= zero || self.height <= zero
     }
 }
 
-impl<T: Zero, U> TypedSize2D<T, U> {
+impl<T: Zero, U> Size2D<T, U> {
     pub fn zero() -> Self {
-        TypedSize2D::new(Zero::zero(), Zero::zero())
+        Size2D::new(Zero::zero(), Zero::zero())
     }
 }
 
-impl<T: Zero, U> Zero for TypedSize2D<T, U> {
+impl<T: Zero, U> Zero for Size2D<T, U> {
     fn zero() -> Self {
-        TypedSize2D::new(Zero::zero(), Zero::zero())
+        Size2D::new(Zero::zero(), Zero::zero())
     }
 }
 
-impl<T: Copy + Mul<T, Output = T>, U> Mul<T> for TypedSize2D<T, U> {
+impl<T: Copy + Mul<T, Output = T>, U> Mul<T> for Size2D<T, U> {
     type Output = Self;
     #[inline]
     fn mul(self, scale: T) -> Self {
-        TypedSize2D::new(self.width * scale, self.height * scale)
+        Size2D::new(self.width * scale, self.height * scale)
     }
 }
 
-impl<T: Copy + Div<T, Output = T>, U> Div<T> for TypedSize2D<T, U> {
+impl<T: Copy + Div<T, Output = T>, U> Div<T> for Size2D<T, U> {
     type Output = Self;
     #[inline]
     fn div(self, scale: T) -> Self {
-        TypedSize2D::new(self.width / scale, self.height / scale)
+        Size2D::new(self.width / scale, self.height / scale)
     }
 }
 
-impl<T: Copy + Mul<T, Output = T>, U1, U2> Mul<TypedScale<T, U1, U2>> for TypedSize2D<T, U1> {
-    type Output = TypedSize2D<T, U2>;
+impl<T: Copy + Mul<T, Output = T>, U1, U2> Mul<Scale<T, U1, U2>> for Size2D<T, U1> {
+    type Output = Size2D<T, U2>;
     #[inline]
-    fn mul(self, scale: TypedScale<T, U1, U2>) -> TypedSize2D<T, U2> {
-        TypedSize2D::new(self.width * scale.get(), self.height * scale.get())
+    fn mul(self, scale: Scale<T, U1, U2>) -> Size2D<T, U2> {
+        Size2D::new(self.width * scale.get(), self.height * scale.get())
     }
 }
 
-impl<T: Copy + Div<T, Output = T>, U1, U2> Div<TypedScale<T, U1, U2>> for TypedSize2D<T, U2> {
-    type Output = TypedSize2D<T, U1>;
+impl<T: Copy + Div<T, Output = T>, U1, U2> Div<Scale<T, U1, U2>> for Size2D<T, U2> {
+    type Output = Size2D<T, U1>;
     #[inline]
-    fn div(self, scale: TypedScale<T, U1, U2>) -> TypedSize2D<T, U1> {
-        TypedSize2D::new(self.width / scale.get(), self.height / scale.get())
+    fn div(self, scale: Scale<T, U1, U2>) -> Size2D<T, U1> {
+        Size2D::new(self.width / scale.get(), self.height / scale.get())
     }
 }
 
-impl<T: Copy, U> TypedSize2D<T, U> {
+impl<T: Copy, U> Size2D<T, U> {
     /// Returns self.width as a Length carrying the unit.
     #[inline]
     pub fn width_typed(&self) -> Length<T, U> {
@@ -268,28 +263,28 @@ impl<T: Copy, U> TypedSize2D<T, U> {
     }
 
     #[inline]
-    pub fn to_vector(&self) -> TypedVector2D<T, U> {
+    pub fn to_vector(&self) -> Vector2D<T, U> {
         vec2(self.width, self.height)
     }
 
     /// Drop the units, preserving only the numeric value.
-    pub fn to_untyped(&self) -> Size2D<T> {
-        TypedSize2D::new(self.width, self.height)
+    pub fn to_untyped(&self) -> Size2D<T, UnknownUnit> {
+        Size2D::new(self.width, self.height)
     }
 
     /// Tag a unitless value with units.
-    pub fn from_untyped(p: &Size2D<T>) -> Self {
-        TypedSize2D::new(p.width, p.height)
+    pub fn from_untyped(p: &Size2D<T, UnknownUnit>) -> Self {
+        Size2D::new(p.width, p.height)
     }
 }
 
-impl<T: NumCast + Copy, Unit> TypedSize2D<T, Unit> {
+impl<T: NumCast + Copy, Unit> Size2D<T, Unit> {
     /// Cast from one numeric representation to another, preserving the units.
     ///
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
-    pub fn cast<NewT: NumCast + Copy>(&self) -> TypedSize2D<NewT, Unit> {
+    pub fn cast<NewT: NumCast + Copy>(&self) -> Size2D<NewT, Unit> {
         self.try_cast().unwrap()
     }
 
@@ -298,9 +293,9 @@ impl<T: NumCast + Copy, Unit> TypedSize2D<T, Unit> {
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
-    pub fn try_cast<NewT: NumCast + Copy>(&self) -> Option<TypedSize2D<NewT, Unit>> {
+    pub fn try_cast<NewT: NumCast + Copy>(&self) -> Option<Size2D<NewT, Unit>> {
         match (NumCast::from(self.width), NumCast::from(self.height)) {
-            (Some(w), Some(h)) => Some(TypedSize2D::new(w, h)),
+            (Some(w), Some(h)) => Some(Size2D::new(w, h)),
             _ => None,
         }
     }
@@ -308,12 +303,12 @@ impl<T: NumCast + Copy, Unit> TypedSize2D<T, Unit> {
     // Convenience functions for common casts
 
     /// Cast into an `f32` size.
-    pub fn to_f32(&self) -> TypedSize2D<f32, Unit> {
+    pub fn to_f32(&self) -> Size2D<f32, Unit> {
         self.cast()
     }
 
     /// Cast into an `f64` size.
-    pub fn to_f64(&self) -> TypedSize2D<f64, Unit> {
+    pub fn to_f64(&self) -> Size2D<f64, Unit> {
         self.cast()
     }
 
@@ -322,7 +317,7 @@ impl<T: NumCast + Copy, Unit> TypedSize2D<T, Unit> {
     /// When casting from floating point sizes, it is worth considering whether
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
-    pub fn to_usize(&self) -> TypedSize2D<usize, Unit> {
+    pub fn to_usize(&self) -> Size2D<usize, Unit> {
         self.cast()
     }
 
@@ -331,7 +326,7 @@ impl<T: NumCast + Copy, Unit> TypedSize2D<T, Unit> {
     /// When casting from floating point sizes, it is worth considering whether
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
-    pub fn to_u32(&self) -> TypedSize2D<u32, Unit> {
+    pub fn to_u32(&self) -> Size2D<u32, Unit> {
         self.cast()
     }
 
@@ -340,7 +335,7 @@ impl<T: NumCast + Copy, Unit> TypedSize2D<T, Unit> {
     /// When casting from floating point sizes, it is worth considering whether
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
-    pub fn to_i32(&self) -> TypedSize2D<i32, Unit> {
+    pub fn to_i32(&self) -> Size2D<i32, Unit> {
         self.cast()
     }
 
@@ -349,12 +344,12 @@ impl<T: NumCast + Copy, Unit> TypedSize2D<T, Unit> {
     /// When casting from floating point sizes, it is worth considering whether
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
-    pub fn to_i64(&self) -> TypedSize2D<i64, Unit> {
+    pub fn to_i64(&self) -> Size2D<i64, Unit> {
         self.cast()
     }
 }
 
-impl<T, U> TypedSize2D<T, U>
+impl<T, U> Size2D<T, U>
 where
     T: Signed,
 {
@@ -367,7 +362,7 @@ where
     }
 }
 
-impl<T: PartialOrd, U> TypedSize2D<T, U> {
+impl<T: PartialOrd, U> Size2D<T, U> {
     pub fn greater_than(&self, other: &Self) -> BoolVector2D {
         BoolVector2D {
             x: self.width > other.width,
@@ -384,7 +379,7 @@ impl<T: PartialOrd, U> TypedSize2D<T, U> {
 }
 
 
-impl<T: PartialEq, U> TypedSize2D<T, U> {
+impl<T: PartialEq, U> Size2D<T, U> {
     pub fn equal(&self, other: &Self) -> BoolVector2D {
         BoolVector2D {
             x: self.width == other.width,
@@ -400,7 +395,7 @@ impl<T: PartialEq, U> TypedSize2D<T, U> {
     }
 }
 
-impl<T: Float, U> TypedSize2D<T, U> {
+impl<T: Float, U> Size2D<T, U> {
     #[inline]
     pub fn min(self, other: Self) -> Self {
         size2(
@@ -424,15 +419,15 @@ impl<T: Float, U> TypedSize2D<T, U> {
 }
 
 
-/// Shorthand for `TypedSize2D::new(w, h)`.
-pub fn size2<T, U>(w: T, h: T) -> TypedSize2D<T, U> {
-    TypedSize2D::new(w, h)
+/// Shorthand for `Size2D::new(w, h)`.
+pub fn size2<T, U>(w: T, h: T) -> Size2D<T, U> {
+    Size2D::new(w, h)
 }
 
 #[cfg(feature = "mint")]
-impl<T, U> From<mint::Vector2<T>> for TypedSize2D<T, U> {
+impl<T, U> From<mint::Vector2<T>> for Size2D<T, U> {
     fn from(v: mint::Vector2<T>) -> Self {
-        TypedSize2D {
+        Size2D {
             width: v.x,
             height: v.y,
             _unit: PhantomData,
@@ -440,7 +435,7 @@ impl<T, U> From<mint::Vector2<T>> for TypedSize2D<T, U> {
     }
 }
 #[cfg(feature = "mint")]
-impl<T, U> Into<mint::Vector2<T>> for TypedSize2D<T, U> {
+impl<T, U> Into<mint::Vector2<T>> for Size2D<T, U> {
     fn into(self) -> mint::Vector2<T> {
         mint::Vector2 {
             x: self.width,
@@ -449,25 +444,25 @@ impl<T, U> Into<mint::Vector2<T>> for TypedSize2D<T, U> {
     }
 }
 
-impl<T: Copy, U> Into<[T; 2]> for TypedSize2D<T, U> {
+impl<T: Copy, U> Into<[T; 2]> for Size2D<T, U> {
     fn into(self) -> [T; 2] {
         self.to_array()
     }
 }
 
-impl<T: Copy, U> From<[T; 2]> for TypedSize2D<T, U> {
+impl<T: Copy, U> From<[T; 2]> for Size2D<T, U> {
     fn from(array: [T; 2]) -> Self {
         size2(array[0], array[1])
     }
 }
 
-impl<T: Copy, U> Into<(T, T)> for TypedSize2D<T, U> {
+impl<T: Copy, U> Into<(T, T)> for Size2D<T, U> {
     fn into(self) -> (T, T) {
         self.to_tuple()
     }
 }
 
-impl<T: Copy, U> From<(T, T)> for TypedSize2D<T, U> {
+impl<T: Copy, U> From<(T, T)> for Size2D<T, U> {
     fn from(tuple: (T, T)) -> Self {
         size2(tuple.0, tuple.1)
     }
@@ -475,7 +470,7 @@ impl<T: Copy, U> From<(T, T)> for TypedSize2D<T, U> {
 
 #[cfg(test)]
 mod size2d {
-    use super::Size2D;
+    use default::Size2D;
     #[cfg(feature = "mint")]
     use mint;
 
@@ -536,7 +531,7 @@ mod size2d {
 
 /// A 3d size tagged with a unit.
 #[repr(C)]
-pub struct TypedSize3D<T, U> {
+pub struct Size3D<T, U> {
     pub width: T,
     pub height: T,
     pub depth: T,
@@ -544,11 +539,11 @@ pub struct TypedSize3D<T, U> {
     pub _unit: PhantomData<U>,
 }
 
-impl<T: Copy, U> Copy for TypedSize3D<T, U> {}
+impl<T: Copy, U> Copy for Size3D<T, U> {}
 
-impl<T: Clone, U> Clone for TypedSize3D<T, U> {
+impl<T: Clone, U> Clone for Size3D<T, U> {
     fn clone(&self) -> Self {
-        TypedSize3D {
+        Size3D {
             width: self.width.clone(),
             height: self.height.clone(),
             depth: self.depth.clone(),
@@ -558,19 +553,19 @@ impl<T: Clone, U> Clone for TypedSize3D<T, U> {
 }
 
 #[cfg(feature = "serde")]
-impl<'de, T, U> serde::Deserialize<'de> for TypedSize3D<T, U>
+impl<'de, T, U> serde::Deserialize<'de> for Size3D<T, U>
     where T: serde::Deserialize<'de>
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where D: serde::Deserializer<'de>
     {
         let (width, height, depth) = try!(serde::Deserialize::deserialize(deserializer));
-        Ok(TypedSize3D { width, height, depth, _unit: PhantomData })
+        Ok(Size3D { width, height, depth, _unit: PhantomData })
     }
 }
 
 #[cfg(feature = "serde")]
-impl<T, U> serde::Serialize for TypedSize3D<T, U>
+impl<T, U> serde::Serialize for Size3D<T, U>
     where T: serde::Serialize
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -580,9 +575,9 @@ impl<T, U> serde::Serialize for TypedSize3D<T, U>
     }
 }
 
-impl<T, U> Eq for TypedSize3D<T, U> where T: Eq {}
+impl<T, U> Eq for Size3D<T, U> where T: Eq {}
 
-impl<T, U> PartialEq for TypedSize3D<T, U>
+impl<T, U> PartialEq for Size3D<T, U>
     where T: PartialEq
 {
     fn eq(&self, other: &Self) -> bool {
@@ -590,7 +585,7 @@ impl<T, U> PartialEq for TypedSize3D<T, U>
     }
 }
 
-impl<T, U> Hash for TypedSize3D<T, U>
+impl<T, U> Hash for Size3D<T, U>
     where T: Hash
 {
     fn hash<H: ::core::hash::Hasher>(&self, h: &mut H) {
@@ -600,33 +595,28 @@ impl<T, U> Hash for TypedSize3D<T, U>
     }
 }
 
-/// Default 3d size type with no unit.
-///
-/// `Size3D` provides the same methods as `TypedSize3D`.
-pub type Size3D<T> = TypedSize3D<T, UnknownUnit>;
-
-impl<T: fmt::Debug, U> fmt::Debug for TypedSize3D<T, U> {
+impl<T: fmt::Debug, U> fmt::Debug for Size3D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}×{:?}×{:?}", self.width, self.height, self.depth)
     }
 }
 
-impl<T: fmt::Display, U> fmt::Display for TypedSize3D<T, U> {
+impl<T: fmt::Display, U> fmt::Display for Size3D<T, U> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(formatter, "({}x{}x{})", self.width, self.height, self.depth)
     }
 }
 
-impl<T: Default, U> Default for TypedSize3D<T, U> {
+impl<T: Default, U> Default for Size3D<T, U> {
     fn default() -> Self {
-        TypedSize3D::new(Default::default(), Default::default(), Default::default())
+        Size3D::new(Default::default(), Default::default(), Default::default())
     }
 }
 
-impl<T, U> TypedSize3D<T, U> {
+impl<T, U> Size3D<T, U> {
     /// Constructor taking scalar values.
     pub fn new(width: T, height: T, depth: T) -> Self {
-        TypedSize3D {
+        Size3D {
             width,
             height,
             depth,
@@ -635,61 +625,61 @@ impl<T, U> TypedSize3D<T, U> {
     }
 }
 
-impl<T: Clone, U> TypedSize3D<T, U> {
+impl<T: Clone, U> Size3D<T, U> {
     /// Constructor taking scalar strongly typed lengths.
     pub fn from_lengths(width: Length<T, U>, height: Length<T, U>, depth: Length<T, U>) -> Self {
-        TypedSize3D::new(width.get(), height.get(), depth.get())
+        Size3D::new(width.get(), height.get(), depth.get())
     }
 }
 
-impl<T: Round, U> TypedSize3D<T, U> {
+impl<T: Round, U> Size3D<T, U> {
     /// Rounds each component to the nearest integer value.
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
     pub fn round(&self) -> Self {
-        TypedSize3D::new(self.width.round(), self.height.round(), self.depth.round())
+        Size3D::new(self.width.round(), self.height.round(), self.depth.round())
     }
 }
 
-impl<T: Ceil, U> TypedSize3D<T, U> {
+impl<T: Ceil, U> Size3D<T, U> {
     /// Rounds each component to the smallest integer equal or greater than the original value.
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
     pub fn ceil(&self) -> Self {
-        TypedSize3D::new(self.width.ceil(), self.height.ceil(), self.depth.ceil())
+        Size3D::new(self.width.ceil(), self.height.ceil(), self.depth.ceil())
     }
 }
 
-impl<T: Floor, U> TypedSize3D<T, U> {
+impl<T: Floor, U> Size3D<T, U> {
     /// Rounds each component to the biggest integer equal or lower than the original value.
     ///
     /// This behavior is preserved for negative values (unlike the basic cast).
     pub fn floor(&self) -> Self {
-        TypedSize3D::new(self.width.floor(), self.height.floor(), self.depth.floor())
+        Size3D::new(self.width.floor(), self.height.floor(), self.depth.floor())
     }
 }
 
-impl<T: Copy + Add<T, Output = T>, U> Add for TypedSize3D<T, U> {
+impl<T: Copy + Add<T, Output = T>, U> Add for Size3D<T, U> {
     type Output = Self;
     fn add(self, other: Self) -> Self {
-        TypedSize3D::new(self.width + other.width, self.height + other.height, self.depth + other.depth)
+        Size3D::new(self.width + other.width, self.height + other.height, self.depth + other.depth)
     }
 }
 
-impl<T: Copy + Sub<T, Output = T>, U> Sub for TypedSize3D<T, U> {
+impl<T: Copy + Sub<T, Output = T>, U> Sub for Size3D<T, U> {
     type Output = Self;
     fn sub(self, other: Self) -> Self {
-        TypedSize3D::new(self.width - other.width, self.height - other.height, self.depth - other.depth)
+        Size3D::new(self.width - other.width, self.height - other.height, self.depth - other.depth)
     }
 }
 
-impl<T: Copy + Clone + Mul<T, Output=T>, U> TypedSize3D<T, U> {
+impl<T: Copy + Clone + Mul<T, Output=T>, U> Size3D<T, U> {
     pub fn volume(&self) -> T {
         self.width * self.height * self.depth
     }
 }
 
-impl<T, U> TypedSize3D<T, U>
+impl<T, U> Size3D<T, U>
 where
     T: Copy + One + Add<Output = T> + Sub<Output = T> + Mul<Output = T>,
 {
@@ -707,58 +697,58 @@ where
     }
 }
 
-impl<T: Zero + PartialOrd, U> TypedSize3D<T, U> {
+impl<T: Zero + PartialOrd, U> Size3D<T, U> {
     pub fn is_empty_or_negative(&self) -> bool {
         let zero = T::zero();
         self.width <= zero || self.height <= zero || self.depth <= zero
     }
 }
 
-impl<T: Zero, U> TypedSize3D<T, U> {
+impl<T: Zero, U> Size3D<T, U> {
     pub fn zero() -> Self {
-        TypedSize3D::new(Zero::zero(), Zero::zero(), Zero::zero())
+        Size3D::new(Zero::zero(), Zero::zero(), Zero::zero())
     }
 }
 
-impl<T: Zero, U> Zero for TypedSize3D<T, U> {
+impl<T: Zero, U> Zero for Size3D<T, U> {
     fn zero() -> Self {
-        TypedSize3D::new(Zero::zero(), Zero::zero(), Zero::zero())
+        Size3D::new(Zero::zero(), Zero::zero(), Zero::zero())
     }
 }
 
-impl<T: Copy + Mul<T, Output = T>, U> Mul<T> for TypedSize3D<T, U> {
+impl<T: Copy + Mul<T, Output = T>, U> Mul<T> for Size3D<T, U> {
     type Output = Self;
     #[inline]
     fn mul(self, scale: T) -> Self {
-        TypedSize3D::new(self.width * scale, self.height * scale, self.depth * scale)
+        Size3D::new(self.width * scale, self.height * scale, self.depth * scale)
     }
 }
 
-impl<T: Copy + Div<T, Output = T>, U> Div<T> for TypedSize3D<T, U> {
+impl<T: Copy + Div<T, Output = T>, U> Div<T> for Size3D<T, U> {
     type Output = Self;
     #[inline]
     fn div(self, scale: T) -> Self {
-        TypedSize3D::new(self.width / scale, self.height / scale, self.depth / scale)
+        Size3D::new(self.width / scale, self.height / scale, self.depth / scale)
     }
 }
 
-impl<T: Copy + Mul<T, Output = T>, U1, U2> Mul<TypedScale<T, U1, U2>> for TypedSize3D<T, U1> {
-    type Output = TypedSize3D<T, U2>;
+impl<T: Copy + Mul<T, Output = T>, U1, U2> Mul<Scale<T, U1, U2>> for Size3D<T, U1> {
+    type Output = Size3D<T, U2>;
     #[inline]
-    fn mul(self, scale: TypedScale<T, U1, U2>) -> TypedSize3D<T, U2> {
-        TypedSize3D::new(self.width * scale.get(), self.height * scale.get(), self.depth * scale.get())
+    fn mul(self, scale: Scale<T, U1, U2>) -> Size3D<T, U2> {
+        Size3D::new(self.width * scale.get(), self.height * scale.get(), self.depth * scale.get())
     }
 }
 
-impl<T: Copy + Div<T, Output = T>, U1, U2> Div<TypedScale<T, U1, U2>> for TypedSize3D<T, U2> {
-    type Output = TypedSize3D<T, U1>;
+impl<T: Copy + Div<T, Output = T>, U1, U2> Div<Scale<T, U1, U2>> for Size3D<T, U2> {
+    type Output = Size3D<T, U1>;
     #[inline]
-    fn div(self, scale: TypedScale<T, U1, U2>) -> TypedSize3D<T, U1> {
-        TypedSize3D::new(self.width / scale.get(), self.height / scale.get(), self.depth / scale.get())
+    fn div(self, scale: Scale<T, U1, U2>) -> Size3D<T, U1> {
+        Size3D::new(self.width / scale.get(), self.height / scale.get(), self.depth / scale.get())
     }
 }
 
-impl<T: Copy, U> TypedSize3D<T, U> {
+impl<T: Copy, U> Size3D<T, U> {
     /// Returns self.width as a Length carrying the unit.
     #[inline]
     pub fn width_typed(&self) -> Length<T, U> {
@@ -783,28 +773,28 @@ impl<T: Copy, U> TypedSize3D<T, U> {
     }
 
     #[inline]
-    pub fn to_vector(&self) -> TypedVector3D<T, U> {
+    pub fn to_vector(&self) -> Vector3D<T, U> {
         vec3(self.width, self.height, self.depth)
     }
 
     /// Drop the units, preserving only the numeric value.
-    pub fn to_untyped(&self) -> Size3D<T> {
-        TypedSize3D::new(self.width, self.height, self.depth)
+    pub fn to_untyped(&self) -> Size3D<T, UnknownUnit> {
+        Size3D::new(self.width, self.height, self.depth)
     }
 
     /// Tag a unitless value with units.
-    pub fn from_untyped(p: &Size3D<T>) -> Self {
-        TypedSize3D::new(p.width, p.height, p.depth)
+    pub fn from_untyped(p: &Size3D<T, UnknownUnit>) -> Self {
+        Size3D::new(p.width, p.height, p.depth)
     }
 }
 
-impl<T: NumCast + Copy, Unit> TypedSize3D<T, Unit> {
+impl<T: NumCast + Copy, Unit> Size3D<T, Unit> {
     /// Cast from one numeric representation to another, preserving the units.
     ///
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
-    pub fn cast<NewT: NumCast + Copy>(&self) -> TypedSize3D<NewT, Unit> {
+    pub fn cast<NewT: NumCast + Copy>(&self) -> Size3D<NewT, Unit> {
         self.try_cast().unwrap()
     }
 
@@ -813,9 +803,9 @@ impl<T: NumCast + Copy, Unit> TypedSize3D<T, Unit> {
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
-    pub fn try_cast<NewT: NumCast + Copy>(&self) -> Option<TypedSize3D<NewT, Unit>> {
+    pub fn try_cast<NewT: NumCast + Copy>(&self) -> Option<Size3D<NewT, Unit>> {
         match (NumCast::from(self.width), NumCast::from(self.height), NumCast::from(self.depth)) {
-            (Some(w), Some(h), Some(d)) => Some(TypedSize3D::new(w, h, d)),
+            (Some(w), Some(h), Some(d)) => Some(Size3D::new(w, h, d)),
             _ => None,
         }
     }
@@ -823,12 +813,12 @@ impl<T: NumCast + Copy, Unit> TypedSize3D<T, Unit> {
     // Convenience functions for common casts
 
     /// Cast into an `f32` size.
-    pub fn to_f32(&self) -> TypedSize3D<f32, Unit> {
+    pub fn to_f32(&self) -> Size3D<f32, Unit> {
         self.cast()
     }
 
     /// Cast into an `f64` size.
-    pub fn to_f64(&self) -> TypedSize3D<f64, Unit> {
+    pub fn to_f64(&self) -> Size3D<f64, Unit> {
         self.cast()
     }
 
@@ -837,7 +827,7 @@ impl<T: NumCast + Copy, Unit> TypedSize3D<T, Unit> {
     /// When casting from floating point sizes, it is worth considering whether
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
-    pub fn to_usize(&self) -> TypedSize3D<usize, Unit> {
+    pub fn to_usize(&self) -> Size3D<usize, Unit> {
         self.cast()
     }
 
@@ -846,7 +836,7 @@ impl<T: NumCast + Copy, Unit> TypedSize3D<T, Unit> {
     /// When casting from floating point sizes, it is worth considering whether
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
-    pub fn to_u32(&self) -> TypedSize3D<u32, Unit> {
+    pub fn to_u32(&self) -> Size3D<u32, Unit> {
         self.cast()
     }
 
@@ -855,7 +845,7 @@ impl<T: NumCast + Copy, Unit> TypedSize3D<T, Unit> {
     /// When casting from floating point sizes, it is worth considering whether
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
-    pub fn to_i32(&self) -> TypedSize3D<i32, Unit> {
+    pub fn to_i32(&self) -> Size3D<i32, Unit> {
         self.cast()
     }
 
@@ -864,12 +854,12 @@ impl<T: NumCast + Copy, Unit> TypedSize3D<T, Unit> {
     /// When casting from floating point sizes, it is worth considering whether
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
-    pub fn to_i64(&self) -> TypedSize3D<i64, Unit> {
+    pub fn to_i64(&self) -> Size3D<i64, Unit> {
         self.cast()
     }
 }
 
-impl<T, U> TypedSize3D<T, U>
+impl<T, U> Size3D<T, U>
 where
     T: Signed,
 {
@@ -882,7 +872,7 @@ where
     }
 }
 
-impl<T: PartialOrd, U> TypedSize3D<T, U> {
+impl<T: PartialOrd, U> Size3D<T, U> {
     pub fn greater_than(&self, other: &Self) -> BoolVector3D {
         BoolVector3D {
             x: self.width > other.width,
@@ -901,7 +891,7 @@ impl<T: PartialOrd, U> TypedSize3D<T, U> {
 }
 
 
-impl<T: PartialEq, U> TypedSize3D<T, U> {
+impl<T: PartialEq, U> Size3D<T, U> {
     pub fn equal(&self, other: &Self) -> BoolVector3D {
         BoolVector3D {
             x: self.width == other.width,
@@ -919,7 +909,7 @@ impl<T: PartialEq, U> TypedSize3D<T, U> {
     }
 }
 
-impl<T: Float, U> TypedSize3D<T, U> {
+impl<T: Float, U> Size3D<T, U> {
     #[inline]
     pub fn min(self, other: Self) -> Self {
         size3(
@@ -945,15 +935,15 @@ impl<T: Float, U> TypedSize3D<T, U> {
 }
 
 
-/// Shorthand for `TypedSize3D::new(w, h, d)`.
-pub fn size3<T, U>(w: T, h: T, d: T) -> TypedSize3D<T, U> {
-    TypedSize3D::new(w, h, d)
+/// Shorthand for `Size3D::new(w, h, d)`.
+pub fn size3<T, U>(w: T, h: T, d: T) -> Size3D<T, U> {
+    Size3D::new(w, h, d)
 }
 
 #[cfg(feature = "mint")]
-impl<T, U> From<mint::Vector3<T>> for TypedSize3D<T, U> {
+impl<T, U> From<mint::Vector3<T>> for Size3D<T, U> {
     fn from(v: mint::Vector3<T>) -> Self {
-        TypedSize3D {
+        Size3D {
             width: v.x,
             height: v.y,
             depth: v.z,
@@ -962,7 +952,7 @@ impl<T, U> From<mint::Vector3<T>> for TypedSize3D<T, U> {
     }
 }
 #[cfg(feature = "mint")]
-impl<T, U> Into<mint::Vector3<T>> for TypedSize3D<T, U> {
+impl<T, U> Into<mint::Vector3<T>> for Size3D<T, U> {
     fn into(self) -> mint::Vector3<T> {
         mint::Vector3 {
             x: self.width,

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -15,11 +15,11 @@ use homogen::HomogeneousVector;
 #[cfg(feature = "mint")]
 use mint;
 use trig::Trig;
-use point::{TypedPoint2D, TypedPoint3D};
-use vector::{TypedVector2D, TypedVector3D, vec2, vec3};
-use rect::TypedRect;
-use transform2d::TypedTransform2D;
-use scale::TypedScale;
+use point::{Point2D, Point3D};
+use vector::{Vector2D, Vector3D, vec2, vec3};
+use rect::Rect;
+use transform2d::Transform2D;
+use scale::Scale;
 use num::{One, Zero};
 use core::ops::{Add, Mul, Sub, Div, Neg};
 use core::marker::PhantomData;
@@ -34,8 +34,8 @@ use serde;
 ///
 /// Transforms can be parametrized over the source and destination units, to describe a
 /// transformation from a space to another.
-/// For example, `TypedTransform3D<f32, WorldSpace, ScreenSpace>::transform_point3d`
-/// takes a `TypedPoint3D<f32, WorldSpace>` and returns a `TypedPoint3D<f32, ScreenSpace>`.
+/// For example, `Transform3D<f32, WorldSpace, ScreenSpace>::transform_point3d`
+/// takes a `Point3D<f32, WorldSpace>` and returns a `Point3D<f32, ScreenSpace>`.
 ///
 /// Transforms expose a set of convenience methods for pre- and post-transformations.
 /// A pre-transformation corresponds to adding an operation that is applied before
@@ -46,7 +46,7 @@ use serde;
 /// a vector is `v * T`. If your library is using column vectors, use `row_major` functions when you
 /// are asked for `column_major` representations and vice versa.
 #[repr(C)]
-pub struct TypedTransform3D<T, Src, Dst> {
+pub struct Transform3D<T, Src, Dst> {
     pub m11: T, pub m12: T, pub m13: T, pub m14: T,
     pub m21: T, pub m22: T, pub m23: T, pub m24: T,
     pub m31: T, pub m32: T, pub m33: T, pub m34: T,
@@ -55,14 +55,11 @@ pub struct TypedTransform3D<T, Src, Dst> {
     pub _unit: PhantomData<(Src, Dst)>,
 }
 
-/// The default 3d transform type with no units.
-pub type Transform3D<T> = TypedTransform3D<T, UnknownUnit, UnknownUnit>;
+impl<T: Copy, Src, Dst> Copy for Transform3D<T, Src, Dst> {}
 
-impl<T: Copy, Src, Dst> Copy for TypedTransform3D<T, Src, Dst> {}
-
-impl<T: Clone, Src, Dst> Clone for TypedTransform3D<T, Src, Dst> {
+impl<T: Clone, Src, Dst> Clone for Transform3D<T, Src, Dst> {
     fn clone(&self) -> Self {
-        TypedTransform3D {
+        Transform3D {
             m11: self.m11.clone(),
             m12: self.m12.clone(),
             m13: self.m13.clone(),
@@ -85,7 +82,7 @@ impl<T: Clone, Src, Dst> Clone for TypedTransform3D<T, Src, Dst> {
 }
 
 #[cfg(feature = "serde")]
-impl<'de, T, Src, Dst> serde::Deserialize<'de> for TypedTransform3D<T, Src, Dst>
+impl<'de, T, Src, Dst> serde::Deserialize<'de> for Transform3D<T, Src, Dst>
     where T: serde::Deserialize<'de>
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -97,7 +94,7 @@ impl<'de, T, Src, Dst> serde::Deserialize<'de> for TypedTransform3D<T, Src, Dst>
             m31, m32, m33, m34,
             m41, m42, m43, m44,
         ) = try!(serde::Deserialize::deserialize(deserializer));
-        Ok(TypedTransform3D {
+        Ok(Transform3D {
             m11, m12, m13, m14,
             m21, m22, m23, m24,
             m31, m32, m33, m34,
@@ -108,7 +105,7 @@ impl<'de, T, Src, Dst> serde::Deserialize<'de> for TypedTransform3D<T, Src, Dst>
 }
 
 #[cfg(feature = "serde")]
-impl<T, Src, Dst> serde::Serialize for TypedTransform3D<T, Src, Dst>
+impl<T, Src, Dst> serde::Serialize for Transform3D<T, Src, Dst>
     where T: serde::Serialize
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -123,9 +120,9 @@ impl<T, Src, Dst> serde::Serialize for TypedTransform3D<T, Src, Dst>
     }
 }
 
-impl<T, Src, Dst> Eq for TypedTransform3D<T, Src, Dst> where T: Eq {}
+impl<T, Src, Dst> Eq for Transform3D<T, Src, Dst> where T: Eq {}
 
-impl<T, Src, Dst> PartialEq for TypedTransform3D<T, Src, Dst>
+impl<T, Src, Dst> PartialEq for Transform3D<T, Src, Dst>
     where T: PartialEq
 {
     fn eq(&self, other: &Self) -> bool {
@@ -148,7 +145,7 @@ impl<T, Src, Dst> PartialEq for TypedTransform3D<T, Src, Dst>
     }
 }
 
-impl<T, Src, Dst> Hash for TypedTransform3D<T, Src, Dst>
+impl<T, Src, Dst> Hash for Transform3D<T, Src, Dst>
     where T: Hash
 {
     fn hash<H: ::core::hash::Hasher>(&self, h: &mut H) {
@@ -171,7 +168,7 @@ impl<T, Src, Dst> Hash for TypedTransform3D<T, Src, Dst>
     }
 }
 
-impl<T, Src, Dst> TypedTransform3D<T, Src, Dst> {
+impl<T, Src, Dst> Transform3D<T, Src, Dst> {
     /// Create a transform specifying its components in row-major order.
     ///
     /// For example, the translation terms m41, m42, m43 on the last row with the
@@ -188,7 +185,7 @@ impl<T, Src, Dst> TypedTransform3D<T, Src, Dst> {
             m31: T, m32: T, m33: T, m34: T,
             m41: T, m42: T, m43: T, m44: T)
          -> Self {
-        TypedTransform3D {
+        Transform3D {
             m11, m12, m13, m14,
             m21, m22, m23, m24,
             m31, m32, m33, m34,
@@ -213,7 +210,7 @@ impl<T, Src, Dst> TypedTransform3D<T, Src, Dst> {
             m13: T, m23: T, m33: T, m43: T,
             m14: T, m24: T, m34: T, m44: T)
          -> Self {
-        TypedTransform3D {
+        Transform3D {
             m11, m12, m13, m14,
             m21, m22, m23, m24,
             m31, m32, m33, m34,
@@ -223,14 +220,14 @@ impl<T, Src, Dst> TypedTransform3D<T, Src, Dst> {
     }
 }
 
-impl <T, Src, Dst> TypedTransform3D<T, Src, Dst>
+impl <T, Src, Dst> Transform3D<T, Src, Dst>
 where T: Copy + Clone +
          PartialEq +
          One + Zero {
     #[inline]
     pub fn identity() -> Self {
         let (_0, _1): (T, T) = (Zero::zero(), One::one());
-        TypedTransform3D::row_major(
+        Transform3D::row_major(
             _1, _0, _0, _0,
             _0, _1, _0, _0,
             _0, _0, _1, _0,
@@ -243,11 +240,11 @@ where T: Copy + Clone +
     // equivalence to deal with floating-point errors.
     #[inline]
     fn is_identity(&self) -> bool {
-        *self == TypedTransform3D::identity()
+        *self == Transform3D::identity()
     }
 }
 
-impl <T, Src, Dst> TypedTransform3D<T, Src, Dst>
+impl <T, Src, Dst> Transform3D<T, Src, Dst>
 where T: Copy + Clone +
          Add<T, Output=T> +
          Sub<T, Output=T> +
@@ -263,7 +260,7 @@ where T: Copy + Clone +
     #[inline]
     pub fn row_major_2d(m11: T, m12: T, m21: T, m22: T, m41: T, m42: T) -> Self {
         let (_0, _1): (T, T) = (Zero::zero(), One::one());
-        TypedTransform3D::row_major(
+        Transform3D::row_major(
             m11, m12, _0, _0,
             m21, m22, _0, _0,
              _0,  _0, _1, _0,
@@ -281,7 +278,7 @@ where T: Copy + Clone +
 
         let (_0, _1): (T, T) = (Zero::zero(), One::one());
         let _2 = _1 + _1;
-        TypedTransform3D::row_major(
+        Transform3D::row_major(
             _2 / (right - left), _0                 , _0                , _0,
             _0                 , _2 / (top - bottom), _0                , _0,
             _0                 , _0                 , -_2 / (far - near), _0,
@@ -289,7 +286,7 @@ where T: Copy + Clone +
         )
     }
 
-    /// Returns true if this transform can be represented with a `TypedTransform2D`.
+    /// Returns true if this transform can be represented with a `Transform2D`.
     ///
     /// See <https://drafts.csswg.org/css-transforms/#2d-transform>
     #[inline]
@@ -306,8 +303,8 @@ where T: Copy + Clone +
     ///
     /// This method assumes that self represents a 2d transformation, callers
     /// should check that self.is_2d() returns true beforehand.
-    pub fn to_2d(&self) -> TypedTransform2D<T, Src, Dst> {
-        TypedTransform2D::row_major(
+    pub fn to_2d(&self) -> Transform2D<T, Src, Dst> {
+        Transform2D::row_major(
             self.m11, self.m12,
             self.m21, self.m22,
             self.m41, self.m42
@@ -340,8 +337,8 @@ where T: Copy + Clone +
 
     /// Returns the same transform with a different destination unit.
     #[inline]
-    pub fn with_destination<NewDst>(&self) -> TypedTransform3D<T, Src, NewDst> {
-        TypedTransform3D::row_major(
+    pub fn with_destination<NewDst>(&self) -> Transform3D<T, Src, NewDst> {
+        Transform3D::row_major(
             self.m11, self.m12, self.m13, self.m14,
             self.m21, self.m22, self.m23, self.m24,
             self.m31, self.m32, self.m33, self.m34,
@@ -351,8 +348,8 @@ where T: Copy + Clone +
 
     /// Returns the same transform with a different source unit.
     #[inline]
-    pub fn with_source<NewSrc>(&self) -> TypedTransform3D<T, NewSrc, Dst> {
-        TypedTransform3D::row_major(
+    pub fn with_source<NewSrc>(&self) -> Transform3D<T, NewSrc, Dst> {
+        Transform3D::row_major(
             self.m11, self.m12, self.m13, self.m14,
             self.m21, self.m22, self.m23, self.m24,
             self.m31, self.m32, self.m33, self.m34,
@@ -362,7 +359,7 @@ where T: Copy + Clone +
 
     /// Drop the units, preserving only the numeric value.
     #[inline]
-    pub fn to_untyped(&self) -> Transform3D<T> {
+    pub fn to_untyped(&self) -> Transform3D<T, UnknownUnit, UnknownUnit> {
         Transform3D::row_major(
             self.m11, self.m12, self.m13, self.m14,
             self.m21, self.m22, self.m23, self.m24,
@@ -373,8 +370,8 @@ where T: Copy + Clone +
 
     /// Tag a unitless value with units.
     #[inline]
-    pub fn from_untyped(m: &Transform3D<T>) -> Self {
-        TypedTransform3D::row_major(
+    pub fn from_untyped(m: &Transform3D<T, UnknownUnit, UnknownUnit>) -> Self {
+        Transform3D::row_major(
             m.m11, m.m12, m.m13, m.m14,
             m.m21, m.m22, m.m23, m.m24,
             m.m31, m.m32, m.m33, m.m34,
@@ -387,8 +384,8 @@ where T: Copy + Clone +
     ///
     /// Assuming row vectors, this is equivalent to self * mat
     #[must_use]
-    pub fn post_transform<NewDst>(&self, mat: &TypedTransform3D<T, Dst, NewDst>) -> TypedTransform3D<T, Src, NewDst> {
-        TypedTransform3D::row_major(
+    pub fn post_transform<NewDst>(&self, mat: &Transform3D<T, Dst, NewDst>) -> Transform3D<T, Src, NewDst> {
+        Transform3D::row_major(
             self.m11 * mat.m11  +  self.m12 * mat.m21  +  self.m13 * mat.m31  +  self.m14 * mat.m41,
             self.m11 * mat.m12  +  self.m12 * mat.m22  +  self.m13 * mat.m32  +  self.m14 * mat.m42,
             self.m11 * mat.m13  +  self.m12 * mat.m23  +  self.m13 * mat.m33  +  self.m14 * mat.m43,
@@ -414,7 +411,7 @@ where T: Copy + Clone +
     /// Assuming row vectors, this is equivalent to mat * self
     #[inline]
     #[must_use]
-    pub fn pre_transform<NewSrc>(&self, mat: &TypedTransform3D<T, NewSrc, Src>) -> TypedTransform3D<T, NewSrc, Dst> {
+    pub fn pre_transform<NewSrc>(&self, mat: &Transform3D<T, NewSrc, Src>) -> Transform3D<T, NewSrc, Dst> {
         mat.post_transform(self)
     }
 
@@ -423,7 +420,7 @@ where T: Copy + Clone +
     ///
     /// Assuming row vectors, this is equivalent to self * mat
     #[must_use]
-    pub fn post_mul<NewDst>(&self, mat: &TypedTransform3D<T, Dst, NewDst>) -> TypedTransform3D<T, Src, NewDst> {
+    pub fn post_mul<NewDst>(&self, mat: &Transform3D<T, Dst, NewDst>) -> Transform3D<T, Src, NewDst> {
         self.post_transform(mat)
     }
 
@@ -432,12 +429,12 @@ where T: Copy + Clone +
     ///
     /// Assuming row vectors, this is equivalent to mat * self
     #[must_use]
-    pub fn pre_mul<NewSrc>(&self, mat: &TypedTransform3D<T, NewSrc, Src>) -> TypedTransform3D<T, NewSrc, Dst> {
+    pub fn pre_mul<NewSrc>(&self, mat: &Transform3D<T, NewSrc, Src>) -> Transform3D<T, NewSrc, Dst> {
         self.pre_transform(mat)
     }
 
     /// Returns the inverse transform if possible.
-    pub fn inverse(&self) -> Option<TypedTransform3D<T, Dst, Src>> {
+    pub fn inverse(&self) -> Option<Transform3D<T, Dst, Src>> {
         let det = self.determinant();
 
         if det == Zero::zero() {
@@ -446,7 +443,7 @@ where T: Copy + Clone +
 
         // todo(gw): this could be made faster by special casing
         // for simpler transform types.
-        let m = TypedTransform3D::row_major(
+        let m = Transform3D::row_major(
             self.m23*self.m34*self.m42 - self.m24*self.m33*self.m42 +
             self.m24*self.m32*self.m43 - self.m22*self.m34*self.m43 -
             self.m23*self.m32*self.m44 + self.m22*self.m33*self.m44,
@@ -547,7 +544,7 @@ where T: Copy + Clone +
     /// Multiplies all of the transform's component by a scalar and returns the result.
     #[must_use]
     pub fn mul_s(&self, x: T) -> Self {
-        TypedTransform3D::row_major(
+        Transform3D::row_major(
             self.m11 * x, self.m12 * x, self.m13 * x, self.m14 * x,
             self.m21 * x, self.m22 * x, self.m23 * x, self.m24 * x,
             self.m31 * x, self.m32 * x, self.m33 * x, self.m34 * x,
@@ -555,9 +552,9 @@ where T: Copy + Clone +
         )
     }
 
-    /// Convenience function to create a scale transform from a `TypedScale`.
-    pub fn from_scale(scale: TypedScale<T, Src, Dst>) -> Self {
-        TypedTransform3D::create_scale(scale.get(), scale.get(), scale.get())
+    /// Convenience function to create a scale transform from a `Scale`.
+    pub fn from_scale(scale: Scale<T, Src, Dst>) -> Self {
+        Transform3D::create_scale(scale.get(), scale.get(), scale.get())
     }
 
     /// Returns the homogeneous vector corresponding to the transformed 2d point.
@@ -567,7 +564,7 @@ where T: Copy + Clone +
     /// Assuming row vectors, this is equivalent to `p * self`
     #[inline]
     pub fn transform_point2d_homogeneous(
-        &self, p: &TypedPoint2D<T, Src>
+        &self, p: &Point2D<T, Src>
     ) -> HomogeneousVector<T, Dst> {
         let x = p.x * self.m11 + p.y * self.m21 + self.m41;
         let y = p.x * self.m12 + p.y * self.m22 + self.m42;
@@ -584,14 +581,14 @@ where T: Copy + Clone +
     ///
     /// Assuming row vectors, this is equivalent to `p * self`
     #[inline]
-    pub fn transform_point2d(&self, p: &TypedPoint2D<T, Src>) -> Option<TypedPoint2D<T, Dst>> {
+    pub fn transform_point2d(&self, p: &Point2D<T, Src>) -> Option<Point2D<T, Dst>> {
         //Note: could use `transform_point2d_homogeneous()` but it would waste the calculus of `z`
         let w = p.x * self.m14 + p.y * self.m24 + self.m44;
         if w > T::zero() {
             let x = p.x * self.m11 + p.y * self.m21 + self.m41;
             let y = p.x * self.m12 + p.y * self.m22 + self.m42;
 
-            Some(TypedPoint2D::new(x / w, y / w))
+            Some(Point2D::new(x / w, y / w))
         } else {
             None
         }
@@ -603,7 +600,7 @@ where T: Copy + Clone +
     ///
     /// Assuming row vectors, this is equivalent to `v * self`
     #[inline]
-    pub fn transform_vector2d(&self, v: &TypedVector2D<T, Src>) -> TypedVector2D<T, Dst> {
+    pub fn transform_vector2d(&self, v: &Vector2D<T, Src>) -> Vector2D<T, Dst> {
         vec2(
             v.x * self.m11 + v.y * self.m21,
             v.x * self.m12 + v.y * self.m22,
@@ -617,7 +614,7 @@ where T: Copy + Clone +
     /// Assuming row vectors, this is equivalent to `p * self`
     #[inline]
     pub fn transform_point3d_homogeneous(
-        &self, p: &TypedPoint3D<T, Src>
+        &self, p: &Point3D<T, Src>
     ) -> HomogeneousVector<T, Dst> {
         let x = p.x * self.m11 + p.y * self.m21 + p.z * self.m31 + self.m41;
         let y = p.x * self.m12 + p.y * self.m22 + p.z * self.m32 + self.m42;
@@ -634,7 +631,7 @@ where T: Copy + Clone +
     ///
     /// Assuming row vectors, this is equivalent to `p * self`
     #[inline]
-    pub fn transform_point3d(&self, p: &TypedPoint3D<T, Src>) -> Option<TypedPoint3D<T, Dst>> {
+    pub fn transform_point3d(&self, p: &Point3D<T, Src>) -> Option<Point3D<T, Dst>> {
         self.transform_point3d_homogeneous(p).to_point3d()
     }
 
@@ -644,7 +641,7 @@ where T: Copy + Clone +
     ///
     /// Assuming row vectors, this is equivalent to `v * self`
     #[inline]
-    pub fn transform_vector3d(&self, v: &TypedVector3D<T, Src>) -> TypedVector3D<T, Dst> {
+    pub fn transform_vector3d(&self, v: &Vector3D<T, Src>) -> Vector3D<T, Dst> {
         vec3(
             v.x * self.m11 + v.y * self.m21 + v.z * self.m31,
             v.x * self.m12 + v.y * self.m22 + v.z * self.m32,
@@ -654,8 +651,8 @@ where T: Copy + Clone +
 
     /// Returns a rectangle that encompasses the result of transforming the given rectangle by this
     /// transform, if the transform makes sense for it, or `None` otherwise.
-    pub fn transform_rect(&self, rect: &TypedRect<T, Src>) -> Option<TypedRect<T, Dst>> {
-        Some(TypedRect::from_points(&[
+    pub fn transform_rect(&self, rect: &Rect<T, Src>) -> Option<Rect<T, Dst>> {
+        Some(Rect::from_points(&[
             self.transform_point2d(&rect.origin)?,
             self.transform_point2d(&rect.top_right())?,
             self.transform_point2d(&rect.bottom_left())?,
@@ -666,7 +663,7 @@ where T: Copy + Clone +
     /// Create a 3d translation transform
     pub fn create_translation(x: T, y: T, z: T) -> Self {
         let (_0, _1): (T, T) = (Zero::zero(), One::one());
-        TypedTransform3D::row_major(
+        Transform3D::row_major(
             _1, _0, _0, _0,
             _0, _1, _0, _0,
             _0, _0, _1, _0,
@@ -676,14 +673,14 @@ where T: Copy + Clone +
 
     /// Returns a transform with a translation applied before self's transformation.
     #[must_use]
-    pub fn pre_translate(&self, v: TypedVector3D<T, Src>) -> Self {
-        self.pre_transform(&TypedTransform3D::create_translation(v.x, v.y, v.z))
+    pub fn pre_translate(&self, v: Vector3D<T, Src>) -> Self {
+        self.pre_transform(&Transform3D::create_translation(v.x, v.y, v.z))
     }
 
     /// Returns a transform with a translation applied after self's transformation.
     #[must_use]
-    pub fn post_translate(&self, v: TypedVector3D<T, Dst>) -> Self {
-        self.post_transform(&TypedTransform3D::create_translation(v.x, v.y, v.z))
+    pub fn post_translate(&self, v: Vector3D<T, Dst>) -> Self {
+        self.post_transform(&Transform3D::create_translation(v.x, v.y, v.z))
     }
 
     /// Returns a projection of this transform in 2d space.
@@ -725,7 +722,7 @@ where T: Copy + Clone +
     /// Create a 3d scale transform
     pub fn create_scale(x: T, y: T, z: T) -> Self {
         let (_0, _1): (T, T) = (Zero::zero(), One::one());
-        TypedTransform3D::row_major(
+        Transform3D::row_major(
              x, _0, _0, _0,
             _0,  y, _0, _0,
             _0, _0,  z, _0,
@@ -736,7 +733,7 @@ where T: Copy + Clone +
     /// Returns a transform with a scale applied before self's transformation.
     #[must_use]
     pub fn pre_scale(&self, x: T, y: T, z: T) -> Self {
-        TypedTransform3D::row_major(
+        Transform3D::row_major(
             self.m11 * x, self.m12,     self.m13,     self.m14,
             self.m21    , self.m22 * y, self.m23,     self.m24,
             self.m31    , self.m32,     self.m33 * z, self.m34,
@@ -747,7 +744,7 @@ where T: Copy + Clone +
     /// Returns a transform with a scale applied after self's transformation.
     #[must_use]
     pub fn post_scale(&self, x: T, y: T, z: T) -> Self {
-        self.post_transform(&TypedTransform3D::create_scale(x, y, z))
+        self.post_transform(&Transform3D::create_scale(x, y, z))
     }
 
     /// Create a 3d rotation transform from an angle / axis.
@@ -764,7 +761,7 @@ where T: Copy + Clone +
         let sc = half_theta.sin() * half_theta.cos();
         let sq = half_theta.sin() * half_theta.sin();
 
-        TypedTransform3D::row_major(
+        Transform3D::row_major(
             _1 - _2 * (yy + zz) * sq,
             _2 * (x * y * sq - z * sc),
             _2 * (x * z * sq + y * sc),
@@ -790,13 +787,13 @@ where T: Copy + Clone +
     /// Returns a transform with a rotation applied after self's transformation.
     #[must_use]
     pub fn post_rotate(&self, x: T, y: T, z: T, theta: Angle<T>) -> Self {
-        self.post_transform(&TypedTransform3D::create_rotation(x, y, z, theta))
+        self.post_transform(&Transform3D::create_rotation(x, y, z, theta))
     }
 
     /// Returns a transform with a rotation applied before self's transformation.
     #[must_use]
     pub fn pre_rotate(&self, x: T, y: T, z: T, theta: Angle<T>) -> Self {
-        self.pre_transform(&TypedTransform3D::create_rotation(x, y, z, theta))
+        self.pre_transform(&Transform3D::create_rotation(x, y, z, theta))
     }
 
     /// Create a 2d skew transform.
@@ -805,7 +802,7 @@ where T: Copy + Clone +
     pub fn create_skew(alpha: Angle<T>, beta: Angle<T>) -> Self {
         let (_0, _1): (T, T) = (Zero::zero(), One::one());
         let (sx, sy) = (beta.get().tan(), alpha.get().tan());
-        TypedTransform3D::row_major(
+        Transform3D::row_major(
             _1, sx, _0, _0,
             sy, _1, _0, _0,
             _0, _0, _1, _0,
@@ -816,7 +813,7 @@ where T: Copy + Clone +
     /// Create a simple perspective projection transform
     pub fn create_perspective(d: T) -> Self {
         let (_0, _1): (T, T) = (Zero::zero(), One::one());
-        TypedTransform3D::row_major(
+        Transform3D::row_major(
             _1, _0, _0, _0,
             _0, _1, _0, _0,
             _0, _0, _1, -_1 / d,
@@ -825,7 +822,7 @@ where T: Copy + Clone +
     }
 }
 
-impl<T: Copy, Src, Dst> TypedTransform3D<T, Src, Dst> {
+impl<T: Copy, Src, Dst> Transform3D<T, Src, Dst> {
     /// Returns an array containing this transform's terms in row-major order (the order
     /// in which the transform is actually laid out in memory).
     ///
@@ -918,14 +915,14 @@ impl<T: Copy, Src, Dst> TypedTransform3D<T, Src, Dst> {
     }
 }
 
-impl<T0: NumCast + Copy, Src, Dst> TypedTransform3D<T0, Src, Dst> {
+impl<T0: NumCast + Copy, Src, Dst> Transform3D<T0, Src, Dst> {
     /// Cast from one numeric representation to another, preserving the units.
-    pub fn cast<T1: NumCast + Copy>(&self) -> TypedTransform3D<T1, Src, Dst> {
+    pub fn cast<T1: NumCast + Copy>(&self) -> Transform3D<T1, Src, Dst> {
         self.try_cast().unwrap()
     }
 
     /// Fallible cast from one numeric representation to another, preserving the units.
-    pub fn try_cast<T1: NumCast + Copy>(&self) -> Option<TypedTransform3D<T1, Src, Dst>> {
+    pub fn try_cast<T1: NumCast + Copy>(&self) -> Option<Transform3D<T1, Src, Dst>> {
         match (NumCast::from(self.m11), NumCast::from(self.m12),
                NumCast::from(self.m13), NumCast::from(self.m14),
                NumCast::from(self.m21), NumCast::from(self.m22),
@@ -938,7 +935,7 @@ impl<T0: NumCast + Copy, Src, Dst> TypedTransform3D<T0, Src, Dst> {
              Some(m21), Some(m22), Some(m23), Some(m24),
              Some(m31), Some(m32), Some(m33), Some(m34),
              Some(m41), Some(m42), Some(m43), Some(m44)) => {
-                Some(TypedTransform3D::row_major(m11, m12, m13, m14,
+                Some(Transform3D::row_major(m11, m12, m13, m14,
                                                  m21, m22, m23, m24,
                                                  m31, m32, m33, m34,
                                                  m41, m42, m43, m44))
@@ -948,7 +945,7 @@ impl<T0: NumCast + Copy, Src, Dst> TypedTransform3D<T0, Src, Dst> {
     }
 }
 
-impl <T, Src, Dst> Default for TypedTransform3D<T, Src, Dst>
+impl <T, Src, Dst> Default for Transform3D<T, Src, Dst>
     where T: Copy + PartialEq + One + Zero
 {
     fn default() -> Self {
@@ -956,7 +953,7 @@ impl <T, Src, Dst> Default for TypedTransform3D<T, Src, Dst>
     }
 }
 
-impl<T, Src, Dst> fmt::Debug for TypedTransform3D<T, Src, Dst>
+impl<T, Src, Dst> fmt::Debug for Transform3D<T, Src, Dst>
 where T: Copy + fmt::Debug +
          PartialEq +
          One + Zero {
@@ -970,9 +967,9 @@ where T: Copy + fmt::Debug +
 }
 
 #[cfg(feature = "mint")]
-impl<T, Src, Dst> From<mint::RowMatrix4<T>> for TypedTransform3D<T, Src, Dst> {
+impl<T, Src, Dst> From<mint::RowMatrix4<T>> for Transform3D<T, Src, Dst> {
     fn from(m: mint::RowMatrix4<T>) -> Self {
-        TypedTransform3D {
+        Transform3D {
             m11: m.x.x, m12: m.x.y, m13: m.x.z, m14: m.x.w,
             m21: m.y.x, m22: m.y.y, m23: m.y.z, m24: m.y.w,
             m31: m.z.x, m32: m.z.y, m33: m.z.z, m34: m.z.w,
@@ -982,7 +979,7 @@ impl<T, Src, Dst> From<mint::RowMatrix4<T>> for TypedTransform3D<T, Src, Dst> {
     }
 }
 #[cfg(feature = "mint")]
-impl<T, Src, Dst> Into<mint::RowMatrix4<T>> for TypedTransform3D<T, Src, Dst> {
+impl<T, Src, Dst> Into<mint::RowMatrix4<T>> for Transform3D<T, Src, Dst> {
     fn into(self) -> mint::RowMatrix4<T> {
         mint::RowMatrix4 {
             x: mint::Vector4 { x: self.m11, y: self.m12, z: self.m13, w: self.m14 },
@@ -997,14 +994,13 @@ impl<T, Src, Dst> Into<mint::RowMatrix4<T>> for TypedTransform3D<T, Src, Dst> {
 #[cfg(test)]
 mod tests {
     use approxeq::ApproxEq;
-    use transform2d::Transform2D;
-    use point::{point2, point3};
-    use Angle;
     use super::*;
+    use {point2, point3};
+    use default;
 
     use core::f32::consts::{FRAC_PI_2, PI};
 
-    type Mf32 = Transform3D<f32>;
+    type Mf32 = default::Transform3D<f32>;
 
     // For convenience.
     fn rad(v: f32) -> Angle<f32> { Angle::radians(v) }
@@ -1161,8 +1157,8 @@ mod tests {
 
     #[test]
     pub fn test_pre_post() {
-        let m1 = Transform3D::identity().post_scale(1.0, 2.0, 3.0).post_translate(vec3(1.0, 2.0, 3.0));
-        let m2 = Transform3D::identity().pre_translate(vec3(1.0, 2.0, 3.0)).pre_scale(1.0, 2.0, 3.0);
+        let m1 = default::Transform3D::identity().post_scale(1.0, 2.0, 3.0).post_translate(vec3(1.0, 2.0, 3.0));
+        let m2 = default::Transform3D::identity().pre_translate(vec3(1.0, 2.0, 3.0)).pre_scale(1.0, 2.0, 3.0);
         assert!(m1.approx_eq(&m2));
 
         let r = Mf32::create_rotation(0.0, 0.0, 1.0, rad(FRAC_PI_2));
@@ -1182,8 +1178,8 @@ mod tests {
     #[test]
     fn test_size_of() {
         use core::mem::size_of;
-        assert_eq!(size_of::<Transform3D<f32>>(), 16*size_of::<f32>());
-        assert_eq!(size_of::<Transform3D<f64>>(), 16*size_of::<f64>());
+        assert_eq!(size_of::<default::Transform3D<f32>>(), 16*size_of::<f32>());
+        assert_eq!(size_of::<default::Transform3D<f64>>(), 16*size_of::<f64>());
     }
 
     #[test]
@@ -1205,7 +1201,7 @@ mod tests {
 
     #[test]
     pub fn test_is_identity() {
-        let m1 = Transform3D::identity();
+        let m1 = default::Transform3D::identity();
         assert!(m1.is_identity());
         let m2 = m1.post_translate(vec3(0.1, 0.0, 0.0));
         assert!(!m2.is_identity());

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -7,8 +7,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use {TypedVector2D, TypedPoint2D, TypedVector3D, TypedPoint3D, TypedTransform2D, TypedTransform3D};
-use {TypedSize2D, TypedRect, vec2, point2, vec3, point3};
+use {Vector2D, Point2D, Vector3D, Point3D, Transform2D, Transform3D};
+use {Size2D, Rect, vec2, point2, vec3, point3};
 use num::*;
 use trig::Trig;
 use core::ops::{Add, Sub, Neg, Mul, Div};
@@ -21,18 +21,18 @@ use serde;
 
 /// A 2d transformation from a space to another that can only express translations.
 ///
-/// The main benefit of this type over a TypedVector2D is the ability to cast
+/// The main benefit of this type over a Vector2D is the ability to cast
 /// between a source and a destination spaces.
 ///
 /// Example:
 ///
 /// ```
-/// use euclid::{TypedTranslation2D, TypedPoint2D, point2};
+/// use euclid::{Translation2D, Point2D, point2};
 /// struct ParentSpace;
 /// struct ChildSpace;
-/// type ScrollOffset = TypedTranslation2D<i32, ParentSpace, ChildSpace>;
-/// type ParentPoint = TypedPoint2D<i32, ParentSpace>;
-/// type ChildPoint = TypedPoint2D<i32, ChildSpace>;
+/// type ScrollOffset = Translation2D<i32, ParentSpace, ChildSpace>;
+/// type ParentPoint = Point2D<i32, ParentSpace>;
+/// type ChildPoint = Point2D<i32, ChildSpace>;
 ///
 /// let scrolling = ScrollOffset::new(0, 100);
 /// let p1: ParentPoint = point2(0, 0);
@@ -40,18 +40,18 @@ use serde;
 /// ```
 ///
 #[repr(C)]
-pub struct TypedTranslation2D<T, Src, Dst> {
+pub struct Translation2D<T, Src, Dst> {
     pub x: T,
     pub y: T,
     #[doc(hidden)]
     pub _unit: PhantomData<(Src, Dst)>,
 }
 
-impl<T: Copy, Src, Dst> Copy for TypedTranslation2D<T, Src, Dst> {}
+impl<T: Copy, Src, Dst> Copy for Translation2D<T, Src, Dst> {}
 
-impl<T: Clone, Src, Dst> Clone for TypedTranslation2D<T, Src, Dst> {
+impl<T: Clone, Src, Dst> Clone for Translation2D<T, Src, Dst> {
     fn clone(&self) -> Self {
-        TypedTranslation2D {
+        Translation2D {
             x: self.x.clone(),
             y: self.y.clone(),
             _unit: PhantomData,
@@ -60,19 +60,19 @@ impl<T: Clone, Src, Dst> Clone for TypedTranslation2D<T, Src, Dst> {
 }
 
 #[cfg(feature = "serde")]
-impl<'de, T, Src, Dst> serde::Deserialize<'de> for TypedTranslation2D<T, Src, Dst>
+impl<'de, T, Src, Dst> serde::Deserialize<'de> for Translation2D<T, Src, Dst>
     where T: serde::Deserialize<'de>
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where D: serde::Deserializer<'de>
     {
         let (x, y) = try!(serde::Deserialize::deserialize(deserializer));
-        Ok(TypedTranslation2D { x, y, _unit: PhantomData })
+        Ok(Translation2D { x, y, _unit: PhantomData })
     }
 }
 
 #[cfg(feature = "serde")]
-impl<T, Src, Dst> serde::Serialize for TypedTranslation2D<T, Src, Dst>
+impl<T, Src, Dst> serde::Serialize for Translation2D<T, Src, Dst>
     where T: serde::Serialize
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -82,9 +82,9 @@ impl<T, Src, Dst> serde::Serialize for TypedTranslation2D<T, Src, Dst>
     }
 }
 
-impl<T, Src, Dst> Eq for TypedTranslation2D<T, Src, Dst> where T: Eq {}
+impl<T, Src, Dst> Eq for Translation2D<T, Src, Dst> where T: Eq {}
 
-impl<T, Src, Dst> PartialEq for TypedTranslation2D<T, Src, Dst>
+impl<T, Src, Dst> PartialEq for Translation2D<T, Src, Dst>
     where T: PartialEq
 {
     fn eq(&self, other: &Self) -> bool {
@@ -92,7 +92,7 @@ impl<T, Src, Dst> PartialEq for TypedTranslation2D<T, Src, Dst>
     }
 }
 
-impl<T, Src, Dst> Hash for TypedTranslation2D<T, Src, Dst>
+impl<T, Src, Dst> Hash for Translation2D<T, Src, Dst>
     where T: Hash
 {
     fn hash<H: ::core::hash::Hasher>(&self, h: &mut H) {
@@ -101,10 +101,10 @@ impl<T, Src, Dst> Hash for TypedTranslation2D<T, Src, Dst>
     }
 }
 
-impl<T, Src, Dst> TypedTranslation2D<T, Src, Dst> {
+impl<T, Src, Dst> Translation2D<T, Src, Dst> {
     #[inline]
     pub fn new(x: T, y: T) -> Self {
-        TypedTranslation2D {
+        Translation2D {
             x,
             y,
             _unit: PhantomData,
@@ -112,7 +112,7 @@ impl<T, Src, Dst> TypedTranslation2D<T, Src, Dst> {
     }
 }
 
-impl<T, Src, Dst> TypedTranslation2D<T, Src, Dst>
+impl<T, Src, Dst> Translation2D<T, Src, Dst>
 where
     T : Copy
 {
@@ -127,18 +127,18 @@ where
     }
 }
 
-impl<T, Src, Dst> TypedTranslation2D<T, Src, Dst>
+impl<T, Src, Dst> Translation2D<T, Src, Dst>
 where
     T : Copy + Zero
 {
     #[inline]
     pub fn identity() -> Self {
         let _0 = T::zero();
-        TypedTranslation2D::new(_0, _0)
+        Translation2D::new(_0, _0)
     }
 }
 
-impl<T, Src, Dst> TypedTranslation2D<T, Src, Dst>
+impl<T, Src, Dst> Translation2D<T, Src, Dst>
 where
     T: Zero + PartialEq
 {
@@ -148,20 +148,20 @@ where
     }
 }
 
-impl<T, Src, Dst> TypedTranslation2D<T, Src, Dst>
+impl<T, Src, Dst> Translation2D<T, Src, Dst>
 where
     T: Copy + Add<T, Output = T>
 {
     /// Translate a point and cast its unit.
     #[inline]
-    pub fn transform_point(&self, p: &TypedPoint2D<T, Src>) -> TypedPoint2D<T, Dst> {
+    pub fn transform_point(&self, p: &Point2D<T, Src>) -> Point2D<T, Dst> {
         point2(p.x + self.x, p.y + self.y)
     }
 
     /// Translate a rectangle and cast its unit.
     #[inline]
-    pub fn transform_rect(&self, r: &TypedRect<T, Src>) -> TypedRect<T, Dst> {
-        TypedRect {
+    pub fn transform_rect(&self, r: &Rect<T, Src>) -> Rect<T, Dst> {
+        Rect {
             origin: self.transform_point(&r.origin),
             size: self.transform_size(&r.size),
         }
@@ -169,35 +169,35 @@ where
 
     /// No-op, just cast the unit.
     #[inline]
-    pub fn transform_size(&self, s: &TypedSize2D<T, Src>) -> TypedSize2D<T, Dst> {
-        TypedSize2D::new(s.width, s.height)
+    pub fn transform_size(&self, s: &Size2D<T, Src>) -> Size2D<T, Dst> {
+        Size2D::new(s.width, s.height)
     }
 
     /// Cast into a 2D vector.
-    pub fn to_vector(&self) -> TypedVector2D<T, Src> {
+    pub fn to_vector(&self) -> Vector2D<T, Src> {
         vec2(self.x, self.y)
     }
 }
 
-impl<T, Src, Dst> TypedTranslation2D<T, Src, Dst>
+impl<T, Src, Dst> Translation2D<T, Src, Dst>
 where
     T: Copy + Neg<Output = T>
 {
     /// Return the inverse transformation.
     #[inline]
-    pub fn inverse(&self) -> TypedTranslation2D<T, Dst, Src> {
-        TypedTranslation2D::new(-self.x, -self.y)
+    pub fn inverse(&self) -> Translation2D<T, Dst, Src> {
+        Translation2D::new(-self.x, -self.y)
     }
 }
 
-impl<T, Src, Dst1, Dst2> Add<TypedTranslation2D<T, Dst1, Dst2>>
-for TypedTranslation2D<T, Src, Dst1>
+impl<T, Src, Dst1, Dst2> Add<Translation2D<T, Dst1, Dst2>>
+for Translation2D<T, Src, Dst1>
 where
     T: Copy + Add<T, Output = T>
 {
-    type Output = TypedTranslation2D<T, Src, Dst2>;
-    fn add(self, other: TypedTranslation2D<T, Dst1, Dst2>) -> TypedTranslation2D<T, Src, Dst2> {
-        TypedTranslation2D::new(
+    type Output = Translation2D<T, Src, Dst2>;
+    fn add(self, other: Translation2D<T, Dst1, Dst2>) -> Translation2D<T, Src, Dst2> {
+        Translation2D::new(
             self.x + other.x,
             self.y + other.y,
         )
@@ -205,21 +205,21 @@ where
 }
 
 impl<T, Src, Dst1, Dst2>
-    Sub<TypedTranslation2D<T, Dst1, Dst2>>
-    for TypedTranslation2D<T, Src, Dst2>
+    Sub<Translation2D<T, Dst1, Dst2>>
+    for Translation2D<T, Src, Dst2>
 where
     T: Copy + Sub<T, Output = T>
 {
-    type Output = TypedTranslation2D<T, Src, Dst1>;
-    fn sub(self, other: TypedTranslation2D<T, Dst1, Dst2>) -> TypedTranslation2D<T, Src, Dst1> {
-        TypedTranslation2D::new(
+    type Output = Translation2D<T, Src, Dst1>;
+    fn sub(self, other: Translation2D<T, Dst1, Dst2>) -> Translation2D<T, Src, Dst1> {
+        Translation2D::new(
             self.x - other.x,
             self.y - other.y,
         )
     }
 }
 
-impl<T, Src, Dst> TypedTranslation2D<T, Src, Dst>
+impl<T, Src, Dst> Translation2D<T, Src, Dst>
 where
     T: Copy
         + Clone
@@ -234,30 +234,30 @@ where
 {
     /// Returns the matrix representation of this translation.
     #[inline]
-    pub fn to_transform(&self) -> TypedTransform2D<T, Src, Dst> {
-        TypedTransform2D::create_translation(self.x, self.y)
+    pub fn to_transform(&self) -> Transform2D<T, Src, Dst> {
+        Transform2D::create_translation(self.x, self.y)
     }
 }
 
-impl<T, Src, Dst> From<TypedVector2D<T, Src>> for TypedTranslation2D<T, Src, Dst>
+impl<T, Src, Dst> From<Vector2D<T, Src>> for Translation2D<T, Src, Dst>
 where
     T: Copy
 {
-    fn from(v: TypedVector2D<T, Src>) -> Self {
-        TypedTranslation2D::new(v.x, v.y)
+    fn from(v: Vector2D<T, Src>) -> Self {
+        Translation2D::new(v.x, v.y)
     }
 }
 
-impl<T, Src, Dst> Into<TypedVector2D<T, Src>> for TypedTranslation2D<T, Src, Dst>
+impl<T, Src, Dst> Into<Vector2D<T, Src>> for Translation2D<T, Src, Dst>
 where
     T: Copy
 {
-    fn into(self) -> TypedVector2D<T, Src> {
+    fn into(self) -> Vector2D<T, Src> {
         vec2(self.x, self.y)
     }
 }
 
-impl<T, Src, Dst> Into<TypedTransform2D<T, Src, Dst>> for TypedTranslation2D<T, Src, Dst>
+impl<T, Src, Dst> Into<Transform2D<T, Src, Dst>> for Translation2D<T, Src, Dst>
 where
     T: Copy
         + Clone
@@ -270,12 +270,12 @@ where
         + One
         + Zero,
 {
-    fn into(self) -> TypedTransform2D<T, Src, Dst> {
+    fn into(self) -> Transform2D<T, Src, Dst> {
         self.to_transform()
     }
 }
 
-impl <T, Src, Dst> Default for TypedTranslation2D<T, Src, Dst>
+impl <T, Src, Dst> Default for Translation2D<T, Src, Dst>
     where T: Copy + Zero
 {
     fn default() -> Self {
@@ -283,7 +283,7 @@ impl <T, Src, Dst> Default for TypedTranslation2D<T, Src, Dst>
     }
 }
 
-impl<T, Src, Dst> fmt::Debug for TypedTranslation2D<T, Src, Dst>
+impl<T, Src, Dst> fmt::Debug for Translation2D<T, Src, Dst>
 where T: Copy + fmt::Debug {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.to_array().fmt(f)
@@ -294,10 +294,10 @@ where T: Copy + fmt::Debug {
 
 /// A 3d transformation from a space to another that can only express translations.
 ///
-/// The main benefit of this type over a TypedVector3D is the ability to cast
+/// The main benefit of this type over a Vector3D is the ability to cast
 /// between a source and a destination spaces.
 #[repr(C)]
-pub struct TypedTranslation3D<T, Src, Dst> {
+pub struct Translation3D<T, Src, Dst> {
     pub x: T,
     pub y: T,
     pub z: T,
@@ -305,11 +305,11 @@ pub struct TypedTranslation3D<T, Src, Dst> {
     pub _unit: PhantomData<(Src, Dst)>,
 }
 
-impl<T: Copy, Src, Dst> Copy for TypedTranslation3D<T, Src, Dst> {}
+impl<T: Copy, Src, Dst> Copy for Translation3D<T, Src, Dst> {}
 
-impl<T: Clone, Src, Dst> Clone for TypedTranslation3D<T, Src, Dst> {
+impl<T: Clone, Src, Dst> Clone for Translation3D<T, Src, Dst> {
     fn clone(&self) -> Self {
-        TypedTranslation3D {
+        Translation3D {
             x: self.x.clone(),
             y: self.y.clone(),
             z: self.z.clone(),
@@ -319,19 +319,19 @@ impl<T: Clone, Src, Dst> Clone for TypedTranslation3D<T, Src, Dst> {
 }
 
 #[cfg(feature = "serde")]
-impl<'de, T, Src, Dst> serde::Deserialize<'de> for TypedTranslation3D<T, Src, Dst>
+impl<'de, T, Src, Dst> serde::Deserialize<'de> for Translation3D<T, Src, Dst>
     where T: serde::Deserialize<'de>
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where D: serde::Deserializer<'de>
     {
         let (x, y, z) = try!(serde::Deserialize::deserialize(deserializer));
-        Ok(TypedTranslation3D { x, y, z, _unit: PhantomData })
+        Ok(Translation3D { x, y, z, _unit: PhantomData })
     }
 }
 
 #[cfg(feature = "serde")]
-impl<T, Src, Dst> serde::Serialize for TypedTranslation3D<T, Src, Dst>
+impl<T, Src, Dst> serde::Serialize for Translation3D<T, Src, Dst>
     where T: serde::Serialize
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -341,9 +341,9 @@ impl<T, Src, Dst> serde::Serialize for TypedTranslation3D<T, Src, Dst>
     }
 }
 
-impl<T, Src, Dst> Eq for TypedTranslation3D<T, Src, Dst> where T: Eq {}
+impl<T, Src, Dst> Eq for Translation3D<T, Src, Dst> where T: Eq {}
 
-impl<T, Src, Dst> PartialEq for TypedTranslation3D<T, Src, Dst>
+impl<T, Src, Dst> PartialEq for Translation3D<T, Src, Dst>
     where T: PartialEq
 {
     fn eq(&self, other: &Self) -> bool {
@@ -351,7 +351,7 @@ impl<T, Src, Dst> PartialEq for TypedTranslation3D<T, Src, Dst>
     }
 }
 
-impl<T, Src, Dst> Hash for TypedTranslation3D<T, Src, Dst>
+impl<T, Src, Dst> Hash for Translation3D<T, Src, Dst>
     where T: Hash
 {
     fn hash<H: ::core::hash::Hasher>(&self, h: &mut H) {
@@ -361,10 +361,10 @@ impl<T, Src, Dst> Hash for TypedTranslation3D<T, Src, Dst>
     }
 }
 
-impl<T, Src, Dst> TypedTranslation3D<T, Src, Dst> {
+impl<T, Src, Dst> Translation3D<T, Src, Dst> {
     #[inline]
     pub fn new(x: T, y: T, z: T) -> Self {
-        TypedTranslation3D {
+        Translation3D {
             x,
             y,
             z,
@@ -373,7 +373,7 @@ impl<T, Src, Dst> TypedTranslation3D<T, Src, Dst> {
     }
 }
 
-impl<T, Src, Dst> TypedTranslation3D<T, Src, Dst>
+impl<T, Src, Dst> Translation3D<T, Src, Dst>
 where
     T: Copy
 {
@@ -388,18 +388,18 @@ where
     }
 }
 
-impl<T, Src, Dst> TypedTranslation3D<T, Src, Dst>
+impl<T, Src, Dst> Translation3D<T, Src, Dst>
 where
     T: Copy + Zero
 {
     #[inline]
     pub fn identity() -> Self {
         let _0 = T::zero();
-        TypedTranslation3D::new(_0, _0, _0)
+        Translation3D::new(_0, _0, _0)
     }
 }
 
-impl<T, Src, Dst> TypedTranslation3D<T, Src, Dst>
+impl<T, Src, Dst> Translation3D<T, Src, Dst>
 where
     T: Zero + PartialEq
 {
@@ -409,26 +409,26 @@ where
     }
 }
 
-impl<T, Src, Dst> TypedTranslation3D<T, Src, Dst>
+impl<T, Src, Dst> Translation3D<T, Src, Dst>
 where
     T: Copy + Add<T, Output = T>
 {
     /// Translate a point and cast its unit.
     #[inline]
-    pub fn transform_point3d(&self, p: &TypedPoint3D<T, Src>) -> TypedPoint3D<T, Dst> {
+    pub fn transform_point3d(&self, p: &Point3D<T, Src>) -> Point3D<T, Dst> {
         point3(p.x + self.x, p.y + self.y, p.z + self.z)
     }
 
     /// Translate a point and cast its unit.
     #[inline]
-    pub fn transform_point2d(&self, p: &TypedPoint2D<T, Src>) -> TypedPoint2D<T, Dst> {
+    pub fn transform_point2d(&self, p: &Point2D<T, Src>) -> Point2D<T, Dst> {
         point2(p.x + self.x, p.y + self.y)
     }
 
     /// Translate a rectangle and cast its unit.
     #[inline]
-    pub fn transform_rect(&self, r: &TypedRect<T, Src>) -> TypedRect<T, Dst> {
-        TypedRect {
+    pub fn transform_rect(&self, r: &Rect<T, Src>) -> Rect<T, Dst> {
+        Rect {
             origin: self.transform_point2d(&r.origin),
             size: self.transform_size(&r.size),
         }
@@ -436,35 +436,35 @@ where
 
     /// No-op, just cast the unit.
     #[inline]
-    pub fn transform_size(&self, s: &TypedSize2D<T, Src>) -> TypedSize2D<T, Dst> {
-        TypedSize2D::new(s.width, s.height)
+    pub fn transform_size(&self, s: &Size2D<T, Src>) -> Size2D<T, Dst> {
+        Size2D::new(s.width, s.height)
     }
 
     /// Cast into a 3D vector.
-    pub fn to_vector(&self) -> TypedVector3D<T, Src> {
+    pub fn to_vector(&self) -> Vector3D<T, Src> {
         vec3(self.x, self.y, self.z)
     }
 }
 
-impl<T, Src, Dst> TypedTranslation3D<T, Src, Dst>
+impl<T, Src, Dst> Translation3D<T, Src, Dst>
 where
     T: Copy + Neg<Output = T>
 {
     /// Return the inverse transformation.
     #[inline]
-    pub fn inverse(&self) -> TypedTranslation3D<T, Dst, Src> {
-        TypedTranslation3D::new(-self.x, -self.y, -self.z)
+    pub fn inverse(&self) -> Translation3D<T, Dst, Src> {
+        Translation3D::new(-self.x, -self.y, -self.z)
     }
 }
 
-impl<T, Src, Dst1, Dst2> Add<TypedTranslation3D<T, Dst1, Dst2>>
-for TypedTranslation3D<T, Src, Dst1>
+impl<T, Src, Dst1, Dst2> Add<Translation3D<T, Dst1, Dst2>>
+for Translation3D<T, Src, Dst1>
 where
     T: Copy + Add<T, Output = T>
 {
-    type Output = TypedTranslation3D<T, Src, Dst2>;
-    fn add(self, other: TypedTranslation3D<T, Dst1, Dst2>) -> TypedTranslation3D<T, Src, Dst2> {
-        TypedTranslation3D::new(
+    type Output = Translation3D<T, Src, Dst2>;
+    fn add(self, other: Translation3D<T, Dst1, Dst2>) -> Translation3D<T, Src, Dst2> {
+        Translation3D::new(
             self.x + other.x,
             self.y + other.y,
             self.z + other.z,
@@ -473,14 +473,14 @@ where
 }
 
 impl<T, Src, Dst1, Dst2>
-    Sub<TypedTranslation3D<T, Dst1, Dst2>>
-    for TypedTranslation3D<T, Src, Dst2>
+    Sub<Translation3D<T, Dst1, Dst2>>
+    for Translation3D<T, Src, Dst2>
 where
     T: Copy + Sub<T, Output = T>
 {
-    type Output = TypedTranslation3D<T, Src, Dst1>;
-    fn sub(self, other: TypedTranslation3D<T, Dst1, Dst2>) -> TypedTranslation3D<T, Src, Dst1> {
-        TypedTranslation3D::new(
+    type Output = Translation3D<T, Src, Dst1>;
+    fn sub(self, other: Translation3D<T, Dst1, Dst2>) -> Translation3D<T, Src, Dst1> {
+        Translation3D::new(
             self.x - other.x,
             self.y - other.y,
             self.z - other.z,
@@ -488,7 +488,7 @@ where
     }
 }
 
-impl<T, Src, Dst> TypedTranslation3D<T, Src, Dst>
+impl<T, Src, Dst> Translation3D<T, Src, Dst>
 where
     T: Copy + Clone +
         Add<T, Output=T> +
@@ -502,30 +502,30 @@ where
 {
     /// Returns the matrix representation of this translation.
     #[inline]
-    pub fn to_transform(&self) -> TypedTransform3D<T, Src, Dst> {
-        TypedTransform3D::create_translation(self.x, self.y, self.z)
+    pub fn to_transform(&self) -> Transform3D<T, Src, Dst> {
+        Transform3D::create_translation(self.x, self.y, self.z)
     }
 }
 
-impl<T, Src, Dst> From<TypedVector3D<T, Src>> for TypedTranslation3D<T, Src, Dst>
+impl<T, Src, Dst> From<Vector3D<T, Src>> for Translation3D<T, Src, Dst>
 where
     T: Copy
 {
-    fn from(v: TypedVector3D<T, Src>) -> Self {
-        TypedTranslation3D::new(v.x, v.y, v.z)
+    fn from(v: Vector3D<T, Src>) -> Self {
+        Translation3D::new(v.x, v.y, v.z)
     }
 }
 
-impl<T, Src, Dst> Into<TypedVector3D<T, Src>> for TypedTranslation3D<T, Src, Dst>
+impl<T, Src, Dst> Into<Vector3D<T, Src>> for Translation3D<T, Src, Dst>
 where
     T: Copy
 {
-    fn into(self) -> TypedVector3D<T, Src> {
+    fn into(self) -> Vector3D<T, Src> {
         vec3(self.x, self.y, self.z)
     }
 }
 
-impl<T, Src, Dst> Into<TypedTransform3D<T, Src, Dst>> for TypedTranslation3D<T, Src, Dst>
+impl<T, Src, Dst> Into<Transform3D<T, Src, Dst>> for Translation3D<T, Src, Dst>
 where
     T: Copy + Clone +
         Add<T, Output=T> +
@@ -537,12 +537,12 @@ where
         Trig +
         One + Zero,
 {
-    fn into(self) -> TypedTransform3D<T, Src, Dst> {
+    fn into(self) -> Transform3D<T, Src, Dst> {
         self.to_transform()
     }
 }
 
-impl <T, Src, Dst> Default for TypedTranslation3D<T, Src, Dst>
+impl <T, Src, Dst> Default for Translation3D<T, Src, Dst>
     where T: Copy + Zero
 {
     fn default() -> Self {
@@ -550,7 +550,7 @@ impl <T, Src, Dst> Default for TypedTranslation3D<T, Src, Dst>
     }
 }
 
-impl<T, Src, Dst> fmt::Debug for TypedTranslation3D<T, Src, Dst>
+impl<T, Src, Dst> fmt::Debug for Translation3D<T, Src, Dst>
 where T: Copy + fmt::Debug {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.to_array().fmt(f)
@@ -564,9 +564,9 @@ fn simple_translation2d() {
     struct A;
     struct B;
 
-    type Translation = TypedTranslation2D<i32, A, B>;
-    type SrcRect = TypedRect<i32, A>;
-    type DstRect = TypedRect<i32, B>;
+    type Translation = Translation2D<i32, A, B>;
+    type SrcRect = Rect<i32, A>;
+    type DstRect = Rect<i32, B>;
 
     let tx = Translation::new(10, -10);
     let r1: SrcRect = rect(10, 20, 30, 40);
@@ -584,9 +584,9 @@ fn simple_translation3d() {
     struct A;
     struct B;
 
-    type Translation = TypedTranslation3D<i32, A, B>;
-    type SrcPoint = TypedPoint3D<i32, A>;
-    type DstPoint = TypedPoint3D<i32, B>;
+    type Translation = Translation3D<i32, A, B>;
+    type SrcPoint = Point3D<i32, A>;
+    type DstPoint = Point3D<i32, B>;
 
     let tx = Translation::new(10, -10, 100);
     let p1: SrcPoint = point3(10, 20, 30);


### PR DESCRIPTION
Number two in a [long list](https://github.com/nical/euclid/commits/breaking-changes) of breaking changes.

This removes the "Typed" prefix on most types (for example TypedRect) which is now unnecessary since the default version of these types using `UnknownUnit` are now in the `euclid::default` namespace.

For users of euclid, accustomed to manipulating the default types, this means that they don't need to look up the doc for `TypedRect` when they think about `Rect`. This doesn't seem like much but since nobody uses `TypedFoo` types directly other than to create aliases in a single place, the names in the documentation never match the names users actually manipulate and the `Typed` prefix is easily forgotten.

As a result the names are a bit prettier and the docs more intuitive.

r? anyone

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/351)
<!-- Reviewable:end -->
