### PR TITLE
Automatically derive serde traits for more types

### DIFF
--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -191,6 +191,8 @@ impl<T: Neg<Output = T>> Neg for Angle<T> {
 
 /// A transform that can represent rotations in 2d, represented as an angle in radians.
 #[repr(C)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound(serialize = "T: serde::Serialize", deserialize = "T: serde::Deserialize<'de>")))]
 pub struct Rotation2D<T, Src, Dst> {
     pub angle : T,
     #[doc(hidden)]
@@ -205,29 +207,6 @@ impl<T: Clone, Src, Dst> Clone for Rotation2D<T, Src, Dst> {
             angle: self.angle.clone(),
             _unit: PhantomData,
         }
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de, T, Src, Dst> serde::Deserialize<'de> for Rotation2D<T, Src, Dst>
-    where T: serde::Deserialize<'de>
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: serde::Deserializer<'de>
-    {
-        let (angle,) = try!(serde::Deserialize::deserialize(deserializer));
-        Ok(Rotation2D { angle, _unit: PhantomData })
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<T, Src, Dst> serde::Serialize for Rotation2D<T, Src, Dst>
-    where T: serde::Serialize
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: serde::Serializer
-    {
-        (&self.angle,).serialize(serializer)
     }
 }
 
@@ -375,6 +354,8 @@ where
 /// as follows: `x -> i`, `y -> j`, `z -> k`, `w -> r`.
 /// The memory layout of this type corresponds to the `x, y, z, w` notation
 #[repr(C)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound(serialize = "T: serde::Serialize", deserialize = "T: serde::Deserialize<'de>")))]
 pub struct Rotation3D<T, Src, Dst> {
     /// Component multiplied by the imaginary number `i`.
     pub i: T,
@@ -399,29 +380,6 @@ impl<T: Clone, Src, Dst> Clone for Rotation3D<T, Src, Dst> {
             r: self.r.clone(),
             _unit: PhantomData,
         }
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de, T, Src, Dst> serde::Deserialize<'de> for Rotation3D<T, Src, Dst>
-    where T: serde::Deserialize<'de>
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: serde::Deserializer<'de>
-    {
-        let (i, j, k, r) = try!(serde::Deserialize::deserialize(deserializer));
-        Ok(Rotation3D { i, j, k, r, _unit: PhantomData })
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<T, Src, Dst> serde::Serialize for Rotation3D<T, Src, Dst>
-    where T: serde::Serialize
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: serde::Serializer
-    {
-        (&self.i, &self.j, &self.k, &self.r).serialize(serializer)
     }
 }
 

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -12,7 +12,7 @@ use num::One;
 
 use num_traits::NumCast;
 #[cfg(feature = "serde")]
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde;
 use core::fmt;
 use core::ops::{Add, Div, Mul, Neg, Sub};
 use core::marker::PhantomData;
@@ -38,36 +38,9 @@ use {Point2D, Rect, Size2D, Vector2D};
 /// let one_foot_in_mm: Length<f32, Mm> = one_foot * mm_per_inch;
 /// ```
 #[repr(C)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound(serialize = "T: serde::Serialize", deserialize = "T: serde::Deserialize<'de>")))]
 pub struct Scale<T, Src, Dst>(pub T, #[doc(hidden)] pub PhantomData<(Src, Dst)>);
-
-#[cfg(feature = "serde")]
-impl<'de, T, Src, Dst> Deserialize<'de> for Scale<T, Src, Dst>
-where
-    T: Deserialize<'de>,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Scale<T, Src, Dst>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Ok(Scale(
-            try!(Deserialize::deserialize(deserializer)),
-            PhantomData,
-        ))
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<T, Src, Dst> Serialize for Scale<T, Src, Dst>
-where
-    T: Serialize,
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.0.serialize(serializer)
-    }
-}
 
 impl<T, Src, Dst> Scale<T, Src, Dst> {
     pub fn new(x: T) -> Self {

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -40,6 +40,8 @@ use serde;
 /// ```
 ///
 #[repr(C)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(bound(serialize = "T: serde::Serialize", deserialize = "T: serde::Deserialize<'de>")))]
 pub struct Translation2D<T, Src, Dst> {
     pub x: T,
     pub y: T,
@@ -56,29 +58,6 @@ impl<T: Clone, Src, Dst> Clone for Translation2D<T, Src, Dst> {
             y: self.y.clone(),
             _unit: PhantomData,
         }
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<'de, T, Src, Dst> serde::Deserialize<'de> for Translation2D<T, Src, Dst>
-    where T: serde::Deserialize<'de>
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: serde::Deserializer<'de>
-    {
-        let (x, y) = try!(serde::Deserialize::deserialize(deserializer));
-        Ok(Translation2D { x, y, _unit: PhantomData })
-    }
-}
-
-#[cfg(feature = "serde")]
-impl<T, Src, Dst> serde::Serialize for Translation2D<T, Src, Dst>
-    where T: serde::Serialize
-{
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: serde::Serializer
-    {
-        (&self.x, &self.y).serialize(serializer)
     }
 }
 


### PR DESCRIPTION
Similar to #327, adding rotations, translations and scales to the list of types deriving their serde implementations automatically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/355)
<!-- Reviewable:end -->
