### PR TITLE
Implement actual support for no_std

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rust:
 env:
   - FEATURES=""
   - FEATURES="--features serde"
+  - FEATURES="--no-default-features --features libm"
 
 matrix:
   include:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ std = ["num-traits/std"]
 libm = ["num-traits/libm"]
 
 [dependencies]
-num-traits = { git = "https://github.com/rust-num/num-traits", default-features = false }
+num-traits = { version = "0.2.10", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["serde_derive"], optional = true }
 mint = {version = "0.5.1", optional = true}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,14 @@ categories = ["science"]
 license = "MIT / Apache-2.0"
 
 [features]
+default = ["std"]
 unstable = []
+std = ["num-traits/std"]
+libm = ["num-traits/libm"]
 
 [dependencies]
-num-traits = { version = "0.2" }
-serde = { version = "1.0", features = ["serde_derive"], optional = true }
+num-traits = { git = "https://github.com/rust-num/num-traits", default-features = false }
+serde = { version = "1.0", default-features = false, features = ["serde_derive"], optional = true }
 mint = {version = "0.5.1", optional = true}
 
 [dev-dependencies]

--- a/src/approxeq.rs
+++ b/src/approxeq.rs
@@ -15,20 +15,22 @@ pub trait ApproxEq<Eps> {
 }
 
 macro_rules! approx_eq {
-    ($ty:ty, $eps:expr) => (
+    ($ty:ty, $eps:expr) => {
         impl ApproxEq<$ty> for $ty {
             #[inline]
-            fn approx_epsilon() -> $ty { $eps }
+            fn approx_epsilon() -> $ty {
+                $eps
+            }
             #[inline]
             fn approx_eq(&self, other: &$ty) -> bool {
                 self.approx_eq_eps(other, &$eps)
             }
             #[inline]
             fn approx_eq_eps(&self, other: &$ty, approx_epsilon: &$ty) -> bool {
-                (*self - *other).abs() < *approx_epsilon
+                num_traits::Float::abs(*self - *other) < *approx_epsilon
             }
         }
-    )
+    };
 }
 
 approx_eq!(f32, 1.0e-6);

--- a/src/num.rs
+++ b/src/num.rs
@@ -41,36 +41,48 @@ pub trait Ceil: Copy {
 }
 
 macro_rules! num_int {
-    ($ty:ty) => (
+    ($ty:ty) => {
         impl Round for $ty {
             #[inline]
-            fn round(self) -> $ty { self }
+            fn round(self) -> $ty {
+                self
+            }
         }
         impl Floor for $ty {
             #[inline]
-            fn floor(self) -> $ty { self }
+            fn floor(self) -> $ty {
+                self
+            }
         }
         impl Ceil for $ty {
             #[inline]
-            fn ceil(self) -> $ty { self }
+            fn ceil(self) -> $ty {
+                self
+            }
         }
-    )
+    };
 }
 macro_rules! num_float {
-    ($ty:ty) => (
+    ($ty:ty) => {
         impl Round for $ty {
             #[inline]
-            fn round(self) -> $ty { self.round() }
+            fn round(self) -> $ty {
+                num_traits::Float::round(self)
+            }
         }
         impl Floor for $ty {
             #[inline]
-            fn floor(self) -> $ty { self.floor() }
+            fn floor(self) -> $ty {
+                num_traits::Float::floor(self)
+            }
         }
         impl Ceil for $ty {
             #[inline]
-            fn ceil(self) -> $ty { self.ceil() }
+            fn ceil(self) -> $ty {
+                num_traits::Float::ceil(self)
+            }
         }
-    )
+    };
 }
 
 num_int!(i16);

--- a/src/trig.rs
+++ b/src/trig.rs
@@ -18,14 +18,20 @@ pub trait Trig {
 }
 
 macro_rules! trig {
-    ($ty:ident) => (
+    ($ty:ident) => {
         impl Trig for $ty {
             #[inline]
-            fn sin(self) -> $ty { self.sin() }
+            fn sin(self) -> $ty {
+                num_traits::Float::sin(self)
+            }
             #[inline]
-            fn cos(self) -> $ty { self.cos() }
+            fn cos(self) -> $ty {
+                num_traits::Float::cos(self)
+            }
             #[inline]
-            fn tan(self) -> $ty { self.tan() }
+            fn tan(self) -> $ty {
+                num_traits::Float::tan(self)
+            }
 
             /// A slightly faster approximation of `atan2`.
             ///
@@ -38,11 +44,12 @@ macro_rules! trig {
 
                 // See https://math.stackexchange.com/questions/1098487/atan2-faster-approximation#1105038
                 use core::$ty::consts;
-                let x_abs = x.abs();
-                let y_abs = y.abs();
+                let x_abs = num_traits::Float::abs(x);
+                let y_abs = num_traits::Float::abs(y);
                 let a = x_abs.min(y_abs) / x_abs.max(y_abs);
                 let s = a * a;
-                let mut result = ((-0.046_496_474_9 * s + 0.159_314_22) * s - 0.327_622_764) * s * a + a;
+                let mut result =
+                    ((-0.046_496_474_9 * s + 0.159_314_22) * s - 0.327_622_764) * s * a + a;
                 if y_abs > x_abs {
                     result = consts::FRAC_PI_2 - result;
                 }
@@ -66,7 +73,7 @@ macro_rules! trig {
                 rad.to_degrees()
             }
         }
-    )
+    };
 }
 
 trig!(f32);


### PR DESCRIPTION
With num-traits having recently gained full support for no_std by using the libm crate, this crate can now fully support no_std as well without any sacrifices.

Currently num-traits has not released a new version yet, so this uses a git dependency until then.

Additionally the tests should fail at the moment when using the libm, as there actually was a bug in libm, but I have created a PR for it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servo/euclid/372)
<!-- Reviewable:end -->
