### PR TITLE
Remove some method names that assume y pointing down

### DIFF
--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -249,8 +249,8 @@ where
     /// and applicate offsets must not be larger than the original side length.
     pub fn inner_box(&self, offsets: SideOffsets2D<T, U>) -> Self {
         Box2D {
-            min: self.min + vec2(offsets.left, offsets.top),
-            max: self.max - vec2(offsets.right, offsets.bottom),
+            min: self.min + vec2(offsets.x0, offsets.y0),
+            max: self.max - vec2(offsets.x1, offsets.y1),
         }
     }
 
@@ -259,8 +259,8 @@ where
     /// Add the offsets to all sides. The expanded box is returned.
     pub fn outer_box(&self, offsets: SideOffsets2D<T, U>) -> Self {
         Box2D {
-            min: self.min - vec2(offsets.left, offsets.top),
-            max: self.max + vec2(offsets.right, offsets.bottom),
+            min: self.min - vec2(offsets.x0, offsets.y0),
+            max: self.max + vec2(offsets.x1, offsets.y1),
         }
     }
 }

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -115,6 +115,16 @@ where
     }
 
     #[inline]
+    pub fn min(&self) -> Point2D<T, U> {
+        self.origin
+    }
+
+    #[inline]
+    pub fn max(&self) -> Point2D<T, U> {
+        self.origin + self.size
+    }
+
+    #[inline]
     pub fn max_x(&self) -> T {
         self.origin.x + self.size.width
     }
@@ -202,25 +212,10 @@ where
     }
 
     #[inline]
-    pub fn top_right(&self) -> Point2D<T, U> {
-        Point2D::new(self.max_x(), self.origin.y)
-    }
-
-    #[inline]
-    pub fn bottom_left(&self) -> Point2D<T, U> {
-        Point2D::new(self.origin.x, self.max_y())
-    }
-
-    #[inline]
-    pub fn bottom_right(&self) -> Point2D<T, U> {
-        Point2D::new(self.max_x(), self.max_y())
-    }
-
-    #[inline]
     pub fn to_box2d(&self) -> Box2D<T, U> {
         Box2D {
-            min: self.origin,
-            max: self.bottom_right(),
+            min: self.min(),
+            max: self.max(),
         }
     }
 
@@ -228,6 +223,7 @@ where
     ///
     /// Subtracts the side offsets from all sides. The horizontal and vertical
     /// offsets must not be larger than the original side length.
+    /// This method assumes y oriented downward.
     pub fn inner_rect(&self, offsets: SideOffsets2D<T, U>) -> Self {
         let rect = Rect::new(
             Point2D::new(
@@ -247,6 +243,7 @@ where
     /// Calculate the size and position of an outer rectangle.
     ///
     /// Add the offsets to all sides. The expanded rectangle is returned.
+    /// This method assumes y oriented downward.
     pub fn outer_rect(&self, offsets: SideOffsets2D<T, U>) -> Self {
         Rect::new(
             Point2D::new(
@@ -583,7 +580,7 @@ pub fn rect<T: Copy, U>(x: T, y: T, w: T, h: T) -> Rect<T, U> {
 #[cfg(test)]
 mod tests {
     use default::{Point2D, Rect, Size2D};
-    use {point2, vec2, rect};
+    use {point2, vec2, rect, size2};
     use side_offsets::SideOffsets2D;
 
     #[test]
@@ -730,7 +727,7 @@ mod tests {
 
     #[test]
     fn test_inner_outer_rect() {
-        let inner_rect: Rect<i32> = Rect::new(Point2D::new(20, 40), Size2D::new(80, 100));
+        let inner_rect = Rect::new(point2(20, 40), size2(80, 100));
         let offsets = SideOffsets2D::new(20, 10, 10, 10);
         let outer_rect = inner_rect.outer_rect(offsets);
         assert_eq!(outer_rect.origin.x, 10);

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -227,8 +227,8 @@ where
     pub fn inner_rect(&self, offsets: SideOffsets2D<T, U>) -> Self {
         let rect = Rect::new(
             Point2D::new(
-                self.origin.x + offsets.left,
-                self.origin.y + offsets.top
+                self.origin.x + offsets.x0,
+                self.origin.y + offsets.y0,
             ),
             Size2D::new(
                 self.size.width - offsets.horizontal(),
@@ -247,8 +247,8 @@ where
     pub fn outer_rect(&self, offsets: SideOffsets2D<T, U>) -> Self {
         Rect::new(
             Point2D::new(
-                self.origin.x - offsets.left,
-                self.origin.y - offsets.top
+                self.origin.x - offsets.x0,
+                self.origin.y - offsets.y0
             ),
             Size2D::new(
                 self.size.width + offsets.horizontal(),

--- a/src/side_offsets.rs
+++ b/src/side_offsets.rs
@@ -1,5 +1,5 @@
-// Copyright 2013 The Servo Project Developers. See the COPYRIGHT
-// file at the top-level directory of this distribution.
+// Copyx1 2013 The Servo Project Developers. See the COPYRIGHT
+// file at the y0-level directory of this distribution.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-//! A group of side offsets, which correspond to top/left/bottom/right for borders, padding,
+//! A group of side offsets, which correspond to y0/x0/y1/x1 for borders, padding,
 //! and margins in CSS.
 
 use length::Length;
@@ -20,16 +20,22 @@ use core::hash::{Hash};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-/// A group of 2D side offsets, which correspond to top/left/bottom/right for borders, padding,
+/// A group of 2D side offsets, which correspond to top/right/bottom/left for borders, padding,
 /// and margins in CSS, optionally tagged with a unit.
+///
+/// When assuming that the y-axis is oriented downward:
+/// - y0 corresponds to top,
+/// - x1 corresponds to right,
+/// - y1 corresponds to bottom,
+/// - x0 corresponds to left,
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(bound(serialize = "T: Serialize", deserialize = "T: Deserialize<'de>")))]
 pub struct SideOffsets2D<T, U> {
-    pub top: T,
-    pub right: T,
-    pub bottom: T,
-    pub left: T,
+    pub y0: T,
+    pub x1: T,
+    pub y1: T,
+    pub x0: T,
     #[doc(hidden)]
     pub _unit: PhantomData<U>,
 }
@@ -39,10 +45,10 @@ impl<T: Copy, U> Copy for SideOffsets2D<T, U> {}
 impl<T: Clone, U> Clone for SideOffsets2D<T, U> {
     fn clone(&self) -> Self {
         SideOffsets2D {
-            top: self.top.clone(),
-            right: self.right.clone(),
-            bottom: self.bottom.clone(),
-            left: self.left.clone(),
+            y0: self.y0.clone(),
+            x1: self.x1.clone(),
+            y1: self.y1.clone(),
+            x0: self.x0.clone(),
             _unit: PhantomData,
         }
     }
@@ -54,10 +60,10 @@ impl<T, U> PartialEq for SideOffsets2D<T, U>
     where T: PartialEq
 {
     fn eq(&self, other: &Self) -> bool {
-        self.top == other.top &&
-            self.right == other.right &&
-            self.bottom == other.bottom &&
-            self.left == other.left
+        self.y0 == other.y0 &&
+            self.x1 == other.x1 &&
+            self.y1 == other.y1 &&
+            self.x0 == other.x0
     }
 }
 
@@ -65,10 +71,10 @@ impl<T, U> Hash for SideOffsets2D<T, U>
     where T: Hash
 {
     fn hash<H: ::core::hash::Hasher>(&self, h: &mut H) {
-        self.top.hash(h);
-        self.right.hash(h);
-        self.bottom.hash(h);
-        self.left.hash(h);
+        self.x0.hash(h);
+        self.y0.hash(h);
+        self.x1.hash(h);
+        self.y1.hash(h);
     }
 }
 
@@ -77,7 +83,7 @@ impl<T: fmt::Debug, U> fmt::Debug for SideOffsets2D<T, U> {
         write!(
             f,
             "({:?},{:?},{:?},{:?})",
-            self.top, self.right, self.bottom, self.left
+            self.y0, self.x1, self.y1, self.x0
         )
     }
 }
@@ -85,10 +91,10 @@ impl<T: fmt::Debug, U> fmt::Debug for SideOffsets2D<T, U> {
 impl<T: Default, U> Default for SideOffsets2D<T, U> {
     fn default() -> Self {
         SideOffsets2D {
-            top: Default::default(),
-            right: Default::default(),
-            bottom: Default::default(),
-            left: Default::default(),
+            x0: Default::default(),
+            y0: Default::default(),
+            x1: Default::default(),
+            y1: Default::default(),
             _unit: PhantomData,
         }
     }
@@ -96,24 +102,24 @@ impl<T: Default, U> Default for SideOffsets2D<T, U> {
 
 impl<T: Copy, U> SideOffsets2D<T, U> {
     /// Constructor taking a scalar for each side.
-    pub fn new(top: T, right: T, bottom: T, left: T) -> Self {
+    pub fn new(y0: T, x1: T, y1: T, x0: T) -> Self {
         SideOffsets2D {
-            top,
-            right,
-            bottom,
-            left,
+            y0,
+            x1,
+            y1,
+            x0,
             _unit: PhantomData,
         }
     }
 
     /// Constructor taking a typed Length for each side.
     pub fn from_lengths(
-        top: Length<T, U>,
-        right: Length<T, U>,
-        bottom: Length<T, U>,
-        left: Length<T, U>,
+        y0: Length<T, U>,
+        x1: Length<T, U>,
+        y1: Length<T, U>,
+        x0: Length<T, U>,
     ) -> Self {
-        SideOffsets2D::new(top.0, right.0, bottom.0, left.0)
+        SideOffsets2D::new(x0.0, y0.0, x1.0, y1.0)
     }
 
     /// Constructor setting the same value to all sides, taking a scalar value directly.
@@ -132,11 +138,11 @@ where
     T: Add<T, Output = T> + Copy,
 {
     pub fn horizontal(&self) -> T {
-        self.left + self.right
+        self.x0 + self.x1
     }
 
     pub fn vertical(&self) -> T {
-        self.top + self.bottom
+        self.y0 + self.y1
     }
 }
 
@@ -147,10 +153,10 @@ where
     type Output = Self;
     fn add(self, other: Self) -> Self {
         SideOffsets2D::new(
-            self.top + other.top,
-            self.right + other.right,
-            self.bottom + other.bottom,
-            self.left + other.left,
+            self.y0 + other.y0,
+            self.x1 + other.x1,
+            self.y1 + other.y1,
+            self.x0 + other.x0,
         )
     }
 }

--- a/src/transform2d.rs
+++ b/src/transform2d.rs
@@ -13,7 +13,7 @@ use super::{UnknownUnit, Angle};
 #[cfg(feature = "mint")]
 use mint;
 use num::{One, Zero};
-use point::Point2D;
+use point::{Point2D, point2};
 use vector::{Vector2D, vec2};
 use rect::Rect;
 use transform3d::Transform3D;
@@ -437,11 +437,13 @@ where T: Copy + Clone +
     #[inline]
     #[must_use]
     pub fn transform_rect(&self, rect: &Rect<T, Src>) -> Rect<T, Dst> {
+        let min = rect.min();
+        let max = rect.max();
         Rect::from_points(&[
-            self.transform_point(rect.origin),
-            self.transform_point(rect.top_right()),
-            self.transform_point(rect.bottom_left()),
-            self.transform_point(rect.bottom_right()),
+            self.transform_point(min),
+            self.transform_point(max),
+            self.transform_point(point2(max.x, min.y)),
+            self.transform_point(point2(min.x, max.y)),
         ])
     }
 

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -15,7 +15,7 @@ use homogen::HomogeneousVector;
 #[cfg(feature = "mint")]
 use mint;
 use trig::Trig;
-use point::{Point2D, Point3D};
+use point::{Point2D, point2, Point3D};
 use vector::{Vector2D, Vector3D, vec2, vec3};
 use rect::Rect;
 use transform2d::Transform2D;
@@ -634,11 +634,13 @@ where T: Copy + Clone +
     /// Returns a rectangle that encompasses the result of transforming the given rectangle by this
     /// transform, if the transform makes sense for it, or `None` otherwise.
     pub fn transform_rect(&self, rect: &Rect<T, Src>) -> Option<Rect<T, Dst>> {
+        let min = rect.min();
+        let max = rect.max();
         Some(Rect::from_points(&[
-            self.transform_point2d(rect.origin)?,
-            self.transform_point2d(rect.top_right())?,
-            self.transform_point2d(rect.bottom_left())?,
-            self.transform_point2d(rect.bottom_right())?,
+            self.transform_point2d(min)?,
+            self.transform_point2d(max)?,
+            self.transform_point2d(point2(max.x, min.y))?,
+            self.transform_point2d(point2(min.x, max.y))?,
         ]))
     }
 


### PR DESCRIPTION
With this PR, the only things in euclid that dictate the direction of the y axis are:

 - `Rect::inner_rect` / `outer_rect`
 - `Box2D::inner_box` / `outer_box`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/363)
<!-- Reviewable:end -->
