### PR TITLE
Opt into y-down semantics by implementing a trait on the unit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,3 +120,5 @@ pub mod default {
     pub type Scale<T> = super::Scale<T, UnknownUnit, UnknownUnit>;
     pub type RigidTransform3D<T> = super::RigidTransform3D<T, UnknownUnit, UnknownUnit>;
 }
+
+pub trait YDown {}

--- a/src/transform2d.rs
+++ b/src/transform2d.rs
@@ -13,7 +13,7 @@ use super::{UnknownUnit, Angle};
 #[cfg(feature = "mint")]
 use mint;
 use num::{One, Zero};
-use point::Point2D;
+use point::{Point2D, point2};
 use vector::{Vector2D, vec2};
 use rect::Rect;
 use transform3d::Transform3D;
@@ -437,11 +437,13 @@ where T: Copy + Clone +
     #[inline]
     #[must_use]
     pub fn transform_rect(&self, rect: &Rect<T, Src>) -> Rect<T, Dst> {
+        let min = rect.min();
+        let max = rect.max();
         Rect::from_points(&[
-            self.transform_point(rect.origin),
-            self.transform_point(rect.top_right()),
-            self.transform_point(rect.bottom_left()),
-            self.transform_point(rect.bottom_right()),
+            self.transform_point(min),
+            self.transform_point(max),
+            self.transform_point(point2(max.x, min.y)),
+            self.transform_point(point2(min.x, max.y)),
         ])
     }
 

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -15,7 +15,7 @@ use homogen::HomogeneousVector;
 #[cfg(feature = "mint")]
 use mint;
 use trig::Trig;
-use point::{Point2D, Point3D};
+use point::{Point2D, point2, Point3D};
 use vector::{Vector2D, Vector3D, vec2, vec3};
 use rect::Rect;
 use transform2d::Transform2D;
@@ -634,11 +634,13 @@ where T: Copy + Clone +
     /// Returns a rectangle that encompasses the result of transforming the given rectangle by this
     /// transform, if the transform makes sense for it, or `None` otherwise.
     pub fn transform_rect(&self, rect: &Rect<T, Src>) -> Option<Rect<T, Dst>> {
+        let min = rect.min();
+        let max = rect.max();
         Some(Rect::from_points(&[
-            self.transform_point2d(rect.origin)?,
-            self.transform_point2d(rect.top_right())?,
-            self.transform_point2d(rect.bottom_left())?,
-            self.transform_point2d(rect.bottom_right())?,
+            self.transform_point2d(min)?,
+            self.transform_point2d(max)?,
+            self.transform_point2d(point2(max.x, min.y))?,
+            self.transform_point2d(point2(min.x, max.y))?,
         ]))
     }
 


### PR DESCRIPTION
Alternative to #353. 

Instead of using a global feature flag, only implement methods with names that depend on the meaning of the y-axis orientation if the unit implements the YDown trait.
The main difference is that the choice is made on a per-unit basis instead of a per-dependency basis.

The upsides are:

 - One can mix y-up and y-down units in the same crate without having some of them expose a bogus set of method names.
 - no need for an extra feature flag.

On the other hand:

 - The semantics of the y-axis are specified where the unit is declared, so it is no longer possible for a crate that is agnostic and one that wants y-down methods to interoperate with the same type. In other words, code that is agnostic to the y axis orientation, by exposing units that don't opt into `YDown` prevent all other users of these types from having y-down semantics, which is not great (but not the end of the world either).
 - By extension, the default UnknownUnit types cannot have y-down methods (or alternatively, they would be forced to always have them, but IMO that would be the wrong default).


Either way there is no intent to add y-up specific methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/361)
<!-- Reviewable:end -->
