### PR TITLE
Some Rect changes

### DIFF
--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -15,6 +15,7 @@ use point::{point2, Point2D};
 use vector::{vec2, Vector2D};
 use side_offsets::SideOffsets2D;
 use size::Size2D;
+use nonempty::NonEmpty;
 use approxord::{min, max};
 
 use num_traits::NumCast;
@@ -114,6 +115,15 @@ where
         self.max.x <= self.min.x || self.max.y <= self.min.y
     }
 
+    #[inline]
+    pub fn to_non_empty(&self) -> Option<NonEmpty<Self>> {
+        if self.is_empty_or_negative() {
+            return None;
+        }
+
+        Some(NonEmpty(*self))
+    }
+
     /// Returns true if the two boxes intersect.
     #[inline]
     pub fn intersects(&self, other: &Self) -> bool {
@@ -142,14 +152,14 @@ where
 
     /// Computes the intersection of two boxes, returning `None` if the boxes do not intersect.
     #[inline]
-    pub fn try_intersection(&self, other: &Self) -> Option<Self> {
+    pub fn try_intersection(&self, other: &Self) -> Option<NonEmpty<Self>> {
         let intersection = self.intersection(other);
 
         if intersection.is_negative() {
             return None;
         }
 
-        Some(intersection)
+        Some(NonEmpty(intersection))
     }
 }
 

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -14,6 +14,7 @@ use point::Point3D;
 use vector::Vector3D;
 use size::Size3D;
 use approxord::{min, max};
+use nonempty::NonEmpty;
 
 use num_traits::NumCast;
 #[cfg(feature = "serde")]
@@ -112,6 +113,14 @@ where
         self.max.x <= self.min.x || self.max.y <= self.min.y || self.max.z <= self.min.z
     }
 
+    #[inline]
+    pub fn to_non_empty(&self) -> Option<NonEmpty<Self>> {
+        if self.is_empty_or_negative() {
+            return None;
+        }
+
+        Some(NonEmpty(*self))
+    }
 
     #[inline]
     pub fn intersects(&self, other: &Self) -> bool {
@@ -124,12 +133,12 @@ where
     }
 
     #[inline]
-    pub fn try_intersection(&self, other: &Self) -> Option<Self> {
+    pub fn try_intersection(&self, other: &Self) -> Option<NonEmpty<Self>> {
         if !self.intersects(other) {
             return None;
         }
 
-        Some(self.intersection(other))
+        Some(NonEmpty(self.intersection(other)))
     }
 
     pub fn intersection(&self, other: &Self) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ pub use point::{Point2D, Point3D, point2, point3};
 pub use vector::{Vector2D, Vector3D, vec2, vec3};
 pub use vector::{BoolVector2D, BoolVector3D, bvec2, bvec3};
 pub use homogen::HomogeneousVector;
+pub use nonempty::NonEmpty;
 
 pub use rect::{rect, Rect};
 pub use rigid::{RigidTransform3D};
@@ -92,6 +93,7 @@ mod translation;
 mod trig;
 mod vector;
 mod box3d;
+mod nonempty;
 
 /// The default unit.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/nonempty.rs
+++ b/src/nonempty.rs
@@ -1,0 +1,259 @@
+use {Rect, Box2D, Box3D, Vector2D, Vector3D, size2, point2, point3};
+use approxord::{min, max};
+use num::Zero;
+use core::ops::Deref;
+use core::ops::{Add, Sub};
+use core::cmp::{PartialEq};
+
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct NonEmpty<T>(pub(crate) T);
+
+impl<T> Deref for NonEmpty<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> NonEmpty<T> {
+    #[inline]
+    pub fn get(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T, U> NonEmpty<Rect<T, U>>
+where
+    T: Copy + Clone + Zero + PartialOrd + PartialEq + Add<T, Output = T> + Sub<T, Output = T>,
+{
+    #[inline]
+    pub fn union(&self, other: &NonEmpty<Rect<T, U>>) -> NonEmpty<Rect<T, U>> {
+        let origin = point2(
+            min(self.min_x(), other.min_x()),
+            min(self.min_y(), other.min_y()),
+        );
+
+        let lower_right_x = max(self.max_x(), other.max_x());
+        let lower_right_y = max(self.max_y(), other.max_y());
+
+        NonEmpty(Rect {
+            origin,
+            size: size2(
+                lower_right_x - origin.x,
+                lower_right_y - origin.y,
+            ),
+        })
+    }
+
+    #[inline]
+    pub fn contains_rect(&self, rect: &Self) -> bool {
+        self.min_x() <= rect.min_x()
+            && rect.max_x() <= self.max_x()
+            && self.min_y() <= rect.min_y()
+            && rect.max_y() <= self.max_y()
+    }
+
+    #[inline]
+    pub fn translate(&self, by: Vector2D<T, U>) -> Self {
+        NonEmpty(self.0.translate(by))
+    }
+}
+
+impl<T, U> NonEmpty<Box2D<T, U>>
+where
+    T: Copy + PartialOrd,
+{
+    #[inline]
+    pub fn union(&self, other: &NonEmpty<Box2D<T, U>>) -> NonEmpty<Box2D<T, U>> {
+        NonEmpty(Box2D {
+            min: point2(
+                min(self.min.x, other.min.x),
+                min(self.min.y, other.min.y),
+            ),
+            max: point2(
+                max(self.max.x, other.max.x),
+                max(self.max.y, other.max.y),
+            ),
+        })
+    }
+
+    /// Returns true if this box contains the interior of the other box.
+    #[inline]
+    pub fn contains_box(&self, other: &Self) -> bool {
+        self.min.x <= other.min.x
+            && other.max.x <= self.max.x
+            && self.min.y <= other.min.y
+            && other.max.y <= self.max.y
+    }
+}
+
+impl<T, U> NonEmpty<Box2D<T, U>>
+where
+    T: Copy + Add<T, Output = T>,
+{
+    #[inline]
+    pub fn translate(&self, by: Vector2D<T, U>) -> Self {
+        NonEmpty(self.0.translate(by))
+    }
+}
+
+impl<T, U> NonEmpty<Box3D<T, U>>
+where
+    T: Copy + PartialOrd,
+{
+    #[inline]
+    pub fn union(&self, other: &NonEmpty<Box3D<T, U>>) -> NonEmpty<Box3D<T, U>> {
+        NonEmpty(Box3D {
+            min: point3(
+                min(self.min.x, other.min.x),
+                min(self.min.y, other.min.y),
+                min(self.min.z, other.min.z),
+            ),
+            max: point3(
+                max(self.max.x, other.max.x),
+                max(self.max.y, other.max.y),
+                max(self.max.z, other.max.z),
+            ),
+        })
+    }
+
+    /// Returns true if this box contains the interior of the other box.
+    #[inline]
+    pub fn contains_box(&self, other: &Self) -> bool {
+        self.min.x <= other.min.x
+            && other.max.x <= self.max.x
+            && self.min.y <= other.min.y
+            && other.max.y <= self.max.y
+            && self.min.z <= other.min.z
+            && other.max.z <= self.max.z
+    }
+}
+
+impl<T, U> NonEmpty<Box3D<T, U>>
+where
+    T: Copy + Add<T, Output = T>,
+{
+    #[inline]
+    pub fn translate(&self, by: Vector3D<T, U>) -> Self {
+        NonEmpty(self.0.translate(by))
+    }
+}
+
+#[test]
+fn empty_nonempty() {
+    use default;
+
+    // zero-width
+    let box1: default::Box2D<i32> = Box2D {
+        min: point2(-10, 2),
+        max: point2(-10, 12),
+    };
+    // zero-height
+    let box2: default::Box2D<i32> = Box2D {
+        min: point2(0, 11),
+        max: point2(2, 11),
+    };
+    // negative width
+    let box3: default::Box2D<i32> = Box2D {
+        min: point2(1, 11),
+        max: point2(0, 12),
+    };
+    // negative height
+    let box4: default::Box2D<i32> = Box2D {
+        min: point2(0, 11),
+        max: point2(5, 10),
+    };
+
+    assert!(box1.to_non_empty().is_none());
+    assert!(box2.to_non_empty().is_none());
+    assert!(box3.to_non_empty().is_none());
+    assert!(box4.to_non_empty().is_none());
+}
+
+#[test]
+fn nonempty_union() {
+    use default;
+
+    let box1: default::Box2D<i32> = Box2D {
+        min: point2(-10, 2),
+        max: point2(15, 12),
+    };
+    let box2 = Box2D {
+        min: point2(-2, -5),
+        max: point2(10, 5),
+    };
+
+    assert_eq!(box1.union(&box2), *box1.to_non_empty().unwrap().union(&box2.to_non_empty().unwrap()));
+
+    let box3: default::Box3D<i32> = Box3D {
+        min: point3(1, -10, 2),
+        max: point3(6, 15, 12),
+    };
+    let box4 = Box3D {
+        min: point3(0, -2, -5),
+        max: point3(7, 10, 5),
+    };
+
+    assert_eq!(box3.union(&box4), *box3.to_non_empty().unwrap().union(&box4.to_non_empty().unwrap()));
+
+    let rect1: default::Rect<i32> = Rect {
+        origin: point2(1, 2),
+        size: size2(3, 4),
+    };
+    let rect2 = Rect {
+        origin: point2(-1, 5),
+        size: size2(1, 10),
+    };
+
+    assert_eq!(rect1.union(&rect2), *rect1.to_non_empty().unwrap().union(&rect2.to_non_empty().unwrap()));
+}
+
+#[test]
+fn nonempty_contains() {
+    use default;
+    use {vec2, vec3};
+
+    let r: NonEmpty<default::Rect<i32>> = Rect {
+        origin: point2(-20, 15),
+        size: size2(100, 200),
+    }.to_non_empty().unwrap();
+
+    assert!(r.contains_rect(&r));
+    assert!(!r.contains_rect(&r.translate(vec2(1, 0))));
+    assert!(!r.contains_rect(&r.translate(vec2(-1, 0))));
+    assert!(!r.contains_rect(&r.translate(vec2(0, 1))));
+    assert!(!r.contains_rect(&r.translate(vec2(0, -1))));
+
+    let b: NonEmpty<default::Box2D<i32>> = Box2D {
+        min: point2(-10, 5),
+        max: point2(30, 100),
+    }.to_non_empty().unwrap();
+
+    assert!(b.contains_box(&b));
+    assert!(!b.contains_box(&b.translate(vec2(1, 0))));
+    assert!(!b.contains_box(&b.translate(vec2(-1, 0))));
+    assert!(!b.contains_box(&b.translate(vec2(0, 1))));
+    assert!(!b.contains_box(&b.translate(vec2(0, -1))));
+
+    let b: NonEmpty<default::Box3D<i32>> = Box3D {
+        min: point3(-1, -10, 5),
+        max: point3(10, 30, 100),
+    }.to_non_empty().unwrap();
+
+    assert!(b.contains_box(&b));
+    assert!(!b.contains_box(&b.translate(vec3(0, 1, 0))));
+    assert!(!b.contains_box(&b.translate(vec3(0, -1, 0))));
+    assert!(!b.contains_box(&b.translate(vec3(0, 0, 1))));
+    assert!(!b.contains_box(&b.translate(vec3(0, 0, -1))));
+    assert!(!b.contains_box(&b.translate(vec3(1, 1, 0))));
+    assert!(!b.contains_box(&b.translate(vec3(1, -1, 0))));
+    assert!(!b.contains_box(&b.translate(vec3(1, 0, 1))));
+    assert!(!b.contains_box(&b.translate(vec3(1, 0, -1))));
+    assert!(!b.contains_box(&b.translate(vec3(-1, 1, 0))));
+    assert!(!b.contains_box(&b.translate(vec3(-1, -1, 0))));
+    assert!(!b.contains_box(&b.translate(vec3(-1, 0, 1))));
+    assert!(!b.contains_box(&b.translate(vec3(-1, 0, -1))));
+}

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -16,6 +16,7 @@ use vector::Vector2D;
 use side_offsets::SideOffsets2D;
 use size::Size2D;
 use approxord::{min, max};
+use nonempty::NonEmpty;
 
 use num_traits::NumCast;
 #[cfg(feature = "serde")]
@@ -386,6 +387,23 @@ impl<T: Copy + PartialEq + Zero, U> Rect<T, U> {
     /// Returns true if the size is zero, regardless of the origin's value.
     pub fn is_empty(&self) -> bool {
         self.size.width == Zero::zero() || self.size.height == Zero::zero()
+    }
+}
+
+impl<T: Copy + Zero + PartialOrd, U> Rect<T, U> {
+
+    #[inline]
+    pub fn is_empty_or_negative(&self) -> bool {
+        self.size.is_empty_or_negative()
+    }
+
+    #[inline]
+    pub fn to_non_empty(&self) -> Option<NonEmpty<Self>> {
+        if self.is_empty_or_negative() {
+            return None;
+        }
+
+        Some(NonEmpty(*self))
     }
 }
 

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -33,7 +33,7 @@ use core::ops::{Add, Div, Mul, Sub, Range};
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(bound(serialize = "T: Serialize", deserialize = "T: Deserialize<'de>")))]
-pub struct Rect<T, U = UnknownUnit> {
+pub struct Rect<T, U> {
     pub origin: Point2D<T, U>,
     pub size: Size2D<T, U>,
 }

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -184,7 +184,7 @@ where
     /// nonempty but this rectangle is empty.
     #[inline]
     pub fn contains_rect(&self, rect: &Self) -> bool {
-        rect.is_empty()
+        rect.is_empty_or_negative()
             || (self.min_x() <= rect.min_x() && rect.max_x() <= self.max_x()
                 && self.min_y() <= rect.min_y() && rect.max_y() <= self.max_y())
     }


### PR DESCRIPTION
 - Introduce `NonEmpty<T>` as discussed in #339.
 - Remove the default unit parameter in Rect as the compiler rarely seem to make use of that information.
 - Treat negative rects as empty rects in contains_rect (just like we do in Box2D and Box3D).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/357)
<!-- Reviewable:end -->
