### PR TITLE
Version 0.20.5.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.20.4"
+version = "0.20.5"
 authors = ["The Servo Project Developers"]
 description = "Geometry primitives"
 documentation = "https://docs.rs/euclid/"


### PR DESCRIPTION
Contains the `pre_scale` fix from #377.