### PR TITLE
Remove some Rect method names that assume y pointing down

### DIFF
--- a/src/rect.rs
+++ b/src/rect.rs
@@ -115,6 +115,16 @@ where
     }
 
     #[inline]
+    pub fn min(&self) -> Point2D<T, U> {
+        self.origin
+    }
+
+    #[inline]
+    pub fn max(&self) -> Point2D<T, U> {
+        self.origin + self.size
+    }
+
+    #[inline]
     pub fn max_x(&self) -> T {
         self.origin.x + self.size.width
     }
@@ -202,25 +212,10 @@ where
     }
 
     #[inline]
-    pub fn top_right(&self) -> Point2D<T, U> {
-        Point2D::new(self.max_x(), self.origin.y)
-    }
-
-    #[inline]
-    pub fn bottom_left(&self) -> Point2D<T, U> {
-        Point2D::new(self.origin.x, self.max_y())
-    }
-
-    #[inline]
-    pub fn bottom_right(&self) -> Point2D<T, U> {
-        Point2D::new(self.max_x(), self.max_y())
-    }
-
-    #[inline]
     pub fn to_box2d(&self) -> Box2D<T, U> {
         Box2D {
-            min: self.origin,
-            max: self.bottom_right(),
+            min: self.min(),
+            max: self.max(),
         }
     }
 
@@ -228,6 +223,7 @@ where
     ///
     /// Subtracts the side offsets from all sides. The horizontal and vertical
     /// offsets must not be larger than the original side length.
+    /// This method assumes y oriented downward.
     pub fn inner_rect(&self, offsets: SideOffsets2D<T, U>) -> Self {
         let rect = Rect::new(
             Point2D::new(
@@ -247,6 +243,7 @@ where
     /// Calculate the size and position of an outer rectangle.
     ///
     /// Add the offsets to all sides. The expanded rectangle is returned.
+    /// This method assumes y oriented downward.
     pub fn outer_rect(&self, offsets: SideOffsets2D<T, U>) -> Self {
         Rect::new(
             Point2D::new(
@@ -583,7 +580,7 @@ pub fn rect<T: Copy, U>(x: T, y: T, w: T, h: T) -> Rect<T, U> {
 #[cfg(test)]
 mod tests {
     use default::{Point2D, Rect, Size2D};
-    use {point2, vec2, rect};
+    use {point2, vec2, rect, size2};
     use side_offsets::SideOffsets2D;
 
     #[test]
@@ -730,7 +727,7 @@ mod tests {
 
     #[test]
     fn test_inner_outer_rect() {
-        let inner_rect: Rect<i32> = Rect::new(Point2D::new(20, 40), Size2D::new(80, 100));
+        let inner_rect = Rect::new(point2(20, 40), size2(80, 100));
         let offsets = SideOffsets2D::new(20, 10, 10, 10);
         let outer_rect = inner_rect.outer_rect(offsets);
         assert_eq!(outer_rect.origin.x, 10);

--- a/src/transform2d.rs
+++ b/src/transform2d.rs
@@ -13,7 +13,7 @@ use super::{UnknownUnit, Angle};
 #[cfg(feature = "mint")]
 use mint;
 use num::{One, Zero};
-use point::Point2D;
+use point::{Point2D, point2};
 use vector::{Vector2D, vec2};
 use rect::Rect;
 use transform3d::Transform3D;
@@ -437,11 +437,13 @@ where T: Copy + Clone +
     #[inline]
     #[must_use]
     pub fn transform_rect(&self, rect: &Rect<T, Src>) -> Rect<T, Dst> {
+        let min = rect.min();
+        let max = rect.max();
         Rect::from_points(&[
-            self.transform_point(rect.origin),
-            self.transform_point(rect.top_right()),
-            self.transform_point(rect.bottom_left()),
-            self.transform_point(rect.bottom_right()),
+            self.transform_point(min),
+            self.transform_point(max),
+            self.transform_point(point2(max.x, min.y)),
+            self.transform_point(point2(min.x, max.y)),
         ])
     }
 

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -15,7 +15,7 @@ use homogen::HomogeneousVector;
 #[cfg(feature = "mint")]
 use mint;
 use trig::Trig;
-use point::{Point2D, Point3D};
+use point::{Point2D, point2, Point3D};
 use vector::{Vector2D, Vector3D, vec2, vec3};
 use rect::Rect;
 use transform2d::Transform2D;
@@ -634,11 +634,13 @@ where T: Copy + Clone +
     /// Returns a rectangle that encompasses the result of transforming the given rectangle by this
     /// transform, if the transform makes sense for it, or `None` otherwise.
     pub fn transform_rect(&self, rect: &Rect<T, Src>) -> Option<Rect<T, Dst>> {
+        let min = rect.min();
+        let max = rect.max();
         Some(Rect::from_points(&[
-            self.transform_point2d(rect.origin)?,
-            self.transform_point2d(rect.top_right())?,
-            self.transform_point2d(rect.bottom_left())?,
-            self.transform_point2d(rect.bottom_right())?,
+            self.transform_point2d(min)?,
+            self.transform_point2d(max)?,
+            self.transform_point2d(point2(max.x, min.y))?,
+            self.transform_point2d(point2(min.x, max.y))?,
         ]))
     }
 


### PR DESCRIPTION
The first (uncontroversial) part of #363. This removes `Rect::to_right` and similar methods but leaves SideOffsets untouched.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/364)
<!-- Reviewable:end -->
