### PR TITLE
Put some symbols behind the y_down feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT / Apache-2.0"
 
 [features]
 unstable = []
+y_down = []
 
 [dependencies]
 num-traits = { version = "0.2" }

--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -581,6 +581,32 @@ impl<T: NumCast + Copy, Unit> Box2D<T, Unit> {
     }
 }
 
+#[cfg(feature = "y_down")]
+impl<T:, U> Box2D<T, U>
+where
+    T: Copy
+{
+    #[inline]
+    pub fn top_left(&self) -> Point2D<T, U> {
+        self.min
+    }
+
+    #[inline]
+    pub fn top_right(&self) -> Point2D<T, U> {
+        Point2D::new(self.max.x, self.min.y)
+    }
+
+    #[inline]
+    pub fn bottom_left(&self) -> Point2D<T, U> {
+        Point2D::new(self.min.x, self.max.y)
+    }
+
+    #[inline]
+    pub fn bottom_right(&self) -> Point2D<T, U> {
+        self.max
+    }
+}
+
 impl<T, U> From<Size2D<T, U>> for Box2D<T, U>
 where
     T: Copy + Zero + PartialOrd,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,9 +82,10 @@ pub use rigid::{RigidTransform3D};
 pub use box3d::{box3d, Box3D};
 pub use translation::{Translation2D, Translation3D};
 pub use rotation::{Angle, Rotation2D, Rotation3D};
-pub use side_offsets::SideOffsets2D;
 pub use size::{Size2D, Size3D, size2, size3};
 pub use trig::Trig;
+#[cfg(feature = "y_down")]
+pub use side_offsets::SideOffsets2D;
 
 #[macro_use]
 mod macros;
@@ -125,7 +126,6 @@ pub mod default {
     pub type Rect<T> = super::Rect<T, UnknownUnit>;
     pub type Box2D<T> = super::Box2D<T, UnknownUnit>;
     pub type Box3D<T> = super::Box3D<T, UnknownUnit>;
-    pub type SideOffsets2D<T> = super::SideOffsets2D<T, UnknownUnit>;
     pub type Transform2D<T> = super::Transform2D<T, UnknownUnit, UnknownUnit>;
     pub type Transform3D<T> = super::Transform3D<T, UnknownUnit, UnknownUnit>;
     pub type Rotation2D<T> = super::Rotation2D<T, UnknownUnit, UnknownUnit>;
@@ -133,4 +133,6 @@ pub mod default {
     pub type Translation3D<T> = super::Translation3D<T, UnknownUnit, UnknownUnit>;
     pub type Scale<T> = super::Scale<T, UnknownUnit, UnknownUnit>;
     pub type RigidTransform3D<T> = super::RigidTransform3D<T, UnknownUnit, UnknownUnit>;
+    #[cfg(feature = "y_down")]
+    pub type SideOffsets2D<T> = super::SideOffsets2D<T, UnknownUnit>;
 }

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -14,9 +14,10 @@ use num::*;
 use box2d::Box2D;
 use point::Point2D;
 use vector::Vector2D;
-use side_offsets::SideOffsets2D;
 use size::Size2D;
 use approxord::{min, max};
+#[cfg(feature = "y_down")]
+use side_offsets::SideOffsets2D;
 
 use num_traits::NumCast;
 #[cfg(feature = "serde")]
@@ -247,25 +248,10 @@ where
     }
 
     #[inline]
-    pub fn top_right(&self) -> Point2D<T, U> {
-        Point2D::new(self.max_x(), self.origin.y)
-    }
-
-    #[inline]
-    pub fn bottom_left(&self) -> Point2D<T, U> {
-        Point2D::new(self.origin.x, self.max_y())
-    }
-
-    #[inline]
-    pub fn bottom_right(&self) -> Point2D<T, U> {
-        Point2D::new(self.max_x(), self.max_y())
-    }
-
-    #[inline]
     pub fn to_box2d(&self) -> Box2D<T, U> {
         Box2D {
             min: self.origin,
-            max: self.bottom_right(),
+            max: self.origin + self.size,
         }
     }
 
@@ -279,6 +265,7 @@ where
     ///
     /// Subtracts the side offsets from all sides. The horizontal and vertical
     /// offsets must not be larger than the original side length.
+    #[cfg(feature = "y_down")]
     pub fn inner_rect(&self, offsets: SideOffsets2D<T, U>) -> Self {
         let rect = Rect::new(
             Point2D::new(
@@ -298,6 +285,7 @@ where
     /// Calculate the size and position of an outer rectangle.
     ///
     /// Add the offsets to all sides. The expanded rectangle is returned.
+    #[cfg(feature = "y_down")]
     pub fn outer_rect(&self, offsets: SideOffsets2D<T, U>) -> Self {
         Rect::new(
             Point2D::new(
@@ -352,6 +340,32 @@ where
             Point2D::new(min_x, min_y),
             Size2D::new(max_x - min_x, max_y - min_y),
         )
+    }
+}
+
+#[cfg(feature = "y_down")]
+impl<T:, U> Rect<T, U>
+where
+    T: Copy + Clone + Zero + PartialOrd + PartialEq + Add<T, Output = T> + Sub<T, Output = T>
+{
+    #[inline]
+    pub fn top_left(&self) -> Point2D<T, U> {
+        self.origin
+    }
+
+    #[inline]
+    pub fn top_right(&self) -> Point2D<T, U> {
+        Point2D::new(self.max_x(), self.origin.y)
+    }
+
+    #[inline]
+    pub fn bottom_left(&self) -> Point2D<T, U> {
+        Point2D::new(self.origin.x, self.max_y())
+    }
+
+    #[inline]
+    pub fn bottom_right(&self) -> Point2D<T, U> {
+        Point2D::new(self.max_x(), self.max_y())
     }
 }
 
@@ -616,6 +630,7 @@ pub fn rect<T: Copy, U>(x: T, y: T, w: T, h: T) -> Rect<T, U> {
 mod tests {
     use default::{Point2D, Rect, Size2D};
     use {point2, vec2, rect};
+    #[cfg(feature = "y_down")]
     use side_offsets::SideOffsets2D;
 
     #[test]
@@ -780,6 +795,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "y_down")]
     fn test_inner_outer_rect() {
         let inner_rect: Rect<i32> = Rect::new(Point2D::new(20, 40), Size2D::new(80, 100));
         let offsets = SideOffsets2D::new(20, 10, 10, 10);

--- a/src/transform2d.rs
+++ b/src/transform2d.rs
@@ -13,7 +13,7 @@ use super::{UnknownUnit, Angle};
 #[cfg(feature = "mint")]
 use mint;
 use num::{One, Zero};
-use point::Point2D;
+use point::{Point2D, point2};
 use vector::{Vector2D, vec2};
 use rect::Rect;
 use transform3d::Transform3D;
@@ -457,11 +457,13 @@ where T: Copy + Clone +
     #[inline]
     #[must_use]
     pub fn transform_rect(&self, rect: &Rect<T, Src>) -> Rect<T, Dst> {
+        let min = rect.origin;
+        let max = rect.origin + rect.size;
         Rect::from_points(&[
-            self.transform_point(&rect.origin),
-            self.transform_point(&rect.top_right()),
-            self.transform_point(&rect.bottom_left()),
-            self.transform_point(&rect.bottom_right()),
+            self.transform_point(&min),
+            self.transform_point(&point2(max.x, min.y)),
+            self.transform_point(&point2(min.x, max.y)),
+            self.transform_point(&max),
         ])
     }
 

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -15,7 +15,7 @@ use homogen::HomogeneousVector;
 #[cfg(feature = "mint")]
 use mint;
 use trig::Trig;
-use point::{Point2D, Point3D};
+use point::{Point2D, Point3D, point2};
 use vector::{Vector2D, Vector3D, vec2, vec3};
 use rect::Rect;
 use transform2d::Transform2D;
@@ -652,11 +652,13 @@ where T: Copy + Clone +
     /// Returns a rectangle that encompasses the result of transforming the given rectangle by this
     /// transform, if the transform makes sense for it, or `None` otherwise.
     pub fn transform_rect(&self, rect: &Rect<T, Src>) -> Option<Rect<T, Dst>> {
+        let min = rect.origin;
+        let max = rect.origin + rect.size;
         Some(Rect::from_points(&[
-            self.transform_point2d(&rect.origin)?,
-            self.transform_point2d(&rect.top_right())?,
-            self.transform_point2d(&rect.bottom_left())?,
-            self.transform_point2d(&rect.bottom_right())?,
+            self.transform_point2d(&min)?,
+            self.transform_point2d(&point2(max.x, min.y))?,
+            self.transform_point2d(&point2(min.x, max.y))?,
+            self.transform_point2d(&max)?,
         ]))
     }
 


### PR DESCRIPTION
Some non-gecko/servo people have complained to me about euclid dictating that y points downward through a few names like `Rect::top`, the side offsets code (etc.), because their app/game/crate uses the y-up convention or is agnostic to these.

At the same time having names like `top()` is very convenient in our own code, so a simple compromise is to opt into it explicitly using a feature flag which we'll use in the servo and gecko ecosystems but others can just ignore.
We can also add an `y_up` feature flag that adds these symbols for the other convention, but i'd rather add it when someone asks for it otherwise it'll just be dead code. The main advantage is that asking for both `y_up` and `y_down` would generate errors at compile time which seems desirable.

There's a discussion about this in #317 in which we talk about finer granularity (for example per unit or per file). It would have been really nice to have it per unit but it's hard to do it in rust without making things complicated (specialization would have helped a lot).

So I think that the feature flag approach is both simple and good enough to address the original complaints and our needs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/353)
<!-- Reviewable:end -->
