### PR TITLE
Remove a few methods

### DIFF
--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -8,7 +8,6 @@
 // except according to those terms.
 
 use super::UnknownUnit;
-use length::Length;
 use scale::Scale;
 use num::*;
 use point::Point3D;
@@ -222,12 +221,6 @@ where
             Point3D::new(self.min.x - width, self.min.y - height, self.min.z - depth),
             Point3D::new(self.max.x + width, self.max.y + height, self.max.z + depth),
         )
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn inflate_typed(&self, width: Length<T, U>, height: Length<T, U>, depth: Length<T, U>) -> Self {
-        self.inflate(width.get(), height.get(), depth.get())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,22 +38,6 @@
 //! All euclid types are marked `#[repr(C)]` in order to facilitate exposing them to
 //! foreign function interfaces (provided the underlying scalar type is also `repr(C)`).
 //!
-//! Components are accessed in their scalar form by default for convenience, and most
-//! types additionally implement strongly typed accessors which return typed ```Length``` wrappers.
-//! For example:
-//!
-//! ```rust
-//! # use euclid::*;
-//! # pub struct WorldSpace;
-//! # pub type WorldPoint = Point3D<f32, WorldSpace>;
-//! let p = WorldPoint::new(0.0, 1.0, 1.0);
-//! // p.x is an f32.
-//! println!("p.x = {:?} ", p.x);
-//! // p.x is a Length<f32, WorldSpace>.
-//! println!("p.x_typed() = {:?} ", p.x_typed());
-//! // Length::get returns the scalar value (f32).
-//! assert_eq!(p.x, p.x_typed().get());
-//! ```
 
 #[cfg(feature = "serde")]
 #[macro_use]

--- a/src/point.rs
+++ b/src/point.rs
@@ -170,18 +170,6 @@ impl<T: Copy, U> Point2D<T, U> {
         point2(self.y, self.x)
     }
 
-    /// Returns self.x as a Length carrying the unit.
-    #[inline]
-    pub fn x_typed(&self) -> Length<T, U> {
-        Length::new(self.x)
-    }
-
-    /// Returns self.y as a Length carrying the unit.
-    #[inline]
-    pub fn y_typed(&self) -> Length<T, U> {
-        Length::new(self.y)
-    }
-
     /// Drop the units, preserving only the numeric value.
     #[inline]
     pub fn to_untyped(&self) -> Point2D<T, UnknownUnit> {
@@ -666,24 +654,6 @@ impl<T: Copy, U> Point3D<T, U> {
     #[inline]
     pub fn yz(&self) -> Point2D<T, U> {
         point2(self.y, self.z)
-    }
-
-    /// Returns self.x as a Length carrying the unit.
-    #[inline]
-    pub fn x_typed(&self) -> Length<T, U> {
-        Length::new(self.x)
-    }
-
-    /// Returns self.y as a Length carrying the unit.
-    #[inline]
-    pub fn y_typed(&self) -> Length<T, U> {
-        Length::new(self.y)
-    }
-
-    /// Returns self.z as a Length carrying the unit.
-    #[inline]
-    pub fn z_typed(&self) -> Length<T, U> {
-        Length::new(self.z)
     }
 
     #[inline]

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -8,7 +8,6 @@
 // except according to those terms.
 
 use super::UnknownUnit;
-use length::Length;
 use scale::Scale;
 use num::*;
 use box2d::Box2D;
@@ -154,26 +153,6 @@ where
     }
 
     #[inline]
-    pub fn max_x_typed(&self) -> Length<T, U> {
-        Length::new(self.max_x())
-    }
-
-    #[inline]
-    pub fn min_x_typed(&self) -> Length<T, U> {
-        Length::new(self.min_x())
-    }
-
-    #[inline]
-    pub fn max_y_typed(&self) -> Length<T, U> {
-        Length::new(self.max_y())
-    }
-
-    #[inline]
-    pub fn min_y_typed(&self) -> Length<T, U> {
-        Length::new(self.min_y())
-    }
-
-    #[inline]
     pub fn x_range(&self) -> Range<T> {
         self.min_x()..self.max_x()
     }
@@ -238,12 +217,6 @@ where
                 self.size.height + height + height,
             ),
         )
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn inflate_typed(&self, width: Length<T, U>, height: Length<T, U>) -> Self {
-        self.inflate(width.get(), height.get())
     }
 
     #[inline]

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -269,12 +269,6 @@ where
         }
     }
 
-    #[inline]
-    #[must_use]
-    pub fn translate_by_size(&self, size: &Size2D<T, U>) -> Self {
-        self.translate(&size.to_vector())
-    }
-
     /// Calculate the size and position of an inner rectangle.
     ///
     /// Subtracts the side offsets from all sides. The horizontal and vertical
@@ -630,25 +624,6 @@ mod tests {
 
         let r = Rect::new(Point2D::new(-10, -5), Size2D::new(50, 40));
         let rr = r.translate(&vec2(0, -10));
-
-        assert!(rr.size.width == 50);
-        assert!(rr.size.height == 40);
-        assert!(rr.origin.x == -10);
-        assert!(rr.origin.y == -15);
-    }
-
-    #[test]
-    fn test_translate_by_size() {
-        let p = Rect::new(Point2D::new(0u32, 0u32), Size2D::new(50u32, 40u32));
-        let pp = p.translate_by_size(&Size2D::new(10, 15));
-
-        assert!(pp.size.width == 50);
-        assert!(pp.size.height == 40);
-        assert!(pp.origin.x == 10);
-        assert!(pp.origin.y == 15);
-
-        let r = Rect::new(Point2D::new(-10, -5), Size2D::new(50, 40));
-        let rr = r.translate_by_size(&Size2D::new(0, -10));
 
         assert!(rr.size.width == 50);
         assert!(rr.size.height == 40);

--- a/src/rigid.rs
+++ b/src/rigid.rs
@@ -101,7 +101,7 @@ impl<T: Float + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
     ///
     /// i.e., this produces `self * other` in row-vector notation
     #[inline]
-    pub fn post_mul<Dst2>(
+    pub fn post_transform<Dst2>(
         &self,
         other: &RigidTransform3D<T, Dst, Dst2>,
     ) -> RigidTransform3D<T, Src, Dst2> {
@@ -133,11 +133,11 @@ impl<T: Float + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
     ///
     /// i.e., this produces `other * self` in row-vector notation
     #[inline]
-    pub fn pre_mul<Src2>(
+    pub fn pre_transform<Src2>(
         &self,
         other: &RigidTransform3D<T, Src2, Src>,
     ) -> RigidTransform3D<T, Src2, Dst> {
-        other.post_mul(&self)
+        other.post_transform(&self)
     }
 
     /// Inverts the transformation
@@ -167,7 +167,7 @@ impl<T: Float + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
     {
         self.translation
             .to_transform()
-            .pre_mul(&self.rotation.to_transform())
+            .pre_transform(&self.rotation.to_transform())
     }
 }
 
@@ -200,13 +200,13 @@ mod test {
         let rigid = RigidTransform3D::new(rotation, translation);
         assert!(rigid
             .to_transform()
-            .approx_eq(&translation.to_transform().pre_mul(&rotation.to_transform())));
+            .approx_eq(&translation.to_transform().pre_transform(&rotation.to_transform())));
 
         let rigid = RigidTransform3D::new_from_reversed(translation, rotation);
         assert!(rigid.to_transform().approx_eq(
             &translation
                 .to_transform()
-                .post_mul(&rotation.to_transform())
+                .post_transform(&rotation.to_transform())
         ));
     }
 
@@ -219,7 +219,7 @@ mod test {
         let (t2, r2) = rigid.decompose_reversed();
         assert!(rigid
             .to_transform()
-            .approx_eq(&t2.to_transform().post_mul(&r2.to_transform())));
+            .approx_eq(&t2.to_transform().post_transform(&r2.to_transform())));
     }
 
     #[test]
@@ -230,7 +230,7 @@ mod test {
         let rigid = RigidTransform3D::new(rotation, translation);
         let inverse = rigid.inverse();
         assert!(rigid
-            .post_mul(&inverse)
+            .post_transform(&inverse)
             .to_transform()
             .approx_eq(&Transform3D::identity()));
         assert!(inverse
@@ -248,12 +248,12 @@ mod test {
         let rigid2 = RigidTransform3D::new(rotation2, translation2);
 
         assert!(rigid
-            .post_mul(&rigid2)
+            .post_transform(&rigid2)
             .to_transform()
-            .approx_eq(&rigid.to_transform().post_mul(&rigid2.to_transform())));
+            .approx_eq(&rigid.to_transform().post_transform(&rigid2.to_transform())));
         assert!(rigid
-            .pre_mul(&rigid2)
+            .pre_transform(&rigid2)
             .to_transform()
-            .approx_eq(&rigid.to_transform().pre_mul(&rigid2.to_transform())));
+            .approx_eq(&rigid.to_transform().pre_transform(&rigid2.to_transform())));
     }
 }

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -939,12 +939,12 @@ fn pre_post() {
     // Check that the order of transformations is correct (corresponds to what
     // we do in Transform3D).
     let p1 = r1.post_rotate(&r2).post_rotate(&r3).rotate_point3d(&p);
-    let p2 = t1.post_mul(&t2).post_mul(&t3).transform_point3d(&p);
+    let p2 = t1.post_transform(&t2).post_transform(&t3).transform_point3d(&p);
 
     assert!(p1.approx_eq(&p2.unwrap()));
 
     // Check that changing the order indeed matters.
-    let p3 = t3.post_mul(&t1).post_mul(&t2).transform_point3d(&p);
+    let p3 = t3.post_transform(&t1).post_transform(&t2).transform_point3d(&p);
     assert!(!p1.approx_eq(&p3.unwrap()));
 }
 

--- a/src/side_offsets.rs
+++ b/src/side_offsets.rs
@@ -137,26 +137,6 @@ impl<T: Copy, U> SideOffsets2D<T, U> {
         SideOffsets2D::new(top.0, right.0, bottom.0, left.0)
     }
 
-    /// Access self.top as a typed Length instead of a scalar value.
-    pub fn top_typed(&self) -> Length<T, U> {
-        Length::new(self.top)
-    }
-
-    /// Access self.right as a typed Length instead of a scalar value.
-    pub fn right_typed(&self) -> Length<T, U> {
-        Length::new(self.right)
-    }
-
-    /// Access self.bottom as a typed Length instead of a scalar value.
-    pub fn bottom_typed(&self) -> Length<T, U> {
-        Length::new(self.bottom)
-    }
-
-    /// Access self.left as a typed Length instead of a scalar value.
-    pub fn left_typed(&self) -> Length<T, U> {
-        Length::new(self.left)
-    }
-
     /// Constructor setting the same value to all sides, taking a scalar value directly.
     pub fn new_all_same(all: T) -> Self {
         SideOffsets2D::new(all, all, all, all)
@@ -178,14 +158,6 @@ where
 
     pub fn vertical(&self) -> T {
         self.top + self.bottom
-    }
-
-    pub fn horizontal_typed(&self) -> Length<T, U> {
-        Length::new(self.horizontal())
-    }
-
-    pub fn vertical_typed(&self) -> Length<T, U> {
-        Length::new(self.vertical())
     }
 }
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -242,17 +242,6 @@ impl<T: Copy + Div<T, Output = T>, U1, U2> Div<Scale<T, U1, U2>> for Size2D<T, U
 impl<T: Copy, U> Size2D<T, U> {
     /// Returns self.width as a Length carrying the unit.
     #[inline]
-    pub fn width_typed(&self) -> Length<T, U> {
-        Length::new(self.width)
-    }
-
-    /// Returns self.height as a Length carrying the unit.
-    #[inline]
-    pub fn height_typed(&self) -> Length<T, U> {
-        Length::new(self.height)
-    }
-
-    #[inline]
     pub fn to_array(&self) -> [T; 2] {
         [self.width, self.height]
     }
@@ -750,23 +739,6 @@ impl<T: Copy + Div<T, Output = T>, U1, U2> Div<Scale<T, U1, U2>> for Size3D<T, U
 
 impl<T: Copy, U> Size3D<T, U> {
     /// Returns self.width as a Length carrying the unit.
-    #[inline]
-    pub fn width_typed(&self) -> Length<T, U> {
-        Length::new(self.width)
-    }
-
-    /// Returns self.height as a Length carrying the unit.
-    #[inline]
-    pub fn height_typed(&self) -> Length<T, U> {
-        Length::new(self.height)
-    }
-
-    /// Returns self.depth as a Length carrying the unit.
-    #[inline]
-    pub fn depth_typed(&self) -> Length<T, U> {
-        Length::new(self.depth)
-    }
-
     #[inline]
     pub fn to_array(&self) -> [T; 3] {
         [self.width, self.height, self.depth]

--- a/src/size.rs
+++ b/src/size.rs
@@ -433,6 +433,16 @@ impl<T, U> Into<mint::Vector2<T>> for Size2D<T, U> {
     }
 }
 
+impl<T, U> From<Vector2D<T, U>> for Size2D<T, U> {
+    fn from(v: Vector2D<T, U>) -> Self {
+        Size2D {
+            width: v.x,
+            height: v.y,
+            _unit: PhantomData,
+        }
+    }
+}
+
 impl<T: Copy, U> Into<[T; 2]> for Size2D<T, U> {
     fn into(self) -> [T; 2] {
         self.to_array()

--- a/src/transform2d.rs
+++ b/src/transform2d.rs
@@ -330,26 +330,6 @@ where T: Copy + Clone +
         mat.post_transform(self)
     }
 
-    /// Returns the multiplication of the two matrices such that mat's transformation
-    /// applies after self's transformation.
-    ///
-    /// Assuming row vectors, this is equivalent to self * mat
-    #[deprecated]
-    #[must_use]
-    pub fn post_mul<NewDst>(&self, mat: &Transform2D<T, Dst, NewDst>) -> Transform2D<T, Src, NewDst> {
-        self.post_transform(mat)
-    }
-
-    /// Returns the multiplication of the two matrices such that mat's transformation
-    /// applies before self's transformation.
-    ///
-    /// Assuming row vectors, this is equivalent to mat * self
-    #[deprecated]
-    #[must_use]
-    pub fn pre_mul<NewSrc>(&self, mat: &Transform2D<T, NewSrc, Src>) -> Transform2D<T, NewSrc, Dst> {
-        self.pre_transform(mat)
-    }
-
     /// Returns a translation transform.
     #[inline]
     pub fn create_translation(x: T, y: T) -> Self {

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -415,24 +415,6 @@ where T: Copy + Clone +
         mat.post_transform(self)
     }
 
-    /// Returns the multiplication of the two matrices such that mat's transformation
-    /// applies after self's transformation.
-    ///
-    /// Assuming row vectors, this is equivalent to self * mat
-    #[must_use]
-    pub fn post_mul<NewDst>(&self, mat: &Transform3D<T, Dst, NewDst>) -> Transform3D<T, Src, NewDst> {
-        self.post_transform(mat)
-    }
-
-    /// Returns the multiplication of the two matrices such that mat's transformation
-    /// applies before self's transformation.
-    ///
-    /// Assuming row vectors, this is equivalent to mat * self
-    #[must_use]
-    pub fn pre_mul<NewSrc>(&self, mat: &Transform3D<T, NewSrc, Src>) -> Transform3D<T, NewSrc, Dst> {
-        self.pre_transform(mat)
-    }
-
     /// Returns the inverse transform if possible.
     pub fn inverse(&self) -> Option<Transform3D<T, Dst, Src>> {
         let det = self.determinant();

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -175,18 +175,6 @@ impl<T: Copy, U> Vector2D<T, U> {
         size2(self.x, self.y)
     }
 
-    /// Returns self.x as a Length carrying the unit.
-    #[inline]
-    pub fn x_typed(&self) -> Length<T, U> {
-        Length::new(self.x)
-    }
-
-    /// Returns self.y as a Length carrying the unit.
-    #[inline]
-    pub fn y_typed(&self) -> Length<T, U> {
-        Length::new(self.y)
-    }
-
     /// Drop the units, preserving only the numeric value.
     #[inline]
     pub fn to_untyped(&self) -> Vector2D<T, UnknownUnit> {
@@ -724,24 +712,6 @@ impl<T: Copy, U> Vector3D<T, U> {
     #[inline]
     pub fn yz(&self) -> Vector2D<T, U> {
         vec2(self.y, self.z)
-    }
-
-    /// Returns self.x as a Length carrying the unit.
-    #[inline]
-    pub fn x_typed(&self) -> Length<T, U> {
-        Length::new(self.x)
-    }
-
-    /// Returns self.y as a Length carrying the unit.
-    #[inline]
-    pub fn y_typed(&self) -> Length<T, U> {
-        Length::new(self.y)
-    }
-
-    /// Returns self.z as a Length carrying the unit.
-    #[inline]
-    pub fn z_typed(&self) -> Length<T, U> {
-        Length::new(self.z)
     }
 
     #[inline]

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -555,6 +555,12 @@ impl<T: Copy, U> From<(T, T)> for Vector2D<T, U> {
     }
 }
 
+impl<T: Copy, U> From<Size2D<T, U>> for Vector2D<T, U> {
+    fn from(size: Size2D<T, U>) -> Self {
+        size.to_vector()
+    }
+}
+
 impl<T, U> Vector2D<T, U>
 where
     T: Signed,


### PR DESCRIPTION
Number three in a [long list](https://github.com/nical/euclid/commits/breaking-changes) of breaking changes.

 - Remove deprecated transform pre_mul/post_mul methods. We already have pre_transform/post_transform which are less ambiguous. It is possible that we will reintroduce pre_mul/post_mul later but if so their name will follow the matrix multiplication convention rather than the semantic of the transformation so they may or may not become the opposite of what they are now depending on the chosen matrix convention. So it's best to remove them for at least a release and add them back when the dependent crates have moved to pre_transform/post_transform to avoid bugs.
 - Remove `*_typed` methods. They are too much of a mouthful and nobody uses them as far as I know. It'd be nice to come up with a nicer naming scheme to reintroduce methods returning `Length<T, U>` in addition to the ones that return `T`, we can do that without causing breaking changes whenever we settle for something.
 - Remove `Rect::translate_by_size` and make it easier to convert sizes into vectors instead to achieve the same thing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/352)
<!-- Reviewable:end -->
