### PR TITLE
Add `cast_unit` to the rest of the basic geometric types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.20.3"
+version = "0.20.4"
 authors = ["The Servo Project Developers"]
 description = "Geometry primitives"
 documentation = "https://docs.rs/euclid/"

--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -472,6 +472,11 @@ where
             Point2D::from_untyped(c.max),
         )
     }
+
+    /// Cast the unit
+    pub fn cast_unit<V>(&self) -> Box2D<T, V> {
+        Box2D::new(self.min.cast_unit(), self.max.cast_unit())
+    }
 }
 
 impl<T0, Unit> Box2D<T0, Unit>

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -470,6 +470,11 @@ where
             max: Point3D::from_untyped(c.max),
         }
     }
+
+    /// Cast the unit
+    pub fn cast_unit<V>(&self) -> Box3D<T, V> {
+        Box3D::new(self.min.cast_unit(), self.max.cast_unit())
+    }
 }
 
 impl<T0, Unit> Box3D<T0, Unit>

--- a/src/length.rs
+++ b/src/length.rs
@@ -84,6 +84,11 @@ impl<Unit, T: Clone> Length<T, Unit> {
     pub fn get(&self) -> T {
         self.0.clone()
     }
+
+    /// Cast the unit
+    pub fn cast_unit<V>(&self) -> Length<T, V> {
+        Length::new(self.0.clone())
+    }
 }
 
 impl<T: fmt::Debug + Clone, U> fmt::Debug for Length<T, U> {

--- a/src/point.rs
+++ b/src/point.rs
@@ -182,6 +182,11 @@ impl<T: Copy, U> Point2D<T, U> {
         point2(p.x, p.y)
     }
 
+    /// Cast the unit
+    pub fn cast_unit<V>(&self) -> Point2D<T, V> {
+        point2(self.x, self.y)
+    }
+
     #[inline]
     pub fn to_array(&self) -> [T; 2] {
         [self.x, self.y]
@@ -678,6 +683,11 @@ impl<T: Copy, U> Point3D<T, U> {
     #[inline]
     pub fn from_untyped(p: Point3D<T, UnknownUnit>) -> Self {
         point3(p.x, p.y, p.z)
+    }
+
+    /// Cast the unit
+    pub fn cast_unit<V>(&self) -> Point3D<T, V> {
+        point3(self.x, self.y, self.z)
     }
 
     /// Convert into a 2d point.

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -451,6 +451,11 @@ impl<T: Copy, Unit> Rect<T, Unit> {
             Size2D::from_untyped(r.size),
         )
     }
+
+    /// Cast the unit
+    pub fn cast_unit<V>(&self) -> Rect<T, V> {
+        Rect::new(self.origin.cast_unit(), self.size.cast_unit())
+    }
 }
 
 impl<T0: NumCast + Copy, Unit> Rect<T0, Unit> {

--- a/src/size.rs
+++ b/src/size.rs
@@ -265,6 +265,11 @@ impl<T: Copy, U> Size2D<T, U> {
     pub fn from_untyped(p: Size2D<T, UnknownUnit>) -> Self {
         Size2D::new(p.width, p.height)
     }
+
+    /// Cast the unit
+    pub fn cast_unit<V>(&self) -> Size2D<T, V> {
+        Size2D::new(self.width, self.height)
+    }
 }
 
 impl<T: NumCast + Copy, Unit> Size2D<T, Unit> {
@@ -776,6 +781,11 @@ impl<T: Copy, U> Size3D<T, U> {
     /// Tag a unitless value with units.
     pub fn from_untyped(p: Size3D<T, UnknownUnit>) -> Self {
         Size3D::new(p.width, p.height, p.depth)
+    }
+
+    /// Cast the unit
+    pub fn cast_unit<V>(&self) -> Size3D<T, V> {
+        Size3D::new(self.width, self.height, self.depth)
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -815,6 +815,11 @@ impl<T: Copy, U> Vector3D<T, U> {
         vec3(p.x, p.y, p.z)
     }
 
+    /// Cast the unit
+    pub fn cast_unit<V>(&self) -> Vector3D<T, V> {
+        vec3(self.x, self.y, self.z)
+    }
+
     /// Convert into a 2d vector.
     #[inline]
     pub fn to_2d(&self) -> Vector2D<T, U> {


### PR DESCRIPTION
This is much more convenient than `X::from_untyped(x.to_untyped())`, and previously only existed on `Vector2D`.

The implementation on `Vector2D` is marked `#[inline]` but it doesn't seem like it needs to be since it is generic in the unit?  Not sure if that has any effect there?  I left the others without `#[inline]` but I can change it if you'd like.