### PR TITLE
Version 0.20.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.19.10"
+version = "0.20.0"
 authors = ["The Servo Project Developers"]
 description = "Geometry primitives"
 documentation = "https://docs.rs/euclid/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,4 @@ serde = { version = "1.0", features = ["serde_derive"], optional = true }
 mint = {version = "0.5.1", optional = true}
 
 [dev-dependencies]
-rand = "0.4"
 serde_test = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,6 @@ extern crate serde;
 pub extern crate mint;
 extern crate num_traits;
 #[cfg(test)]
-extern crate rand;
-#[cfg(test)]
 use std as core;
 
 pub use box2d::Box2D;


### PR DESCRIPTION
The majority of the planned breaking changes are in.
Version 0.21 will probably follow soon with the matrix convention changes, but It'd be nice to update WebRender before that to avoid the complication of updating webrender for both the matrix changes and all of the API breaks that landed recently.

Also removed the rand dependency as it looks like it isn't used anywhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/365)
<!-- Reviewable:end -->
