### PR TITLE
Pass points vectors and sizes by value

### DIFF
--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -159,8 +159,11 @@ where
 {
     /// Returns the same box, translated by a vector.
     #[inline]
-    pub fn translate(&self, by: &Vector2D<T, U>) -> Self {
-        Self::new(self.min + *by, self.max + *by)
+    pub fn translate(&self, by: Vector2D<T, U>) -> Self {
+        Box2D {
+            min: self.min + by,
+            max: self.max + by,
+        }
     }
 }
 
@@ -172,7 +175,7 @@ where
     /// in the box if they are on the front, left or top faces, but outside if they
     /// are on the back, right or bottom faces.
     #[inline]
-    pub fn contains(&self, p: &Point2D<T, U>) -> bool {
+    pub fn contains(&self, p: Point2D<T, U>) -> bool {
         self.min.x <= p.x && p.x < self.max.x
             && self.min.y <= p.y && p.y < self.max.y
     }
@@ -455,8 +458,8 @@ where
     /// Tag a unitless value with units.
     pub fn from_untyped(c: &Box2D<T, UnknownUnit>) -> Box2D<T, Unit> {
         Box2D::new(
-            Point2D::from_untyped(&c.min),
-            Point2D::from_untyped(&c.max),
+            Point2D::from_untyped(c.min),
+            Point2D::from_untyped(c.max),
         )
     }
 }
@@ -685,7 +688,7 @@ mod tests {
         let b = Box2D::from_size(size);
         assert_eq!(b.center(), center);
         let translation = vec2(10.0, 2.5);
-        let b = b.translate(&translation);
+        let b = b.translate(translation);
         center += translation;
         assert_eq!(b.center(), center);
         assert_eq!(b.max.x, 25.0);
@@ -757,7 +760,7 @@ mod tests {
     #[test]
     fn test_contains() {
         let b = Box2D::from_points(&[point2(-20.0, -20.0), point2(20.0, 20.0)]);
-        assert!(b.contains(&point2(-15.3, 10.5)));
+        assert!(b.contains(point2(-15.3, 10.5)));
     }
 
     #[test]

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -159,8 +159,11 @@ where
     /// Returns the same box3d, translated by a vector.
     #[inline]
     #[must_use]
-    pub fn translate(&self, by: &Vector3D<T, U>) -> Self {
-        Self::new(self.min + *by, self.max + *by)
+    pub fn translate(&self, by: Vector3D<T, U>) -> Self {
+        Box3D {
+            min: self.min + by,
+            max: self.max + by,
+        }
     }
 }
 
@@ -172,7 +175,7 @@ where
     /// in the box3d if they are on the front, left or top faces, but outside if they
     /// are on the back, right or bottom faces.
     #[inline]
-    pub fn contains(&self, other: &Point3D<T, U>) -> bool {
+    pub fn contains(&self, other: Point3D<T, U>) -> bool {
         self.min.x <= other.x && other.x < self.max.x
             && self.min.y <= other.y && other.y < self.max.y
             && self.min.z <= other.z && other.z < self.max.z
@@ -442,16 +445,21 @@ where
     T: Copy,
 {
     /// Drop the units, preserving only the numeric value.
+    #[inline]
     pub fn to_untyped(&self) -> Box3D<T, UnknownUnit> {
-        Box3D::new(self.min.to_untyped(), self.max.to_untyped())
+        Box3D {
+            min: self.min.to_untyped(),
+            max: self.max.to_untyped(),
+        }
     }
 
     /// Tag a unitless value with units.
+    #[inline]
     pub fn from_untyped(c: &Box3D<T, UnknownUnit>) -> Box3D<T, Unit> {
-        Box3D::new(
-            Point3D::from_untyped(&c.min),
-            Point3D::from_untyped(&c.max),
-        )
+        Box3D {
+            min: Point3D::from_untyped(c.min),
+            max: Point3D::from_untyped(c.max),
+        }
     }
 }
 
@@ -702,7 +710,7 @@ mod tests {
         let b = Box3D::from_size(size);
         assert!(b.center() == center);
         let translation = vec3(10.0, 2.5, 9.5);
-        let b = b.translate(&translation);
+        let b = b.translate(translation);
         center += translation;
         assert!(b.center() == center);
         assert!(b.max.x == 25.0);
@@ -796,7 +804,7 @@ mod tests {
     #[test]
     fn test_contains() {
         let b = Box3D::from_points(&[point3(-20.0, -20.0, -20.0), point3(20.0, 20.0, 20.0)]);
-        assert!(b.contains(&point3(-15.3, 10.5, 18.4)));
+        assert!(b.contains(point3(-15.3, 10.5, 18.4)));
     }
 
     #[test]

--- a/src/point.rs
+++ b/src/point.rs
@@ -178,7 +178,7 @@ impl<T: Copy, U> Point2D<T, U> {
 
     /// Tag a unitless value with units.
     #[inline]
-    pub fn from_untyped(p: &Point2D<T, UnknownUnit>) -> Self {
+    pub fn from_untyped(p: Point2D<T, UnknownUnit>) -> Self {
         point2(p.x, p.y)
     }
 
@@ -674,7 +674,7 @@ impl<T: Copy, U> Point3D<T, U> {
 
     /// Tag a unitless value with units.
     #[inline]
-    pub fn from_untyped(p: &Point3D<T, UnknownUnit>) -> Self {
+    pub fn from_untyped(p: Point3D<T, UnknownUnit>) -> Self {
         point3(p.x, p.y, p.z)
     }
 

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -165,15 +165,15 @@ where
     /// Returns the same rectangle, translated by a vector.
     #[inline]
     #[must_use]
-    pub fn translate(&self, by: &Vector2D<T, U>) -> Self {
-        Self::new(self.origin + *by, self.size)
+    pub fn translate(&self, by: Vector2D<T, U>) -> Self {
+        Self::new(self.origin + by, self.size)
     }
 
     /// Returns true if this rectangle contains the point. Points are considered
     /// in the rectangle if they are on the left or top edge, but outside if they
     /// are on the right or bottom edge.
     #[inline]
-    pub fn contains(&self, other: &Point2D<T, U>) -> bool {
+    pub fn contains(&self, other: Point2D<T, U>) -> bool {
         self.origin.x <= other.x && other.x < self.origin.x + self.size.width
             && self.origin.y <= other.y && other.y < self.origin.y + self.size.height
     }
@@ -423,15 +423,17 @@ impl<T: Copy + Div<T, Output = T>, U1, U2> Div<Scale<T, U1, U2>> for Rect<T, U2>
 
 impl<T: Copy, Unit> Rect<T, Unit> {
     /// Drop the units, preserving only the numeric value.
+    #[inline]
     pub fn to_untyped(&self) -> Rect<T, UnknownUnit> {
         Rect::new(self.origin.to_untyped(), self.size.to_untyped())
     }
 
     /// Tag a unitless value with units.
+    #[inline]
     pub fn from_untyped(r: &Rect<T, UnknownUnit>) -> Rect<T, Unit> {
         Rect::new(
-            Point2D::from_untyped(&r.origin),
-            Size2D::from_untyped(&r.size),
+            Point2D::from_untyped(r.origin),
+            Size2D::from_untyped(r.size),
         )
     }
 }
@@ -569,7 +571,7 @@ mod tests {
     #[test]
     fn test_translate() {
         let p = Rect::new(Point2D::new(0u32, 0u32), Size2D::new(50u32, 40u32));
-        let pp = p.translate(&vec2(10, 15));
+        let pp = p.translate(vec2(10, 15));
 
         assert!(pp.size.width == 50);
         assert!(pp.size.height == 40);
@@ -577,7 +579,7 @@ mod tests {
         assert!(pp.origin.y == 15);
 
         let r = Rect::new(Point2D::new(-10, -5), Size2D::new(50, 40));
-        let rr = r.translate(&vec2(0, -10));
+        let rr = r.translate(vec2(0, -10));
 
         assert!(rr.size.width == 50);
         assert!(rr.size.height == 40);
@@ -631,42 +633,42 @@ mod tests {
     fn test_contains() {
         let r = Rect::new(Point2D::new(-20, 15), Size2D::new(100, 200));
 
-        assert!(r.contains(&Point2D::new(0, 50)));
-        assert!(r.contains(&Point2D::new(-10, 200)));
+        assert!(r.contains(Point2D::new(0, 50)));
+        assert!(r.contains(Point2D::new(-10, 200)));
 
         // The `contains` method is inclusive of the top/left edges, but not the
         // bottom/right edges.
-        assert!(r.contains(&Point2D::new(-20, 15)));
-        assert!(!r.contains(&Point2D::new(80, 15)));
-        assert!(!r.contains(&Point2D::new(80, 215)));
-        assert!(!r.contains(&Point2D::new(-20, 215)));
+        assert!(r.contains(Point2D::new(-20, 15)));
+        assert!(!r.contains(Point2D::new(80, 15)));
+        assert!(!r.contains(Point2D::new(80, 215)));
+        assert!(!r.contains(Point2D::new(-20, 215)));
 
         // Points beyond the top-left corner.
-        assert!(!r.contains(&Point2D::new(-25, 15)));
-        assert!(!r.contains(&Point2D::new(-15, 10)));
+        assert!(!r.contains(Point2D::new(-25, 15)));
+        assert!(!r.contains(Point2D::new(-15, 10)));
 
         // Points beyond the top-right corner.
-        assert!(!r.contains(&Point2D::new(85, 20)));
-        assert!(!r.contains(&Point2D::new(75, 10)));
+        assert!(!r.contains(Point2D::new(85, 20)));
+        assert!(!r.contains(Point2D::new(75, 10)));
 
         // Points beyond the bottom-right corner.
-        assert!(!r.contains(&Point2D::new(85, 210)));
-        assert!(!r.contains(&Point2D::new(75, 220)));
+        assert!(!r.contains(Point2D::new(85, 210)));
+        assert!(!r.contains(Point2D::new(75, 220)));
 
         // Points beyond the bottom-left corner.
-        assert!(!r.contains(&Point2D::new(-25, 210)));
-        assert!(!r.contains(&Point2D::new(-15, 220)));
+        assert!(!r.contains(Point2D::new(-25, 210)));
+        assert!(!r.contains(Point2D::new(-15, 220)));
 
         let r = Rect::new(Point2D::new(-20.0, 15.0), Size2D::new(100.0, 200.0));
         assert!(r.contains_rect(&r));
-        assert!(!r.contains_rect(&r.translate(&vec2(0.1, 0.0))));
-        assert!(!r.contains_rect(&r.translate(&vec2(-0.1, 0.0))));
-        assert!(!r.contains_rect(&r.translate(&vec2(0.0, 0.1))));
-        assert!(!r.contains_rect(&r.translate(&vec2(0.0, -0.1))));
+        assert!(!r.contains_rect(&r.translate(vec2(0.1, 0.0))));
+        assert!(!r.contains_rect(&r.translate(vec2(-0.1, 0.0))));
+        assert!(!r.contains_rect(&r.translate(vec2(0.0, 0.1))));
+        assert!(!r.contains_rect(&r.translate(vec2(0.0, -0.1))));
         // Empty rectangles are always considered as contained in other rectangles,
         // even if their origin is not.
         let p = Point2D::new(1.0, 1.0);
-        assert!(!r.contains(&p));
+        assert!(!r.contains(p));
         assert!(r.contains_rect(&Rect::new(p, Size2D::zero())));
     }
 

--- a/src/rigid.rs
+++ b/src/rigid.rs
@@ -57,7 +57,7 @@ impl<T: Float + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
         // It is equivalent to the translation matrix obtained by rotating the
         // translation by R
 
-        let translation = rotation.rotate_vector3d(&translation);
+        let translation = rotation.transform_vector3d(translation);
         Self {
             rotation,
             translation,
@@ -92,7 +92,7 @@ impl<T: Float + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
         //
         // T' = (R^ * T * R^-1) is T rotated by R^-1
 
-        let translation = self.rotation.inverse().rotate_vector3d(&self.translation);
+        let translation = self.rotation.inverse().transform_vector3d(self.translation);
         (translation, self.rotation)
     }
 
@@ -119,7 +119,7 @@ impl<T: Float + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
 
         let t_prime = other
             .rotation
-            .rotate_vector3d(&self.translation);
+            .transform_vector3d(self.translation);
         let r_prime = self.rotation.post_rotate(&other.rotation);
         let t_prime2 = t_prime + other.translation;
         RigidTransform3D {

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -310,7 +310,7 @@ where
     ///
     /// The input point must be use the unit Src, and the returned point has the unit Dst.
     #[inline]
-    pub fn transform_point(&self, point: &Point2D<T, Src>) -> Point2D<T, Dst> {
+    pub fn transform_point(&self, point: Point2D<T, Src>) -> Point2D<T, Dst> {
         let (sin, cos) = Float::sin_cos(self.angle);
         point2(point.x * cos - point.y * sin, point.y * cos + point.x * sin)
     }
@@ -319,8 +319,8 @@ where
     ///
     /// The input point must be use the unit Src, and the returned point has the unit Dst.
     #[inline]
-    pub fn transform_vector(&self, vector: &Vector2D<T, Src>) -> Vector2D<T, Dst> {
-        self.transform_point(&vector.to_point()).to_vector()
+    pub fn transform_vector(&self, vector: Vector2D<T, Src>) -> Vector2D<T, Dst> {
+        self.transform_point(vector.to_point()).to_vector()
     }
 }
 
@@ -600,7 +600,7 @@ where
     /// Returns the given 3d point transformed by this rotation.
     ///
     /// The input point must be use the unit Src, and the returned point has the unit Dst.
-    pub fn rotate_point3d(&self, point: &Point3D<T, Src>) -> Point3D<T, Dst>
+    pub fn rotate_point3d(&self, point: Point3D<T, Src>) -> Point3D<T, Dst>
     where
         T: ApproxEq<T>,
     {
@@ -620,11 +620,11 @@ where
     ///
     /// The input point must be use the unit Src, and the returned point has the unit Dst.
     #[inline]
-    pub fn rotate_point2d(&self, point: &Point2D<T, Src>) -> Point2D<T, Dst>
+    pub fn rotate_point2d(&self, point: Point2D<T, Src>) -> Point2D<T, Dst>
     where
         T: ApproxEq<T>,
     {
-        self.rotate_point3d(&point.to_3d()).xy()
+        self.rotate_point3d(point.to_3d()).xy()
     }
 
     /// Returns the given 3d vector transformed by this rotation.
@@ -635,7 +635,7 @@ where
     where
         T: ApproxEq<T>,
     {
-        self.rotate_point3d(&vector.to_point()).to_vector()
+        self.rotate_point3d(vector.to_point()).to_vector()
     }
 
     /// Returns the given 2d vector transformed by this rotation then projected on the xy plane.
@@ -820,27 +820,27 @@ fn simple_rotation_2d() {
     let r180 = Rotation2D::radians(PI);
 
     assert!(
-        ri.transform_point(&point2(1.0, 2.0))
+        ri.transform_point(point2(1.0, 2.0))
             .approx_eq(&point2(1.0, 2.0))
     );
     assert!(
-        r90.transform_point(&point2(1.0, 2.0))
+        r90.transform_point(point2(1.0, 2.0))
             .approx_eq(&point2(-2.0, 1.0))
     );
     assert!(
-        rm90.transform_point(&point2(1.0, 2.0))
+        rm90.transform_point(point2(1.0, 2.0))
             .approx_eq(&point2(2.0, -1.0))
     );
     assert!(
-        r180.transform_point(&point2(1.0, 2.0))
+        r180.transform_point(point2(1.0, 2.0))
             .approx_eq(&point2(-1.0, -2.0))
     );
 
     assert!(
         r90.inverse()
             .inverse()
-            .transform_point(&point2(1.0, 2.0))
-            .approx_eq(&r90.transform_point(&point2(1.0, 2.0)))
+            .transform_point(point2(1.0, 2.0))
+            .approx_eq(&r90.transform_point(point2(1.0, 2.0)))
     );
 }
 
@@ -855,27 +855,27 @@ fn simple_rotation_3d_in_2d() {
     let r180 = Rotation3D::around_z(Angle::radians(PI));
 
     assert!(
-        ri.rotate_point2d(&point2(1.0, 2.0))
+        ri.rotate_point2d(point2(1.0, 2.0))
             .approx_eq(&point2(1.0, 2.0))
     );
     assert!(
-        r90.rotate_point2d(&point2(1.0, 2.0))
+        r90.rotate_point2d(point2(1.0, 2.0))
             .approx_eq(&point2(-2.0, 1.0))
     );
     assert!(
-        rm90.rotate_point2d(&point2(1.0, 2.0))
+        rm90.rotate_point2d(point2(1.0, 2.0))
             .approx_eq(&point2(2.0, -1.0))
     );
     assert!(
-        r180.rotate_point2d(&point2(1.0, 2.0))
+        r180.rotate_point2d(point2(1.0, 2.0))
             .approx_eq(&point2(-1.0, -2.0))
     );
 
     assert!(
         r90.inverse()
             .inverse()
-            .rotate_point2d(&point2(1.0, 2.0))
-            .approx_eq(&r90.rotate_point2d(&point2(1.0, 2.0)))
+            .rotate_point2d(point2(1.0, 2.0))
+            .approx_eq(&r90.rotate_point2d(point2(1.0, 2.0)))
     );
 }
 
@@ -896,13 +896,13 @@ fn pre_post() {
 
     // Check that the order of transformations is correct (corresponds to what
     // we do in Transform3D).
-    let p1 = r1.post_rotate(&r2).post_rotate(&r3).rotate_point3d(&p);
-    let p2 = t1.post_transform(&t2).post_transform(&t3).transform_point3d(&p);
+    let p1 = r1.post_rotate(&r2).post_rotate(&r3).rotate_point3d(p);
+    let p2 = t1.post_transform(&t2).post_transform(&t3).transform_point3d(p);
 
     assert!(p1.approx_eq(&p2.unwrap()));
 
     // Check that changing the order indeed matters.
-    let p3 = t3.post_transform(&t1).post_transform(&t2).transform_point3d(&p);
+    let p3 = t3.post_transform(&t1).post_transform(&t2).transform_point3d(p);
     assert!(!p1.approx_eq(&p3.unwrap()));
 }
 
@@ -932,7 +932,7 @@ fn to_transform3d() {
     ];
 
     for rotation in &rotations {
-        for point in &points {
+        for &point in &points {
             let p1 = rotation.rotate_point3d(point);
             let p2 = rotation.to_transform().transform_point3d(point);
             assert!(p1.approx_eq(&p2.unwrap()));
@@ -1019,17 +1019,17 @@ fn around_axis() {
     let r1 = Rotation3D::around_axis(vec3(1.0, 1.0, 0.0), Angle::radians(PI));
     let r2 = Rotation3D::around_axis(vec3(1.0, 1.0, 0.0), Angle::radians(FRAC_PI_2));
     assert!(
-        r1.rotate_point3d(&point3(1.0, 2.0, 0.0))
+        r1.rotate_point3d(point3(1.0, 2.0, 0.0))
             .approx_eq(&point3(2.0, 1.0, 0.0))
     );
     assert!(
-        r2.rotate_point3d(&point3(1.0, 0.0, 0.0))
+        r2.rotate_point3d(point3(1.0, 0.0, 0.0))
             .approx_eq(&point3(0.5, 0.5, -0.5.sqrt()))
     );
 
     // A more arbitrary test (made up with numpy):
     let r3 = Rotation3D::around_axis(vec3(0.5, 1.0, 2.0), Angle::radians(2.291288));
-    assert!(r3.rotate_point3d(&point3(1.0, 0.0, 0.0)).approx_eq(&point3(
+    assert!(r3.rotate_point3d(point3(1.0, 0.0, 0.0)).approx_eq(&point3(
         -0.58071821,
         0.81401868,
         -0.01182979
@@ -1053,20 +1053,20 @@ fn from_euler() {
     // roll
     let roll_re = Rotation3D::euler(angle, zero, zero);
     let roll_rq = Rotation3D::around_x(angle);
-    let roll_pe = roll_re.rotate_point3d(&p);
-    let roll_pq = roll_rq.rotate_point3d(&p);
+    let roll_pe = roll_re.rotate_point3d(p);
+    let roll_pq = roll_rq.rotate_point3d(p);
 
     // pitch
     let pitch_re = Rotation3D::euler(zero, angle, zero);
     let pitch_rq = Rotation3D::around_y(angle);
-    let pitch_pe = pitch_re.rotate_point3d(&p);
-    let pitch_pq = pitch_rq.rotate_point3d(&p);
+    let pitch_pe = pitch_re.rotate_point3d(p);
+    let pitch_pq = pitch_rq.rotate_point3d(p);
 
     // yaw
     let yaw_re = Rotation3D::euler(zero, zero, angle);
     let yaw_rq = Rotation3D::around_z(angle);
-    let yaw_pe = yaw_re.rotate_point3d(&p);
-    let yaw_pq = yaw_rq.rotate_point3d(&p);
+    let yaw_pe = yaw_re.rotate_point3d(p);
+    let yaw_pq = yaw_rq.rotate_point3d(p);
 
     assert!(roll_pe.approx_eq(&roll_pq));
     assert!(pitch_pe.approx_eq(&pitch_pq));
@@ -1076,8 +1076,8 @@ fn from_euler() {
     // the proper order: roll -> pitch -> yaw.
     let ypr_e = Rotation3D::euler(angle, angle, angle);
     let ypr_q = roll_rq.post_rotate(&pitch_rq).post_rotate(&yaw_rq);
-    let ypr_pe = ypr_e.rotate_point3d(&p);
-    let ypr_pq = ypr_q.rotate_point3d(&p);
+    let ypr_pe = ypr_e.rotate_point3d(p);
+    let ypr_pq = ypr_q.rotate_point3d(p);
 
     assert!(ypr_pe.approx_eq(&ypr_pq));
 }

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -600,7 +600,7 @@ where
     /// Returns the given 3d point transformed by this rotation.
     ///
     /// The input point must be use the unit Src, and the returned point has the unit Dst.
-    pub fn rotate_point3d(&self, point: Point3D<T, Src>) -> Point3D<T, Dst>
+    pub fn transform_point3d(&self, point: Point3D<T, Src>) -> Point3D<T, Dst>
     where
         T: ApproxEq<T>,
     {
@@ -620,33 +620,33 @@ where
     ///
     /// The input point must be use the unit Src, and the returned point has the unit Dst.
     #[inline]
-    pub fn rotate_point2d(&self, point: Point2D<T, Src>) -> Point2D<T, Dst>
+    pub fn transform_point2d(&self, point: Point2D<T, Src>) -> Point2D<T, Dst>
     where
         T: ApproxEq<T>,
     {
-        self.rotate_point3d(point.to_3d()).xy()
+        self.transform_point3d(point.to_3d()).xy()
     }
 
     /// Returns the given 3d vector transformed by this rotation.
     ///
     /// The input vector must be use the unit Src, and the returned point has the unit Dst.
     #[inline]
-    pub fn rotate_vector3d(&self, vector: &Vector3D<T, Src>) -> Vector3D<T, Dst>
+    pub fn transform_vector3d(&self, vector: Vector3D<T, Src>) -> Vector3D<T, Dst>
     where
         T: ApproxEq<T>,
     {
-        self.rotate_point3d(vector.to_point()).to_vector()
+        self.transform_point3d(vector.to_point()).to_vector()
     }
 
     /// Returns the given 2d vector transformed by this rotation then projected on the xy plane.
     ///
     /// The input vector must be use the unit Src, and the returned point has the unit Dst.
     #[inline]
-    pub fn rotate_vector2d(&self, vector: &Vector2D<T, Src>) -> Vector2D<T, Dst>
+    pub fn transform_vector2d(&self, vector: Vector2D<T, Src>) -> Vector2D<T, Dst>
     where
         T: ApproxEq<T>,
     {
-        self.rotate_vector3d(&vector.to_3d()).xy()
+        self.transform_vector3d(vector.to_3d()).xy()
     }
 
     /// Returns the matrix representation of this rotation.
@@ -855,27 +855,27 @@ fn simple_rotation_3d_in_2d() {
     let r180 = Rotation3D::around_z(Angle::radians(PI));
 
     assert!(
-        ri.rotate_point2d(point2(1.0, 2.0))
+        ri.transform_point2d(point2(1.0, 2.0))
             .approx_eq(&point2(1.0, 2.0))
     );
     assert!(
-        r90.rotate_point2d(point2(1.0, 2.0))
+        r90.transform_point2d(point2(1.0, 2.0))
             .approx_eq(&point2(-2.0, 1.0))
     );
     assert!(
-        rm90.rotate_point2d(point2(1.0, 2.0))
+        rm90.transform_point2d(point2(1.0, 2.0))
             .approx_eq(&point2(2.0, -1.0))
     );
     assert!(
-        r180.rotate_point2d(point2(1.0, 2.0))
+        r180.transform_point2d(point2(1.0, 2.0))
             .approx_eq(&point2(-1.0, -2.0))
     );
 
     assert!(
         r90.inverse()
             .inverse()
-            .rotate_point2d(point2(1.0, 2.0))
-            .approx_eq(&r90.rotate_point2d(point2(1.0, 2.0)))
+            .transform_point2d(point2(1.0, 2.0))
+            .approx_eq(&r90.transform_point2d(point2(1.0, 2.0)))
     );
 }
 
@@ -896,7 +896,7 @@ fn pre_post() {
 
     // Check that the order of transformations is correct (corresponds to what
     // we do in Transform3D).
-    let p1 = r1.post_rotate(&r2).post_rotate(&r3).rotate_point3d(p);
+    let p1 = r1.post_rotate(&r2).post_rotate(&r3).transform_point3d(p);
     let p2 = t1.post_transform(&t2).post_transform(&t3).transform_point3d(p);
 
     assert!(p1.approx_eq(&p2.unwrap()));
@@ -933,7 +933,7 @@ fn to_transform3d() {
 
     for rotation in &rotations {
         for &point in &points {
-            let p1 = rotation.rotate_point3d(point);
+            let p1 = rotation.transform_point3d(point);
             let p2 = rotation.to_transform().transform_point3d(point);
             assert!(p1.approx_eq(&p2.unwrap()));
         }
@@ -1019,17 +1019,17 @@ fn around_axis() {
     let r1 = Rotation3D::around_axis(vec3(1.0, 1.0, 0.0), Angle::radians(PI));
     let r2 = Rotation3D::around_axis(vec3(1.0, 1.0, 0.0), Angle::radians(FRAC_PI_2));
     assert!(
-        r1.rotate_point3d(point3(1.0, 2.0, 0.0))
+        r1.transform_point3d(point3(1.0, 2.0, 0.0))
             .approx_eq(&point3(2.0, 1.0, 0.0))
     );
     assert!(
-        r2.rotate_point3d(point3(1.0, 0.0, 0.0))
+        r2.transform_point3d(point3(1.0, 0.0, 0.0))
             .approx_eq(&point3(0.5, 0.5, -0.5.sqrt()))
     );
 
     // A more arbitrary test (made up with numpy):
     let r3 = Rotation3D::around_axis(vec3(0.5, 1.0, 2.0), Angle::radians(2.291288));
-    assert!(r3.rotate_point3d(point3(1.0, 0.0, 0.0)).approx_eq(&point3(
+    assert!(r3.transform_point3d(point3(1.0, 0.0, 0.0)).approx_eq(&point3(
         -0.58071821,
         0.81401868,
         -0.01182979
@@ -1053,20 +1053,20 @@ fn from_euler() {
     // roll
     let roll_re = Rotation3D::euler(angle, zero, zero);
     let roll_rq = Rotation3D::around_x(angle);
-    let roll_pe = roll_re.rotate_point3d(p);
-    let roll_pq = roll_rq.rotate_point3d(p);
+    let roll_pe = roll_re.transform_point3d(p);
+    let roll_pq = roll_rq.transform_point3d(p);
 
     // pitch
     let pitch_re = Rotation3D::euler(zero, angle, zero);
     let pitch_rq = Rotation3D::around_y(angle);
-    let pitch_pe = pitch_re.rotate_point3d(p);
-    let pitch_pq = pitch_rq.rotate_point3d(p);
+    let pitch_pe = pitch_re.transform_point3d(p);
+    let pitch_pq = pitch_rq.transform_point3d(p);
 
     // yaw
     let yaw_re = Rotation3D::euler(zero, zero, angle);
     let yaw_rq = Rotation3D::around_z(angle);
-    let yaw_pe = yaw_re.rotate_point3d(p);
-    let yaw_pq = yaw_rq.rotate_point3d(p);
+    let yaw_pe = yaw_re.transform_point3d(p);
+    let yaw_pq = yaw_rq.transform_point3d(p);
 
     assert!(roll_pe.approx_eq(&roll_pq));
     assert!(pitch_pe.approx_eq(&pitch_pq));
@@ -1076,8 +1076,8 @@ fn from_euler() {
     // the proper order: roll -> pitch -> yaw.
     let ypr_e = Rotation3D::euler(angle, angle, angle);
     let ypr_q = roll_rq.post_rotate(&pitch_rq).post_rotate(&yaw_rq);
-    let ypr_pe = ypr_e.rotate_point3d(p);
-    let ypr_pq = ypr_q.rotate_point3d(p);
+    let ypr_pe = ypr_e.transform_point3d(p);
+    let ypr_pq = ypr_q.transform_point3d(p);
 
     assert!(ypr_pe.approx_eq(&ypr_pq));
 }

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -112,19 +112,19 @@ where
 {
     /// Returns the given point transformed by this scale.
     #[inline]
-    pub fn transform_point(&self, point: &Point2D<T, Src>) -> Point2D<T, Dst> {
+    pub fn transform_point(&self, point: Point2D<T, Src>) -> Point2D<T, Dst> {
         Point2D::new(point.x * self.get(), point.y * self.get())
     }
 
     /// Returns the given vector transformed by this scale.
     #[inline]
-    pub fn transform_vector(&self, vec: &Vector2D<T, Src>) -> Vector2D<T, Dst> {
+    pub fn transform_vector(&self, vec: Vector2D<T, Src>) -> Vector2D<T, Dst> {
         Vector2D::new(vec.x * self.get(), vec.y * self.get())
     }
 
     /// Returns the given vector transformed by this scale.
     #[inline]
-    pub fn transform_size(&self, size: &Size2D<T, Src>) -> Size2D<T, Dst> {
+    pub fn transform_size(&self, size: Size2D<T, Src>) -> Size2D<T, Dst> {
         Size2D::new(size.width * self.get(), size.height * self.get())
     }
 
@@ -132,8 +132,8 @@ where
     #[inline]
     pub fn transform_rect(&self, rect: &Rect<T, Src>) -> Rect<T, Dst> {
         Rect::new(
-            self.transform_point(&rect.origin),
-            self.transform_size(&rect.size),
+            self.transform_point(rect.origin),
+            self.transform_size(rect.size),
         )
     }
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -262,7 +262,7 @@ impl<T: Copy, U> Size2D<T, U> {
     }
 
     /// Tag a unitless value with units.
-    pub fn from_untyped(p: &Size2D<T, UnknownUnit>) -> Self {
+    pub fn from_untyped(p: Size2D<T, UnknownUnit>) -> Self {
         Size2D::new(p.width, p.height)
     }
 }
@@ -352,14 +352,14 @@ where
 }
 
 impl<T: PartialOrd, U> Size2D<T, U> {
-    pub fn greater_than(&self, other: &Self) -> BoolVector2D {
+    pub fn greater_than(&self, other: Self) -> BoolVector2D {
         BoolVector2D {
             x: self.width > other.width,
             y: self.height > other.height,
         }
     }
 
-    pub fn lower_than(&self, other: &Self) -> BoolVector2D {
+    pub fn lower_than(&self, other: Self) -> BoolVector2D {
         BoolVector2D {
             x: self.width < other.width,
             y: self.height < other.height,
@@ -369,14 +369,14 @@ impl<T: PartialOrd, U> Size2D<T, U> {
 
 
 impl<T: PartialEq, U> Size2D<T, U> {
-    pub fn equal(&self, other: &Self) -> BoolVector2D {
+    pub fn equal(&self, other: Self) -> BoolVector2D {
         BoolVector2D {
             x: self.width == other.width,
             y: self.height == other.height,
         }
     }
 
-    pub fn not_equal(&self, other: &Self) -> BoolVector2D {
+    pub fn not_equal(&self, other: Self) -> BoolVector2D {
         BoolVector2D {
             x: self.width != other.width,
             y: self.height != other.height,
@@ -765,7 +765,7 @@ impl<T: Copy, U> Size3D<T, U> {
     }
 
     /// Tag a unitless value with units.
-    pub fn from_untyped(p: &Size3D<T, UnknownUnit>) -> Self {
+    pub fn from_untyped(p: Size3D<T, UnknownUnit>) -> Self {
         Size3D::new(p.width, p.height, p.depth)
     }
 }
@@ -855,7 +855,7 @@ where
 }
 
 impl<T: PartialOrd, U> Size3D<T, U> {
-    pub fn greater_than(&self, other: &Self) -> BoolVector3D {
+    pub fn greater_than(&self, other: Self) -> BoolVector3D {
         BoolVector3D {
             x: self.width > other.width,
             y: self.height > other.height,
@@ -863,7 +863,7 @@ impl<T: PartialOrd, U> Size3D<T, U> {
         }
     }
 
-    pub fn lower_than(&self, other: &Self) -> BoolVector3D {
+    pub fn lower_than(&self, other: Self) -> BoolVector3D {
         BoolVector3D {
             x: self.width < other.width,
             y: self.height < other.height,
@@ -874,7 +874,7 @@ impl<T: PartialOrd, U> Size3D<T, U> {
 
 
 impl<T: PartialEq, U> Size3D<T, U> {
-    pub fn equal(&self, other: &Self) -> BoolVector3D {
+    pub fn equal(&self, other: Self) -> BoolVector3D {
         BoolVector3D {
             x: self.width == other.width,
             y: self.height == other.height,
@@ -882,7 +882,7 @@ impl<T: PartialEq, U> Size3D<T, U> {
         }
     }
 
-    pub fn not_equal(&self, other: &Self) -> BoolVector3D {
+    pub fn not_equal(&self, other: Self) -> BoolVector3D {
         BoolVector3D {
             x: self.width != other.width,
             y: self.height != other.height,

--- a/src/transform2d.rs
+++ b/src/transform2d.rs
@@ -415,7 +415,7 @@ where T: Copy + Clone +
     /// Assuming row vectors, this is equivalent to `p * self`
     #[inline]
     #[must_use]
-    pub fn transform_point(&self, point: &Point2D<T, Src>) -> Point2D<T, Dst> {
+    pub fn transform_point(&self, point: Point2D<T, Src>) -> Point2D<T, Dst> {
         Point2D::new(
             point.x * self.m11 + point.y * self.m21 + self.m31,
             point.x * self.m12 + point.y * self.m22 + self.m32
@@ -427,7 +427,7 @@ where T: Copy + Clone +
     /// Assuming row vectors, this is equivalent to `v * self`
     #[inline]
     #[must_use]
-    pub fn transform_vector(&self, vec: &Vector2D<T, Src>) -> Vector2D<T, Dst> {
+    pub fn transform_vector(&self, vec: Vector2D<T, Src>) -> Vector2D<T, Dst> {
         vec2(vec.x * self.m11 + vec.y * self.m21,
              vec.x * self.m12 + vec.y * self.m22)
     }
@@ -438,10 +438,10 @@ where T: Copy + Clone +
     #[must_use]
     pub fn transform_rect(&self, rect: &Rect<T, Src>) -> Rect<T, Dst> {
         Rect::from_points(&[
-            self.transform_point(&rect.origin),
-            self.transform_point(&rect.top_right()),
-            self.transform_point(&rect.bottom_left()),
-            self.transform_point(&rect.bottom_right()),
+            self.transform_point(rect.origin),
+            self.transform_point(rect.top_right()),
+            self.transform_point(rect.bottom_left()),
+            self.transform_point(rect.bottom_right()),
         ])
     }
 
@@ -585,7 +585,7 @@ mod test {
         assert_eq!(t1, t2);
         assert_eq!(t1, t3);
 
-        assert_eq!(t1.transform_point(&Point2D::new(1.0, 1.0)), Point2D::new(2.0, 3.0));
+        assert_eq!(t1.transform_point(Point2D::new(1.0, 1.0)), Point2D::new(2.0, 3.0));
 
         assert_eq!(t1.post_transform(&t1), Mat::create_translation(2.0, 4.0));
     }
@@ -598,7 +598,7 @@ mod test {
         assert_eq!(r1, r2);
         assert_eq!(r1, r3);
 
-        assert!(r1.transform_point(&Point2D::new(1.0, 2.0)).approx_eq(&Point2D::new(2.0, -1.0)));
+        assert!(r1.transform_point(Point2D::new(1.0, 2.0)).approx_eq(&Point2D::new(2.0, -1.0)));
 
         assert!(r1.post_transform(&r1).approx_eq(&Mat::create_rotation(rad(FRAC_PI_2*2.0))));
     }
@@ -611,7 +611,7 @@ mod test {
         assert_eq!(s1, s2);
         assert_eq!(s1, s3);
 
-        assert!(s1.transform_point(&Point2D::new(2.0, 2.0)).approx_eq(&Point2D::new(4.0, 6.0)));
+        assert!(s1.transform_point(Point2D::new(2.0, 2.0)).approx_eq(&Point2D::new(4.0, 6.0)));
     }
 
     #[test]
@@ -667,13 +667,13 @@ mod test {
 
         let a = Point2D::new(1.0, 1.0);
 
-        assert!(r.post_transform(&t).transform_point(&a).approx_eq(&Point2D::new(3.0, 2.0)));
-        assert!(t.post_transform(&r).transform_point(&a).approx_eq(&Point2D::new(4.0, -3.0)));
-        assert!(t.post_transform(&r).transform_point(&a).approx_eq(&r.transform_point(&t.transform_point(&a))));
+        assert!(r.post_transform(&t).transform_point(a).approx_eq(&Point2D::new(3.0, 2.0)));
+        assert!(t.post_transform(&r).transform_point(a).approx_eq(&Point2D::new(4.0, -3.0)));
+        assert!(t.post_transform(&r).transform_point(a).approx_eq(&r.transform_point(t.transform_point(a))));
 
-        assert!(r.pre_transform(&t).transform_point(&a).approx_eq(&Point2D::new(4.0, -3.0)));
-        assert!(t.pre_transform(&r).transform_point(&a).approx_eq(&Point2D::new(3.0, 2.0)));
-        assert!(t.pre_transform(&r).transform_point(&a).approx_eq(&t.transform_point(&r.transform_point(&a))));
+        assert!(r.pre_transform(&t).transform_point(a).approx_eq(&Point2D::new(4.0, -3.0)));
+        assert!(t.pre_transform(&r).transform_point(a).approx_eq(&Point2D::new(3.0, 2.0)));
+        assert!(t.pre_transform(&r).transform_point(a).approx_eq(&t.transform_point(r.transform_point(a))));
     }
 
     #[test]
@@ -696,7 +696,7 @@ mod test {
         // Translation does not apply to vectors.
         let m1 = Mat::create_translation(1.0, 1.0);
         let v1 = vec2(10.0, -10.0);
-        assert_eq!(v1, m1.transform_vector(&v1));
+        assert_eq!(v1, m1.transform_vector(v1));
     }
 
     #[cfg(feature = "mint")]

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -546,7 +546,7 @@ where T: Copy + Clone +
     /// Assuming row vectors, this is equivalent to `p * self`
     #[inline]
     pub fn transform_point2d_homogeneous(
-        &self, p: &Point2D<T, Src>
+        &self, p: Point2D<T, Src>
     ) -> HomogeneousVector<T, Dst> {
         let x = p.x * self.m11 + p.y * self.m21 + self.m41;
         let y = p.x * self.m12 + p.y * self.m22 + self.m42;
@@ -563,7 +563,7 @@ where T: Copy + Clone +
     ///
     /// Assuming row vectors, this is equivalent to `p * self`
     #[inline]
-    pub fn transform_point2d(&self, p: &Point2D<T, Src>) -> Option<Point2D<T, Dst>> {
+    pub fn transform_point2d(&self, p: Point2D<T, Src>) -> Option<Point2D<T, Dst>> {
         //Note: could use `transform_point2d_homogeneous()` but it would waste the calculus of `z`
         let w = p.x * self.m14 + p.y * self.m24 + self.m44;
         if w > T::zero() {
@@ -582,7 +582,7 @@ where T: Copy + Clone +
     ///
     /// Assuming row vectors, this is equivalent to `v * self`
     #[inline]
-    pub fn transform_vector2d(&self, v: &Vector2D<T, Src>) -> Vector2D<T, Dst> {
+    pub fn transform_vector2d(&self, v: Vector2D<T, Src>) -> Vector2D<T, Dst> {
         vec2(
             v.x * self.m11 + v.y * self.m21,
             v.x * self.m12 + v.y * self.m22,
@@ -596,7 +596,7 @@ where T: Copy + Clone +
     /// Assuming row vectors, this is equivalent to `p * self`
     #[inline]
     pub fn transform_point3d_homogeneous(
-        &self, p: &Point3D<T, Src>
+        &self, p: Point3D<T, Src>
     ) -> HomogeneousVector<T, Dst> {
         let x = p.x * self.m11 + p.y * self.m21 + p.z * self.m31 + self.m41;
         let y = p.x * self.m12 + p.y * self.m22 + p.z * self.m32 + self.m42;
@@ -613,7 +613,7 @@ where T: Copy + Clone +
     ///
     /// Assuming row vectors, this is equivalent to `p * self`
     #[inline]
-    pub fn transform_point3d(&self, p: &Point3D<T, Src>) -> Option<Point3D<T, Dst>> {
+    pub fn transform_point3d(&self, p: Point3D<T, Src>) -> Option<Point3D<T, Dst>> {
         self.transform_point3d_homogeneous(p).to_point3d()
     }
 
@@ -623,7 +623,7 @@ where T: Copy + Clone +
     ///
     /// Assuming row vectors, this is equivalent to `v * self`
     #[inline]
-    pub fn transform_vector3d(&self, v: &Vector3D<T, Src>) -> Vector3D<T, Dst> {
+    pub fn transform_vector3d(&self, v: Vector3D<T, Src>) -> Vector3D<T, Dst> {
         vec3(
             v.x * self.m11 + v.y * self.m21 + v.z * self.m31,
             v.x * self.m12 + v.y * self.m22 + v.z * self.m32,
@@ -635,10 +635,10 @@ where T: Copy + Clone +
     /// transform, if the transform makes sense for it, or `None` otherwise.
     pub fn transform_rect(&self, rect: &Rect<T, Src>) -> Option<Rect<T, Dst>> {
         Some(Rect::from_points(&[
-            self.transform_point2d(&rect.origin)?,
-            self.transform_point2d(&rect.top_right())?,
-            self.transform_point2d(&rect.bottom_left())?,
-            self.transform_point2d(&rect.bottom_right())?,
+            self.transform_point2d(rect.origin)?,
+            self.transform_point2d(rect.top_right())?,
+            self.transform_point2d(rect.bottom_left())?,
+            self.transform_point2d(rect.bottom_right())?,
         ]))
     }
 
@@ -995,8 +995,8 @@ mod tests {
         assert_eq!(t1, t2);
         assert_eq!(t1, t3);
 
-        assert_eq!(t1.transform_point3d(&point3(1.0, 1.0, 1.0)), Some(point3(2.0, 3.0, 4.0)));
-        assert_eq!(t1.transform_point2d(&point2(1.0, 1.0)), Some(point2(2.0, 3.0)));
+        assert_eq!(t1.transform_point3d(point3(1.0, 1.0, 1.0)), Some(point3(2.0, 3.0, 4.0)));
+        assert_eq!(t1.transform_point2d(point2(1.0, 1.0)), Some(point2(2.0, 3.0)));
 
         assert_eq!(t1.post_transform(&t1), Mf32::create_translation(2.0, 4.0, 6.0));
 
@@ -1012,8 +1012,8 @@ mod tests {
         assert_eq!(r1, r2);
         assert_eq!(r1, r3);
 
-        assert!(r1.transform_point3d(&point3(1.0, 2.0, 3.0)).unwrap().approx_eq(&point3(2.0, -1.0, 3.0)));
-        assert!(r1.transform_point2d(&point2(1.0, 2.0)).unwrap().approx_eq(&point2(2.0, -1.0)));
+        assert!(r1.transform_point3d(point3(1.0, 2.0, 3.0)).unwrap().approx_eq(&point3(2.0, -1.0, 3.0)));
+        assert!(r1.transform_point2d(point2(1.0, 2.0)).unwrap().approx_eq(&point2(2.0, -1.0)));
 
         assert!(r1.post_transform(&r1).approx_eq(&Mf32::create_rotation(0.0, 0.0, 1.0, rad(FRAC_PI_2*2.0))));
 
@@ -1029,8 +1029,8 @@ mod tests {
         assert_eq!(s1, s2);
         assert_eq!(s1, s3);
 
-        assert!(s1.transform_point3d(&point3(2.0, 2.0, 2.0)).unwrap().approx_eq(&point3(4.0, 6.0, 8.0)));
-        assert!(s1.transform_point2d(&point2(2.0, 2.0)).unwrap().approx_eq(&point2(4.0, 6.0)));
+        assert!(s1.transform_point3d(point3(2.0, 2.0, 2.0)).unwrap().approx_eq(&point3(4.0, 6.0, 8.0)));
+        assert!(s1.transform_point2d(point2(2.0, 2.0)).unwrap().approx_eq(&point2(4.0, 6.0)));
 
         assert_eq!(s1.post_transform(&s1), Mf32::create_scale(4.0, 9.0, 16.0));
 
@@ -1124,10 +1124,10 @@ mod tests {
         assert!(m1.pre_transform(&m2).approx_eq(&Mf32::identity()));
 
         let p1 = point2(1000.0, 2000.0);
-        let p2 = m1.transform_point2d(&p1);
+        let p2 = m1.transform_point2d(p1);
         assert_eq!(p2, Some(point2(1100.0, 2200.0)));
 
-        let p3 = m2.transform_point2d(&p2.unwrap());
+        let p3 = m2.transform_point2d(p2.unwrap());
         assert_eq!(p3, Some(p1));
     }
 
@@ -1148,13 +1148,13 @@ mod tests {
 
         let a = point3(1.0, 1.0, 1.0);
 
-        assert!(r.post_transform(&t).transform_point3d(&a).unwrap().approx_eq(&point3(3.0, 2.0, 1.0)));
-        assert!(t.post_transform(&r).transform_point3d(&a).unwrap().approx_eq(&point3(4.0, -3.0, 1.0)));
-        assert!(t.post_transform(&r).transform_point3d(&a).unwrap().approx_eq(&r.transform_point3d(&t.transform_point3d(&a).unwrap()).unwrap()));
+        assert!(r.post_transform(&t).transform_point3d(a).unwrap().approx_eq(&point3(3.0, 2.0, 1.0)));
+        assert!(t.post_transform(&r).transform_point3d(a).unwrap().approx_eq(&point3(4.0, -3.0, 1.0)));
+        assert!(t.post_transform(&r).transform_point3d(a).unwrap().approx_eq(&r.transform_point3d(t.transform_point3d(a).unwrap()).unwrap()));
 
-        assert!(r.pre_transform(&t).transform_point3d(&a).unwrap().approx_eq(&point3(4.0, -3.0, 1.0)));
-        assert!(t.pre_transform(&r).transform_point3d(&a).unwrap().approx_eq(&point3(3.0, 2.0, 1.0)));
-        assert!(t.pre_transform(&r).transform_point3d(&a).unwrap().approx_eq(&t.transform_point3d(&r.transform_point3d(&a).unwrap()).unwrap()));
+        assert!(r.pre_transform(&t).transform_point3d(a).unwrap().approx_eq(&point3(4.0, -3.0, 1.0)));
+        assert!(t.pre_transform(&r).transform_point3d(a).unwrap().approx_eq(&point3(3.0, 2.0, 1.0)));
+        assert!(t.pre_transform(&r).transform_point3d(a).unwrap().approx_eq(&t.transform_point3d(r.transform_point3d(a).unwrap()).unwrap()));
     }
 
     #[test]
@@ -1176,8 +1176,8 @@ mod tests {
                                  -2.5, 6.0, 1.0, 1.0);
 
         let p = point3(1.0, 3.0, 5.0);
-        let p1 = m2.pre_transform(&m1).transform_point3d(&p).unwrap();
-        let p2 = m2.transform_point3d(&m1.transform_point3d(&p).unwrap()).unwrap();
+        let p1 = m2.pre_transform(&m1).transform_point3d(p).unwrap();
+        let p2 = m2.transform_point3d(m1.transform_point3d(p).unwrap()).unwrap();
         assert!(p1.approx_eq(&p2));
     }
 
@@ -1194,14 +1194,14 @@ mod tests {
         // Translation does not apply to vectors.
         let m = Mf32::create_translation(1.0, 2.0, 3.0);
         let v1 = vec3(10.0, -10.0, 3.0);
-        assert_eq!(v1, m.transform_vector3d(&v1));
+        assert_eq!(v1, m.transform_vector3d(v1));
         // While it does apply to points.
-        assert_ne!(Some(v1.to_point()), m.transform_point3d(&v1.to_point()));
+        assert_ne!(Some(v1.to_point()), m.transform_point3d(v1.to_point()));
 
         // same thing with 2d vectors/points
         let v2 = vec2(10.0, -5.0);
-        assert_eq!(v2, m.transform_vector2d(&v2));
-        assert_ne!(Some(v2.to_point()), m.transform_point2d(&v2.to_point()));
+        assert_eq!(v2, m.transform_vector2d(v2));
+        assert_ne!(Some(v2.to_point()), m.transform_point2d(v2.to_point()));
     }
 
     #[test]
@@ -1232,11 +1232,11 @@ mod tests {
             -1.0, 1.0, -1.0, 2.0,
         );
         assert_eq!(
-            m.transform_point2d_homogeneous(&point2(1.0, 2.0)),
+            m.transform_point2d_homogeneous(point2(1.0, 2.0)),
             HomogeneousVector::new(6.0, 11.0, 0.0, 19.0),
         );
         assert_eq!(
-            m.transform_point3d_homogeneous(&point3(1.0, 2.0, 4.0)),
+            m.transform_point3d_homogeneous(point3(1.0, 2.0, 4.0)),
             HomogeneousVector::new(8.0, 7.0, 4.0, 15.0),
         );
     }
@@ -1245,12 +1245,12 @@ mod tests {
     pub fn test_perspective_division() {
         let p = point2(1.0, 2.0);
         let mut m = Mf32::identity();
-        assert!(m.transform_point2d(&p).is_some());
+        assert!(m.transform_point2d(p).is_some());
         m.m44 = 0.0;
-        assert_eq!(None, m.transform_point2d(&p));
+        assert_eq!(None, m.transform_point2d(p));
         m.m44 = 1.0;
         m.m24 = -1.0;
-        assert_eq!(None, m.transform_point2d(&p));
+        assert_eq!(None, m.transform_point2d(p));
     }
 
     #[cfg(feature = "mint")]

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -36,7 +36,7 @@ use serde;
 ///
 /// let scrolling = ScrollOffset::new(0, 100);
 /// let p1: ParentPoint = point2(0, 0);
-/// let p2: ChildPoint = scrolling.transform_point(&p1);
+/// let p2: ChildPoint = scrolling.transform_point(p1);
 /// ```
 ///
 #[repr(C)]
@@ -133,7 +133,7 @@ where
 {
     /// Translate a point and cast its unit.
     #[inline]
-    pub fn transform_point(&self, p: &Point2D<T, Src>) -> Point2D<T, Dst> {
+    pub fn transform_point(&self, p: Point2D<T, Src>) -> Point2D<T, Dst> {
         point2(p.x + self.x, p.y + self.y)
     }
 
@@ -141,14 +141,14 @@ where
     #[inline]
     pub fn transform_rect(&self, r: &Rect<T, Src>) -> Rect<T, Dst> {
         Rect {
-            origin: self.transform_point(&r.origin),
-            size: self.transform_size(&r.size),
+            origin: self.transform_point(r.origin),
+            size: self.transform_size(r.size),
         }
     }
 
     /// No-op, just cast the unit.
     #[inline]
-    pub fn transform_size(&self, s: &Size2D<T, Src>) -> Size2D<T, Dst> {
+    pub fn transform_size(&self, s: Size2D<T, Src>) -> Size2D<T, Dst> {
         Size2D::new(s.width, s.height)
     }
 
@@ -409,13 +409,13 @@ where
     pub fn transform_rect(&self, r: &Rect<T, Src>) -> Rect<T, Dst> {
         Rect {
             origin: self.transform_point2d(&r.origin),
-            size: self.transform_size(&r.size),
+            size: self.transform_size(r.size),
         }
     }
 
     /// No-op, just cast the unit.
     #[inline]
-    pub fn transform_size(&self, s: &Size2D<T, Src>) -> Size2D<T, Dst> {
+    pub fn transform_size(self, s: Size2D<T, Src>) -> Size2D<T, Dst> {
         Size2D::new(s.width, s.height)
     }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -183,7 +183,7 @@ impl<T: Copy, U> Vector2D<T, U> {
 
     /// Tag a unit-less value with units.
     #[inline]
-    pub fn from_untyped(p: &Vector2D<T, UnknownUnit>) -> Self {
+    pub fn from_untyped(p: Vector2D<T, UnknownUnit>) -> Self {
         vec2(p.x, p.y)
     }
 
@@ -738,7 +738,7 @@ impl<T: Copy, U> Vector3D<T, U> {
 
     /// Tag a unitless value with units.
     #[inline]
-    pub fn from_untyped(p: &Vector3D<T, UnknownUnit>) -> Self {
+    pub fn from_untyped(p: Vector3D<T, UnknownUnit>) -> Self {
         vec3(p.x, p.y, p.z)
     }
 
@@ -1171,7 +1171,7 @@ impl BoolVector2D {
     }
 
     #[inline]
-    pub fn select_point<T: Copy, U>(&self, a: &Point2D<T, U>, b: &Point2D<T, U>) -> Point2D<T, U> {
+    pub fn select_point<T: Copy, U>(&self, a: Point2D<T, U>, b: Point2D<T, U>) -> Point2D<T, U> {
         point2(
             if self.x { a.x } else { b.x },
             if self.y { a.y } else { b.y },
@@ -1179,7 +1179,7 @@ impl BoolVector2D {
     }
 
     #[inline]
-    pub fn select_vector<T: Copy, U>(&self, a: &Vector2D<T, U>, b: &Vector2D<T, U>) -> Vector2D<T, U> {
+    pub fn select_vector<T: Copy, U>(&self, a: Vector2D<T, U>, b: Vector2D<T, U>) -> Vector2D<T, U> {
         vec2(
             if self.x { a.x } else { b.x },
             if self.y { a.y } else { b.y },
@@ -1187,7 +1187,7 @@ impl BoolVector2D {
     }
 
     #[inline]
-    pub fn select_size<T: Copy, U>(&self, a: &Size2D<T, U>, b: &Size2D<T, U>) -> Size2D<T, U> {
+    pub fn select_size<T: Copy, U>(&self, a: Size2D<T, U>, b: Size2D<T, U>) -> Size2D<T, U> {
         size2(
             if self.x { a.width } else { b.width },
             if self.y { a.height } else { b.height },
@@ -1240,7 +1240,7 @@ impl BoolVector3D {
 
 
     #[inline]
-    pub fn select_point<T: Copy, U>(&self, a: &Point3D<T, U>, b: &Point3D<T, U>) -> Point3D<T, U> {
+    pub fn select_point<T: Copy, U>(&self, a: Point3D<T, U>, b: Point3D<T, U>) -> Point3D<T, U> {
         point3(
             if self.x { a.x } else { b.x },
             if self.y { a.y } else { b.y },
@@ -1249,7 +1249,7 @@ impl BoolVector3D {
     }
 
     #[inline]
-    pub fn select_vector<T: Copy, U>(&self, a: &Vector3D<T, U>, b: &Vector3D<T, U>) -> Vector3D<T, U> {
+    pub fn select_vector<T: Copy, U>(&self, a: Vector3D<T, U>, b: Vector3D<T, U>) -> Vector3D<T, U> {
         vec3(
             if self.x { a.x } else { b.x },
             if self.y { a.y } else { b.y },
@@ -1283,14 +1283,16 @@ impl BoolVector3D {
 }
 
 impl<T: PartialOrd, U> Vector2D<T, U> {
-    pub fn greater_than(&self, other: &Self) -> BoolVector2D {
+    #[inline]
+    pub fn greater_than(&self, other: Self) -> BoolVector2D {
         BoolVector2D {
             x: self.x > other.x,
             y: self.y > other.y,
         }
     }
 
-    pub fn lower_than(&self, other: &Self) -> BoolVector2D {
+    #[inline]
+    pub fn lower_than(&self, other: Self) -> BoolVector2D {
         BoolVector2D {
             x: self.x < other.x,
             y: self.y < other.y,
@@ -1300,14 +1302,16 @@ impl<T: PartialOrd, U> Vector2D<T, U> {
 
 
 impl<T: PartialEq, U> Vector2D<T, U> {
-    pub fn equal(&self, other: &Self) -> BoolVector2D {
+    #[inline]
+    pub fn equal(&self, other: Self) -> BoolVector2D {
         BoolVector2D {
             x: self.x == other.x,
             y: self.y == other.y,
         }
     }
 
-    pub fn not_equal(&self, other: &Self) -> BoolVector2D {
+    #[inline]
+    pub fn not_equal(&self, other: Self) -> BoolVector2D {
         BoolVector2D {
             x: self.x != other.x,
             y: self.y != other.y,
@@ -1316,7 +1320,8 @@ impl<T: PartialEq, U> Vector2D<T, U> {
 }
 
 impl<T: PartialOrd, U> Vector3D<T, U> {
-    pub fn greater_than(&self, other: &Self) -> BoolVector3D {
+    #[inline]
+    pub fn greater_than(&self, other: Self) -> BoolVector3D {
         BoolVector3D {
             x: self.x > other.x,
             y: self.y > other.y,
@@ -1324,7 +1329,8 @@ impl<T: PartialOrd, U> Vector3D<T, U> {
         }
     }
 
-    pub fn lower_than(&self, other: &Self) -> BoolVector3D {
+    #[inline]
+    pub fn lower_than(&self, other: Self) -> BoolVector3D {
         BoolVector3D {
             x: self.x < other.x,
             y: self.y < other.y,
@@ -1335,7 +1341,8 @@ impl<T: PartialOrd, U> Vector3D<T, U> {
 
 
 impl<T: PartialEq, U> Vector3D<T, U> {
-    pub fn equal(&self, other: &Self) -> BoolVector3D {
+    #[inline]
+    pub fn equal(&self, other: Self) -> BoolVector3D {
         BoolVector3D {
             x: self.x == other.x,
             y: self.y == other.y,
@@ -1343,7 +1350,8 @@ impl<T: PartialEq, U> Vector3D<T, U> {
         }
     }
 
-    pub fn not_equal(&self, other: &Self) -> BoolVector3D {
+    #[inline]
+    pub fn not_equal(&self, other: Self) -> BoolVector3D {
         BoolVector3D {
             x: self.x != other.x,
             y: self.y != other.y,
@@ -1629,22 +1637,22 @@ mod bool_vector {
     fn test_bvec2() {
 
         assert_eq!(
-            Vec2::new(1.0, 2.0).greater_than(&Vec2::new(2.0, 1.0)),
+            Vec2::new(1.0, 2.0).greater_than(Vec2::new(2.0, 1.0)),
             bvec2(false, true),
         );
 
         assert_eq!(
-            Vec2::new(1.0, 2.0).lower_than(&Vec2::new(2.0, 1.0)),
+            Vec2::new(1.0, 2.0).lower_than(Vec2::new(2.0, 1.0)),
             bvec2(true, false),
         );
 
         assert_eq!(
-            Vec2::new(1.0, 2.0).equal(&Vec2::new(1.0, 3.0)),
+            Vec2::new(1.0, 2.0).equal(Vec2::new(1.0, 3.0)),
             bvec2(true, false),
         );
 
         assert_eq!(
-            Vec2::new(1.0, 2.0).not_equal(&Vec2::new(1.0, 3.0)),
+            Vec2::new(1.0, 2.0).not_equal(Vec2::new(1.0, 3.0)),
             bvec2(false, true),
         );
 
@@ -1663,7 +1671,7 @@ mod bool_vector {
         assert_eq!(bvec2(true, false).or(bvec2(true, true)), bvec2(true, true));
 
         assert_eq!(
-            bvec2(true, false).select_vector(&Vec2::new(1.0, 2.0), &Vec2::new(3.0, 4.0)),
+            bvec2(true, false).select_vector(Vec2::new(1.0, 2.0), Vec2::new(3.0, 4.0)),
             Vec2::new(1.0, 4.0),
         );
     }
@@ -1672,22 +1680,22 @@ mod bool_vector {
     fn test_bvec3() {
 
         assert_eq!(
-            Vec3::new(1.0, 2.0, 3.0).greater_than(&Vec3::new(3.0, 2.0, 1.0)),
+            Vec3::new(1.0, 2.0, 3.0).greater_than(Vec3::new(3.0, 2.0, 1.0)),
             bvec3(false, false, true),
         );
 
         assert_eq!(
-            Vec3::new(1.0, 2.0, 3.0).lower_than(&Vec3::new(3.0, 2.0, 1.0)),
+            Vec3::new(1.0, 2.0, 3.0).lower_than(Vec3::new(3.0, 2.0, 1.0)),
             bvec3(true, false, false),
         );
 
         assert_eq!(
-            Vec3::new(1.0, 2.0, 3.0).equal(&Vec3::new(3.0, 2.0, 1.0)),
+            Vec3::new(1.0, 2.0, 3.0).equal(Vec3::new(3.0, 2.0, 1.0)),
             bvec3(false, true, false),
         );
 
         assert_eq!(
-            Vec3::new(1.0, 2.0, 3.0).not_equal(&Vec3::new(3.0, 2.0, 1.0)),
+            Vec3::new(1.0, 2.0, 3.0).not_equal(Vec3::new(3.0, 2.0, 1.0)),
             bvec3(true, false, true),
         );
 
@@ -1706,7 +1714,7 @@ mod bool_vector {
         assert_eq!(bvec3(true, false, false).or(bvec3(true, true, false)), bvec3(true, true, false));
 
         assert_eq!(
-            bvec3(true, false, true).select_vector(&Vec3::new(1.0, 2.0, 3.0), &Vec3::new(4.0, 5.0, 6.0)),
+            bvec3(true, false, true).select_vector(Vec3::new(1.0, 2.0, 3.0), Vec3::new(4.0, 5.0, 6.0)),
             Vec3::new(1.0, 5.0, 3.0),
         );
     }


### PR DESCRIPTION
Fixes #269. The general rule is, points, vectors, sizes and smaller things are passed by value, other types (larger ones) by reference. It's arbitrary but at least it's consistent.

Also renamed `Rotation3D`'s `rotate_*` methods into `transform_*` since all other transform types use the latter name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/358)
<!-- Reviewable:end -->
