### PR TITLE
Make most constructors const fns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 
 rust:
-  - 1.23.0
+  - 1.31.0
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.20.1"
+version = "0.20.2"
 authors = ["The Servo Project Developers"]
 description = "Geometry primitives"
 documentation = "https://docs.rs/euclid/"

--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -75,7 +75,7 @@ impl<T: fmt::Display, U> fmt::Display for Box2D<T, U> {
 
 impl<T, U> Box2D<T, U> {
     /// Constructor.
-    pub fn new(min: Point2D<T, U>, max: Point2D<T, U>) -> Self {
+    pub const fn new(min: Point2D<T, U>, max: Point2D<T, U>) -> Self {
         Box2D {
             min,
             max,

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -73,7 +73,7 @@ impl<T: fmt::Display, U> fmt::Display for Box3D<T, U> {
 
 impl<T, U> Box3D<T, U> {
     /// Constructor.
-    pub fn new(min: Point3D<T, U>, max: Point3D<T, U>) -> Self {
+    pub const fn new(min: Point3D<T, U>, max: Point3D<T, U>) -> Self {
         Box3D {
             min,
             max,

--- a/src/homogen.rs
+++ b/src/homogen.rs
@@ -93,7 +93,7 @@ impl<T, U> Hash for HomogeneousVector<T, U>
 impl<T, U> HomogeneousVector<T, U> {
     /// Constructor taking scalar values directly.
     #[inline]
-    pub fn new(x: T, y: T, z: T, w: T) -> Self {
+    pub const fn new(x: T, y: T, z: T, w: T) -> Self {
         HomogeneousVector { x, y, z, w, _unit: PhantomData }
     }
 }

--- a/src/length.rs
+++ b/src/length.rs
@@ -75,7 +75,7 @@ where
 }
 
 impl<T, Unit> Length<T, Unit> {
-    pub fn new(x: T) -> Self {
+    pub const fn new(x: T) -> Self {
         Length(x, PhantomData)
     }
 }

--- a/src/point.rs
+++ b/src/point.rs
@@ -130,7 +130,7 @@ impl<T: Default, U> Default for Point2D<T, U> {
 impl<T, U> Point2D<T, U> {
     /// Constructor taking scalar values directly.
     #[inline]
-    pub fn new(x: T, y: T) -> Self {
+    pub const fn new(x: T, y: T) -> Self {
         Point2D {
             x,
             y,
@@ -607,10 +607,10 @@ impl<T: Copy + Default, U> Default for Point3D<T, U> {
     }
 }
 
-impl<T: Copy, U> Point3D<T, U> {
+impl<T, U> Point3D<T, U> {
     /// Constructor taking scalar values directly.
     #[inline]
-    pub fn new(x: T, y: T, z: T) -> Self {
+    pub const fn new(x: T, y: T, z: T) -> Self {
         Point3D {
             x,
             y,
@@ -618,7 +618,9 @@ impl<T: Copy, U> Point3D<T, U> {
             _unit: PhantomData,
         }
     }
+}
 
+impl<T: Copy, U> Point3D<T, U> {
     /// Constructor taking properly  Lengths instead of scalar values.
     #[inline]
     pub fn from_lengths(x: Length<T, U>, y: Length<T, U>, z: Length<T, U>) -> Self {
@@ -950,7 +952,7 @@ impl<T: Copy, U> From<(T, T, T)> for Point3D<T, U> {
 }
 
 #[inline]
-pub fn point2<T: Copy, U>(x: T, y: T) -> Point2D<T, U> {
+pub const fn point2<T, U>(x: T, y: T) -> Point2D<T, U> {
     Point2D {
         x,
         y,
@@ -959,7 +961,7 @@ pub fn point2<T: Copy, U>(x: T, y: T) -> Point2D<T, U> {
 }
 
 #[inline]
-pub fn point3<T: Copy, U>(x: T, y: T, z: T) -> Point3D<T, U> {
+pub const fn point3<T, U>(x: T, y: T, z: T) -> Point3D<T, U> {
     Point3D {
         x,
         y,

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -81,7 +81,7 @@ impl<T: Default, U> Default for Rect<T, U> {
 
 impl<T, U> Rect<T, U> {
     /// Constructor.
-    pub fn new(origin: Point2D<T, U>, size: Size2D<T, U>) -> Self {
+    pub const fn new(origin: Point2D<T, U>, size: Size2D<T, U>) -> Self {
         Rect {
             origin,
             size,
@@ -573,7 +573,7 @@ where T: Copy + Zero
 }
 
 /// Shorthand for `Rect::new(Point2D::new(x, y), Size2D::new(w, h))`.
-pub fn rect<T: Copy, U>(x: T, y: T, w: T, h: T) -> Rect<T, U> {
+pub const fn rect<T, U>(x: T, y: T, w: T, h: T) -> Rect<T, U> {
     Rect::new(Point2D::new(x, y), Size2D::new(w, h))
 }
 

--- a/src/rigid.rs
+++ b/src/rigid.rs
@@ -23,16 +23,18 @@ pub struct RigidTransform3D<T, Src, Dst> {
 // i.e. a vector `v` is transformed with `v * T`, and if you want to apply `T1`
 // before `T2` you use `T1 * T2`
 
-impl<T: Float + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
+impl<T, Src, Dst> RigidTransform3D<T, Src, Dst> {
     /// Construct a new rigid transformation, where the `rotation` applies first
     #[inline]
-    pub fn new(rotation: Rotation3D<T, Src, Dst>, translation: Vector3D<T, Dst>) -> Self {
+    pub const fn new(rotation: Rotation3D<T, Src, Dst>, translation: Vector3D<T, Dst>) -> Self {
         Self {
             rotation,
             translation,
         }
     }
+}
 
+impl<T: Float + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
     /// Construct an identity transform
     #[inline]
     pub fn identity() -> Self {

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -43,7 +43,7 @@ use {Point2D, Rect, Size2D, Vector2D};
 pub struct Scale<T, Src, Dst>(pub T, #[doc(hidden)] pub PhantomData<(Src, Dst)>);
 
 impl<T, Src, Dst> Scale<T, Src, Dst> {
-    pub fn new(x: T) -> Self {
+    pub const fn new(x: T) -> Self {
         Scale(x, PhantomData)
     }
 }

--- a/src/side_offsets.rs
+++ b/src/side_offsets.rs
@@ -94,9 +94,9 @@ impl<T: Default, U> Default for SideOffsets2D<T, U> {
     }
 }
 
-impl<T: Copy, U> SideOffsets2D<T, U> {
+impl<T, U> SideOffsets2D<T, U> {
     /// Constructor taking a scalar for each side.
-    pub fn new(top: T, right: T, bottom: T, left: T) -> Self {
+    pub const fn new(top: T, right: T, bottom: T, left: T) -> Self {
         SideOffsets2D {
             top,
             right,
@@ -105,7 +105,9 @@ impl<T: Copy, U> SideOffsets2D<T, U> {
             _unit: PhantomData,
         }
     }
+}
 
+impl<T: Copy, U> SideOffsets2D<T, U> {
     /// Constructor taking a typed Length for each side.
     pub fn from_lengths(
         top: Length<T, U>,

--- a/src/size.rs
+++ b/src/size.rs
@@ -108,7 +108,7 @@ impl<T: Default, U> Default for Size2D<T, U> {
 
 impl<T, U> Size2D<T, U> {
     /// Constructor taking scalar values.
-    pub fn new(width: T, height: T) -> Self {
+    pub const fn new(width: T, height: T) -> Self {
         Size2D {
             width,
             height,
@@ -409,7 +409,7 @@ impl<T: Float, U> Size2D<T, U> {
 
 
 /// Shorthand for `Size2D::new(w, h)`.
-pub fn size2<T, U>(w: T, h: T) -> Size2D<T, U> {
+pub const fn size2<T, U>(w: T, h: T) -> Size2D<T, U> {
     Size2D::new(w, h)
 }
 
@@ -614,7 +614,7 @@ impl<T: Default, U> Default for Size3D<T, U> {
 
 impl<T, U> Size3D<T, U> {
     /// Constructor taking scalar values.
-    pub fn new(width: T, height: T, depth: T) -> Self {
+    pub const fn new(width: T, height: T, depth: T) -> Self {
         Size3D {
             width,
             height,
@@ -918,7 +918,7 @@ impl<T: Float, U> Size3D<T, U> {
 
 
 /// Shorthand for `Size3D::new(w, h, d)`.
-pub fn size3<T, U>(w: T, h: T, d: T) -> Size3D<T, U> {
+pub const fn size3<T, U>(w: T, h: T, d: T) -> Size3D<T, U> {
     Size3D::new(w, h, d)
 }
 

--- a/src/transform2d.rs
+++ b/src/transform2d.rs
@@ -132,13 +132,13 @@ impl<T, Src, Dst> Hash for Transform2D<T, Src, Dst>
     }
 }
 
-impl<T: Copy, Src, Dst> Transform2D<T, Src, Dst> {
+impl<T, Src, Dst> Transform2D<T, Src, Dst> {
     /// Create a transform specifying its matrix elements in row-major order.
     ///
     /// Beware: This library is written with the assumption that row vectors
     /// are being used. If your matrices use column vectors (i.e. transforming a vector
     /// is `T * v`), then please use `column_major`
-    pub fn row_major(m11: T, m12: T, m21: T, m22: T, m31: T, m32: T) -> Self {
+    pub const fn row_major(m11: T, m12: T, m21: T, m22: T, m31: T, m32: T) -> Self {
         Transform2D {
             m11, m12,
             m21, m22,
@@ -152,7 +152,7 @@ impl<T: Copy, Src, Dst> Transform2D<T, Src, Dst> {
     /// Beware: This library is written with the assumption that row vectors
     /// are being used. If your matrices use column vectors (i.e. transforming a vector
     /// is `T * v`), then please use `row_major`
-    pub fn column_major(m11: T, m21: T, m31: T, m12: T, m22: T, m32: T) -> Self {
+    pub const fn column_major(m11: T, m21: T, m31: T, m12: T, m22: T, m32: T) -> Self {
         Transform2D {
             m11, m12,
             m21, m22,
@@ -160,7 +160,9 @@ impl<T: Copy, Src, Dst> Transform2D<T, Src, Dst> {
             _unit: PhantomData,
         }
     }
+}
 
+impl<T: Copy, Src, Dst> Transform2D<T, Src, Dst> {
     /// Returns an array containing this transform's terms in row-major order (the order
     /// in which the transform is actually laid out in memory).
     ///

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -179,7 +179,7 @@ impl<T, Src, Dst> Transform3D<T, Src, Dst> {
     /// is `T * v`), then please use `column_major`
     #[inline]
     #[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
-    pub fn row_major(
+    pub const fn row_major(
             m11: T, m12: T, m13: T, m14: T,
             m21: T, m22: T, m23: T, m24: T,
             m31: T, m32: T, m33: T, m34: T,
@@ -204,7 +204,7 @@ impl<T, Src, Dst> Transform3D<T, Src, Dst> {
     /// is `T * v`), then please use `row_major`
     #[inline]
     #[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
-    pub fn column_major(
+    pub const fn column_major(
             m11: T, m21: T, m31: T, m41: T,
             m12: T, m22: T, m32: T, m42: T,
             m13: T, m23: T, m33: T, m43: T,

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -83,7 +83,7 @@ impl<T, Src, Dst> Hash for Translation2D<T, Src, Dst>
 
 impl<T, Src, Dst> Translation2D<T, Src, Dst> {
     #[inline]
-    pub fn new(x: T, y: T) -> Self {
+    pub const fn new(x: T, y: T) -> Self {
         Translation2D {
             x,
             y,
@@ -363,7 +363,7 @@ impl<T, Src, Dst> Hash for Translation3D<T, Src, Dst>
 
 impl<T, Src, Dst> Translation3D<T, Src, Dst> {
     #[inline]
-    pub fn new(x: T, y: T, z: T) -> Self {
+    pub const fn new(x: T, y: T, z: T) -> Self {
         Translation3D {
             x,
             y,

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -129,7 +129,7 @@ impl<T: Default, U> Default for Vector2D<T, U> {
 impl<T, U> Vector2D<T, U> {
     /// Constructor taking scalar values directly.
     #[inline]
-    pub fn new(x: T, y: T) -> Self {
+    pub const fn new(x: T, y: T) -> Self {
         Vector2D {
             x,
             y,
@@ -677,7 +677,7 @@ impl<T: Default, U> Default for Vector3D<T, U> {
 impl<T, U> Vector3D<T, U> {
     /// Constructor taking scalar values directly.
     #[inline]
-    pub fn new(x: T, y: T, z: T) -> Self {
+    pub const fn new(x: T, y: T, z: T) -> Self {
         Vector3D {
             x,
             y,


### PR DESCRIPTION
This will make declaring constant points, sizes, etc. quite a bit nicer.

Currently const fns only accept one trait bound (Sized), so some constructors that required Copy and other traits were moved to their own `impl` block to require no trait bounds.
Also `Rotation2D::new(Angle<T>)` could not be made const because const fns can't destroy values (even if Angle does not implement Drop). This could work if the rotation stored an `Angle<T>` instead of a `T` directly which also makes sense regardless of the appeal of const fn. It wasn't worth the breaking change but it could be something we sneak in the next breaking changes when we address the matrix conventions for example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/368)
<!-- Reviewable:end -->
