### PR TITLE
Fix Box2D/Box3D::from_points.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.20.6"
+version = "0.20.7"
 authors = ["The Servo Project Developers"]
 description = "Geometry primitives"
 documentation = "https://docs.rs/euclid/"

--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -288,37 +288,25 @@ where
     {
         let mut points = points.into_iter();
 
-        // Need at least 2 different points for a valid box (ie: volume > 0).
         let (mut min_x, mut min_y) = match points.next() {
             Some(first) => (first.borrow().x, first.borrow().y),
             None => return Box2D::zero(),
         };
+
         let (mut max_x, mut max_y) = (min_x, min_y);
-
-        {
-            let mut assign_min_max = |point: I::Item| {
-                let p = point.borrow();
-                if p.x < min_x {
-                    min_x = p.x
-                }
-                if p.x > max_x {
-                    max_x = p.x
-                }
-                if p.y < min_y {
-                    min_y = p.y
-                }
-                if p.y > max_y {
-                    max_y = p.y
-                }
-            };
-
-            match points.next() {
-                Some(second) => assign_min_max(second),
-                None => return Box2D::zero(),
+        for point in points {
+            let p = point.borrow();
+            if p.x < min_x {
+                min_x = p.x
             }
-
-            for point in points {
-                assign_min_max(point);
+            if p.x > max_x {
+                max_x = p.x
+            }
+            if p.y < min_y {
+                min_y = p.y
+            }
+            if p.y > max_y {
+                max_y = p.y
             }
         }
 

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -10,7 +10,7 @@
 use super::UnknownUnit;
 use scale::Scale;
 use num::*;
-use point::Point3D;
+use point::{Point3D, point3};
 use vector::Vector3D;
 use size::Size3D;
 use approxord::{min, max};
@@ -263,47 +263,38 @@ where
     {
         let mut points = points.into_iter();
 
-        // Need at least 2 different points for a valid box3d (ie: volume > 0).
         let (mut min_x, mut min_y, mut min_z) = match points.next() {
             Some(first) => (first.borrow().x, first.borrow().y, first.borrow().z),
             None => return Box3D::zero(),
         };
         let (mut max_x, mut max_y, mut max_z) = (min_x, min_y, min_z);
 
-        {
-            let mut assign_min_max = |point: I::Item| {
-                let p = point.borrow();
-                if p.x < min_x {
-                    min_x = p.x
-                }
-                if p.x > max_x {
-                    max_x = p.x
-                }
-                if p.y < min_y {
-                    min_y = p.y
-                }
-                if p.y > max_y {
-                    max_y = p.y
-                }
-                if p.z < min_z {
-                    min_z = p.z
-                }
-                if p.z > max_z {
-                    max_z = p.z
-                }
-            };
-                    
-            match points.next() {
-                Some(second) => assign_min_max(second),
-                None => return Box3D::zero(),
+        for point in points {
+            let p = point.borrow();
+            if p.x < min_x {
+                min_x = p.x
             }
-
-            for point in points {
-                assign_min_max(point);
+            if p.x > max_x {
+                max_x = p.x
+            }
+            if p.y < min_y {
+                min_y = p.y
+            }
+            if p.y > max_y {
+                max_y = p.y
+            }
+            if p.z < min_z {
+                min_z = p.z
+            }
+            if p.z > max_z {
+                max_z = p.z
             }
         }
 
-        Self::new(Point3D::new(min_x, min_y, min_z), Point3D::new(max_x, max_y, max_z))
+        Box3D {
+            min: point3(min_x, min_y, min_z),
+            max: point3(max_x, max_y, max_z),
+        }
     }
 }
 


### PR DESCRIPTION
The behavior of returning Box2D::zero() when a single point is passed was unintuitive and inconsistent with the behavior previoulsy established in Rect::from_points (to return an empty rect at the position of the single point).

Fixes #390.