### PR TITLE
Relax some type requirements

### DIFF
--- a/src/angle.rs
+++ b/src/angle.rs
@@ -115,33 +115,33 @@ where
     }
 }
 
-impl<T: Clone + Add<T, Output = T>> Add for Angle<T> {
+impl<T: Add<T, Output = T>> Add for Angle<T> {
     type Output = Angle<T>;
     fn add(self, other: Angle<T>) -> Angle<T> {
         Angle::radians(self.radians + other.radians)
     }
 }
 
-impl<T: Clone + AddAssign<T>> AddAssign for Angle<T> {
+impl<T: AddAssign<T>> AddAssign for Angle<T> {
     fn add_assign(&mut self, other: Angle<T>) {
         self.radians += other.radians;
     }
 }
 
-impl<T: Clone + Sub<T, Output = T>> Sub<Angle<T>> for Angle<T> {
+impl<T: Sub<T, Output = T>> Sub<Angle<T>> for Angle<T> {
     type Output = Angle<T>;
     fn sub(self, other: Angle<T>) -> <Self as Sub>::Output {
         Angle::radians(self.radians - other.radians)
     }
 }
 
-impl<T: Clone + SubAssign<T>> SubAssign for Angle<T> {
+impl<T: SubAssign<T>> SubAssign for Angle<T> {
     fn sub_assign(&mut self, other: Angle<T>) {
         self.radians -= other.radians;
     }
 }
 
-impl<T: Clone + Div<T, Output = T>> Div<Angle<T>> for Angle<T> {
+impl<T: Div<T, Output = T>> Div<Angle<T>> for Angle<T> {
     type Output = T;
     #[inline]
     fn div(self, other: Angle<T>) -> T {
@@ -149,7 +149,7 @@ impl<T: Clone + Div<T, Output = T>> Div<Angle<T>> for Angle<T> {
     }
 }
 
-impl<T: Clone + Div<T, Output = T>> Div<T> for Angle<T> {
+impl<T: Div<T, Output = T>> Div<T> for Angle<T> {
     type Output = Angle<T>;
     #[inline]
     fn div(self, factor: T) -> Angle<T> {
@@ -157,13 +157,13 @@ impl<T: Clone + Div<T, Output = T>> Div<T> for Angle<T> {
     }
 }
 
-impl<T: Clone + DivAssign<T>> DivAssign<T> for Angle<T> {
+impl<T: DivAssign<T>> DivAssign<T> for Angle<T> {
     fn div_assign(&mut self, factor: T) {
         self.radians /= factor;
     }
 }
 
-impl<T: Clone + Mul<T, Output = T>> Mul<T> for Angle<T> {
+impl<T: Mul<T, Output = T>> Mul<T> for Angle<T> {
     type Output = Angle<T>;
     #[inline]
     fn mul(self, factor: T) -> Angle<T> {
@@ -171,7 +171,7 @@ impl<T: Clone + Mul<T, Output = T>> Mul<T> for Angle<T> {
     }
 }
 
-impl<T: Clone + MulAssign<T>> MulAssign<T> for Angle<T> {
+impl<T: MulAssign<T>> MulAssign<T> for Angle<T> {
     fn mul_assign(&mut self, factor: T) {
         self.radians *= factor;
     }

--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -47,9 +47,9 @@ impl<T: Hash, U> Hash for Box2D<T, U> {
 
 impl<T: Copy, U> Copy for Box2D<T, U> {}
 
-impl<T: Copy, U> Clone for Box2D<T, U> {
+impl<T: Clone, U> Clone for Box2D<T, U> {
     fn clone(&self) -> Self {
-        *self
+        Self::new(self.min.clone(), self.max.clone())
     }
 }
 
@@ -75,6 +75,7 @@ impl<T: fmt::Display, U> fmt::Display for Box2D<T, U> {
 
 impl<T, U> Box2D<T, U> {
     /// Constructor.
+    #[inline]
     pub const fn new(min: Point2D<T, U>, max: Point2D<T, U>) -> Self {
         Box2D {
             min,

--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -385,7 +385,7 @@ where
 
 impl<T, U> Box2D<T, U>
 where
-    T: Copy + Zero,
+    T: Zero,
 {
     /// Constructor, setting all sides to zero.
     pub fn zero() -> Self {
@@ -480,7 +480,7 @@ where
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using round(), round_in or round_out() before casting.
-    pub fn cast<T1: NumCast + Copy>(&self) -> Box2D<T1, Unit> {
+    pub fn cast<T1: NumCast>(&self) -> Box2D<T1, Unit> {
         Box2D::new(
             self.min.cast(),
             self.max.cast(),
@@ -492,7 +492,7 @@ where
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using round(), round_in or round_out() before casting.
-    pub fn try_cast<T1: NumCast + Copy>(&self) -> Option<Box2D<T1, Unit>> {
+    pub fn try_cast<T1: NumCast>(&self) -> Option<Box2D<T1, Unit>> {
         match (self.min.try_cast(), self.max.try_cast()) {
             (Some(a), Some(b)) => Some(Box2D::new(a, b)),
             _ => None,

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -96,7 +96,7 @@ where
 
 impl<T, U> Box3D<T, U>
 where
-    T: Copy + PartialOrd,
+    T: PartialOrd,
 {
     /// Returns true if the box has a negative volume.
     ///
@@ -114,15 +114,6 @@ where
     }
 
     #[inline]
-    pub fn to_non_empty(&self) -> Option<NonEmpty<Self>> {
-        if self.is_empty_or_negative() {
-            return None;
-        }
-
-        Some(NonEmpty(*self))
-    }
-
-    #[inline]
     pub fn intersects(&self, other: &Self) -> bool {
         self.min.x < other.max.x
             && self.max.x > other.min.x
@@ -130,6 +121,41 @@ where
             && self.max.y > other.min.y
             && self.min.z < other.max.z
             && self.max.z > other.min.z
+    }
+
+    /// Returns `true` if this box3d contains the point. Points are considered
+    /// in the box3d if they are on the front, left or top faces, but outside if they
+    /// are on the back, right or bottom faces.
+    #[inline]
+    pub fn contains(&self, other: Point3D<T, U>) -> bool {
+        self.min.x <= other.x && other.x < self.max.x
+            && self.min.y <= other.y && other.y < self.max.y
+            && self.min.z <= other.z && other.z < self.max.z
+    }
+
+    /// Returns `true` if this box3d contains the interior of the other box3d. Always
+    /// returns `true` if other is empty, and always returns `false` if other is
+    /// nonempty but this box3d is empty.
+    #[inline]
+    pub fn contains_box(&self, other: &Self) -> bool {
+        other.is_empty_or_negative()
+            || (self.min.x <= other.min.x && other.max.x <= self.max.x
+                && self.min.y <= other.min.y && other.max.y <= self.max.y
+                && self.min.z <= other.min.z && other.max.z <= self.max.z)
+    }
+}
+
+impl<T, U> Box3D<T, U>
+where
+    T: Copy + PartialOrd,
+{
+    #[inline]
+    pub fn to_non_empty(&self) -> Option<NonEmpty<Self>> {
+        if self.is_empty_or_negative() {
+            return None;
+        }
+
+        Some(NonEmpty(*self))
     }
 
     #[inline]
@@ -173,37 +199,6 @@ where
             min: self.min + by,
             max: self.max + by,
         }
-    }
-}
-
-impl<T, U> Box3D<T, U>
-where
-    T: Copy + PartialOrd + Zero,
-{
-    /// Returns true if this box3d contains the point. Points are considered
-    /// in the box3d if they are on the front, left or top faces, but outside if they
-    /// are on the back, right or bottom faces.
-    #[inline]
-    pub fn contains(&self, other: Point3D<T, U>) -> bool {
-        self.min.x <= other.x && other.x < self.max.x
-            && self.min.y <= other.y && other.y < self.max.y
-            && self.min.z <= other.z && other.z < self.max.z
-    }
-}
-
-impl<T, U> Box3D<T, U>
-where
-    T: Copy + PartialOrd + Zero + Sub<T, Output = T>,
-{
-    /// Returns true if this box3d contains the interior of the other box3d. Always
-    /// returns true if other is empty, and always returns false if other is
-    /// nonempty but this box3d is empty.
-    #[inline]
-    pub fn contains_box(&self, other: &Self) -> bool {
-        other.is_empty_or_negative()
-            || (self.min.x <= other.min.x && other.max.x <= self.max.x
-                && self.min.y <= other.min.y && other.max.y <= self.max.y
-                && self.min.z <= other.min.z && other.max.z <= self.max.z)
     }
 }
 

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -32,7 +32,7 @@ use core::ops::{Add, Div, Mul, Sub};
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(bound(serialize = "T: Serialize", deserialize = "T: Deserialize<'de>")))]
 pub struct Box3D<T, U> {
-    pub min: Point3D<T, U>, 
+    pub min: Point3D<T, U>,
     pub max: Point3D<T, U>,
 }
 
@@ -155,7 +155,7 @@ where
         );
 
         Box3D::new(
-            intersection_min, 
+            intersection_min,
             intersection_max,
         )
     }
@@ -326,7 +326,7 @@ where
 
 impl<T, U> Box3D<T, U>
 where
-    T: Copy + Clone + PartialOrd + Add<T, Output = T> + Sub<T, Output = T> + Zero,
+    T: Copy + PartialOrd + Add<T, Output = T> + Sub<T, Output = T> + Zero,
 {
     #[inline]
     pub fn union(&self, other: &Self) -> Self {
@@ -390,7 +390,7 @@ where
     }
 }
 
-impl<T, U> Box3D<T, U> 
+impl<T, U> Box3D<T, U>
 where
     T: Copy + Zero,
 {
@@ -606,7 +606,7 @@ impl<T: NumCast + Copy, Unit> Box3D<T, Unit> {
 }
 
 impl<T, U> From<Size3D<T, U>> for Box3D<T, U>
-where 
+where
     T: Copy + Zero + PartialOrd,
 {
     fn from(b: Size3D<T, U>) -> Self {
@@ -789,7 +789,7 @@ mod tests {
         let b1 = Box3D::from_points(&[point3(-15.0, -20.0, -20.0), point3(10.0, 20.0, 20.0)]);
         let b2 = Box3D::from_points(&[point3(-10.0, 20.0, 20.0), point3(15.0, -20.0, -20.0)]);
         assert!(b1.try_intersection(&b2).is_some());
-    
+
         let b1 = Box3D::from_points(&[point3(-15.0, -20.0, -20.0), point3(-10.0, 20.0, 20.0)]);
         let b2 = Box3D::from_points(&[point3(10.0, 20.0, 20.0), point3(15.0, -20.0, -20.0)]);
         assert!(b1.try_intersection(&b2).is_none());

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -45,9 +45,9 @@ impl<T: Hash, U> Hash for Box3D<T, U> {
 
 impl<T: Copy, U> Copy for Box3D<T, U> {}
 
-impl<T: Copy, U> Clone for Box3D<T, U> {
+impl<T: Clone, U> Clone for Box3D<T, U> {
     fn clone(&self) -> Self {
-        *self
+        Self::new(self.min.clone(), self.max.clone())
     }
 }
 
@@ -73,6 +73,7 @@ impl<T: fmt::Display, U> fmt::Display for Box3D<T, U> {
 
 impl<T, U> Box3D<T, U> {
     /// Constructor.
+    #[inline]
     pub const fn new(min: Point3D<T, U>, max: Point3D<T, U>) -> Self {
         Box3D {
             min,

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -387,7 +387,7 @@ where
 
 impl<T, U> Box3D<T, U>
 where
-    T: Copy + Zero,
+    T: Zero,
 {
     /// Constructor, setting all sides to zero.
     pub fn zero() -> Self {
@@ -487,7 +487,7 @@ where
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using round(), round_in or round_out() before casting.
-    pub fn cast<T1: NumCast + Copy>(&self) -> Box3D<T1, Unit> {
+    pub fn cast<T1: NumCast>(&self) -> Box3D<T1, Unit> {
         Box3D::new(
             self.min.cast(),
             self.max.cast(),
@@ -499,7 +499,7 @@ where
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using round(), round_in or round_out() before casting.
-    pub fn try_cast<T1: NumCast + Copy>(&self) -> Option<Box3D<T1, Unit>> {
+    pub fn try_cast<T1: NumCast>(&self) -> Option<Box3D<T1, Unit>> {
         match (self.min.try_cast(), self.max.try_cast()) {
             (Some(a), Some(b)) => Some(Box3D::new(a, b)),
             _ => None,

--- a/src/length.rs
+++ b/src/length.rs
@@ -170,11 +170,11 @@ impl<Src, Dst, T: Div<T, Output = T>> Div<Length<T, Src>> for Length<T, Dst> {
 }
 
 // length * scalar
-impl<T: Copy + Mul<T, Output = T>, U> Mul<T> for Length<T, U> {
+impl<T: Mul<T, Output = T>, U> Mul<T> for Length<T, U> {
     type Output = Self;
     #[inline]
     fn mul(self, scale: T) -> Self {
-        Length::new(self.get() * scale)
+        Length::new(self.0 * scale)
     }
 }
 
@@ -187,11 +187,11 @@ impl<T: Copy + Mul<T, Output = T>, U> MulAssign<T> for Length<T, U> {
 }
 
 // length / scalar
-impl<T: Copy + Div<T, Output = T>, U> Div<T> for Length<T, U> {
+impl<T: Div<T, Output = T>, U> Div<T> for Length<T, U> {
     type Output = Self;
     #[inline]
     fn div(self, scale: T) -> Self {
-        Length::new(self.get() / scale)
+        Length::new(self.0 / scale)
     }
 }
 

--- a/src/length.rs
+++ b/src/length.rs
@@ -92,15 +92,15 @@ impl<Unit, T: Clone> Length<T, Unit> {
     }
 }
 
-impl<T: fmt::Debug + Clone, U> fmt::Debug for Length<T, U> {
+impl<T: fmt::Debug, U> fmt::Debug for Length<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.get().fmt(f)
+        self.0.fmt(f)
     }
 }
 
-impl<T: fmt::Display + Clone, U> fmt::Display for Length<T, U> {
+impl<T: fmt::Display, U> fmt::Display for Length<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.get().fmt(f)
+        self.0.fmt(f)
     }
 }
 
@@ -120,52 +120,52 @@ impl<T, U> Hash for Length<T, U>
 }
 
 // length + length
-impl<U, T: Clone + Add<T, Output = T>> Add for Length<T, U> {
+impl<U, T: Add<T, Output = T>> Add for Length<T, U> {
     type Output = Length<T, U>;
     fn add(self, other: Length<T, U>) -> Length<T, U> {
-        Length::new(self.get() + other.get())
+        Length::new(self.0 + other.0)
     }
 }
 
 // length += length
-impl<U, T: Clone + AddAssign<T>> AddAssign for Length<T, U> {
+impl<U, T: AddAssign<T>> AddAssign for Length<T, U> {
     fn add_assign(&mut self, other: Length<T, U>) {
-        self.0 += other.get();
+        self.0 += other.0;
     }
 }
 
 // length - length
-impl<U, T: Clone + Sub<T, Output = T>> Sub<Length<T, U>> for Length<T, U> {
+impl<U, T: Sub<T, Output = T>> Sub<Length<T, U>> for Length<T, U> {
     type Output = Length<T, U>;
     fn sub(self, other: Length<T, U>) -> <Self as Sub>::Output {
-        Length::new(self.get() - other.get())
+        Length::new(self.0 - other.0)
     }
 }
 
 // length -= length
-impl<U, T: Clone + SubAssign<T>> SubAssign for Length<T, U> {
+impl<U, T: SubAssign<T>> SubAssign for Length<T, U> {
     fn sub_assign(&mut self, other: Length<T, U>) {
-        self.0 -= other.get();
+        self.0 -= other.0;
     }
 }
 
 // Saturating length + length and length - length.
-impl<U, T: Clone + Saturating> Saturating for Length<T, U> {
+impl<U, T: Saturating> Saturating for Length<T, U> {
     fn saturating_add(self, other: Length<T, U>) -> Length<T, U> {
-        Length::new(self.get().saturating_add(other.get()))
+        Length::new(self.0.saturating_add(other.0))
     }
 
     fn saturating_sub(self, other: Length<T, U>) -> Length<T, U> {
-        Length::new(self.get().saturating_sub(other.get()))
+        Length::new(self.0.saturating_sub(other.0))
     }
 }
 
 // length / length
-impl<Src, Dst, T: Clone + Div<T, Output = T>> Div<Length<T, Src>> for Length<T, Dst> {
+impl<Src, Dst, T: Div<T, Output = T>> Div<Length<T, Src>> for Length<T, Dst> {
     type Output = Scale<T, Src, Dst>;
     #[inline]
     fn div(self, other: Length<T, Src>) -> Scale<T, Src, Dst> {
-        Scale::new(self.get() / other.get())
+        Scale::new(self.0 / other.0)
     }
 }
 
@@ -204,61 +204,61 @@ impl<T: Copy + Div<T, Output = T>, U> DivAssign<T> for Length<T, U> {
 }
 
 // length * scaleFactor
-impl<Src, Dst, T: Clone + Mul<T, Output = T>> Mul<Scale<T, Src, Dst>> for Length<T, Src> {
+impl<Src, Dst, T: Mul<T, Output = T>> Mul<Scale<T, Src, Dst>> for Length<T, Src> {
     type Output = Length<T, Dst>;
     #[inline]
     fn mul(self, scale: Scale<T, Src, Dst>) -> Length<T, Dst> {
-        Length::new(self.get() * scale.get())
+        Length::new(self.0 * scale.0)
     }
 }
 
 // length / scaleFactor
-impl<Src, Dst, T: Clone + Div<T, Output = T>> Div<Scale<T, Src, Dst>> for Length<T, Dst> {
+impl<Src, Dst, T: Div<T, Output = T>> Div<Scale<T, Src, Dst>> for Length<T, Dst> {
     type Output = Length<T, Src>;
     #[inline]
     fn div(self, scale: Scale<T, Src, Dst>) -> Length<T, Src> {
-        Length::new(self.get() / scale.get())
+        Length::new(self.0 / scale.0)
     }
 }
 
 // -length
-impl<U, T: Clone + Neg<Output = T>> Neg for Length<T, U> {
+impl<U, T: Neg<Output = T>> Neg for Length<T, U> {
     type Output = Length<T, U>;
     #[inline]
     fn neg(self) -> Length<T, U> {
-        Length::new(-self.get())
+        Length::new(-self.0)
     }
 }
 
 impl<Unit, T0: NumCast + Clone> Length<T0, Unit> {
     /// Cast from one numeric representation to another, preserving the units.
-    pub fn cast<T1: NumCast + Clone>(&self) -> Length<T1, Unit> {
+    pub fn cast<T1: NumCast>(&self) -> Length<T1, Unit> {
         self.try_cast().unwrap()
     }
 
     /// Fallible cast from one numeric representation to another, preserving the units.
-    pub fn try_cast<T1: NumCast + Clone>(&self) -> Option<Length<T1, Unit>> {
+    pub fn try_cast<T1: NumCast>(&self) -> Option<Length<T1, Unit>> {
         NumCast::from(self.get()).map(Length::new)
     }
 }
 
-impl<Unit, T: Clone + PartialEq> PartialEq for Length<T, Unit> {
+impl<Unit, T: PartialEq> PartialEq for Length<T, Unit> {
     fn eq(&self, other: &Self) -> bool {
-        self.get().eq(&other.get())
+        self.0.eq(&other.0)
     }
 }
 
-impl<Unit, T: Clone + PartialOrd> PartialOrd for Length<T, Unit> {
+impl<Unit, T: PartialOrd> PartialOrd for Length<T, Unit> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.get().partial_cmp(&other.get())
+        self.0.partial_cmp(&other.0)
     }
 }
 
-impl<Unit, T: Clone + Eq> Eq for Length<T, Unit> {}
+impl<Unit, T: Eq> Eq for Length<T, Unit> {}
 
-impl<Unit, T: Clone + Ord> Ord for Length<T, Unit> {
+impl<Unit, T: Ord> Ord for Length<T, Unit> {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.get().cmp(&other.get())
+        self.0.cmp(&other.0)
     }
 }
 

--- a/src/nonempty.rs
+++ b/src/nonempty.rs
@@ -1,6 +1,5 @@
 use {Rect, Box2D, Box3D, Vector2D, Vector3D, size2, point2, point3};
 use approxord::{min, max};
-use num::Zero;
 use core::ops::Deref;
 use core::ops::{Add, Sub};
 use core::cmp::{PartialEq};
@@ -27,7 +26,7 @@ impl<T> NonEmpty<T> {
 
 impl<T, U> NonEmpty<Rect<T, U>>
 where
-    T: Copy + Zero + PartialOrd + PartialEq + Add<T, Output = T> + Sub<T, Output = T>,
+    T: Copy + PartialOrd + Add<T, Output = T> + Sub<T, Output = T>,
 {
     #[inline]
     pub fn union(&self, other: &NonEmpty<Rect<T, U>>) -> NonEmpty<Rect<T, U>> {

--- a/src/nonempty.rs
+++ b/src/nonempty.rs
@@ -27,7 +27,7 @@ impl<T> NonEmpty<T> {
 
 impl<T, U> NonEmpty<Rect<T, U>>
 where
-    T: Copy + Clone + Zero + PartialOrd + PartialEq + Add<T, Output = T> + Sub<T, Output = T>,
+    T: Copy + Zero + PartialOrd + PartialEq + Add<T, Output = T> + Sub<T, Output = T>,
 {
     #[inline]
     pub fn union(&self, other: &NonEmpty<Rect<T, U>>) -> NonEmpty<Rect<T, U>> {

--- a/src/point.rs
+++ b/src/point.rs
@@ -463,21 +463,21 @@ impl<T: Copy + ApproxEq<T>, U> ApproxEq<Point2D<T, U>> for Point2D<T, U> {
     }
 }
 
-impl<T: Copy, U> Into<[T; 2]> for Point2D<T, U> {
+impl<T, U> Into<[T; 2]> for Point2D<T, U> {
     fn into(self) -> [T; 2] {
-        self.to_array()
+        [self.x, self.y]
     }
 }
 
-impl<T: Copy, U> From<[T; 2]> for Point2D<T, U> {
-    fn from(array: [T; 2]) -> Self {
-        point2(array[0], array[1])
+impl<T, U> From<[T; 2]> for Point2D<T, U> {
+    fn from([x, y]: [T; 2]) -> Self {
+        point2(x, y)
     }
 }
 
-impl<T: Copy, U> Into<(T, T)> for Point2D<T, U> {
+impl<T, U> Into<(T, T)> for Point2D<T, U> {
     fn into(self) -> (T, T) {
-        self.to_tuple()
+        (self.x, self.y)
     }
 }
 
@@ -943,21 +943,21 @@ impl<T: Copy + ApproxEq<T>, U> ApproxEq<Point3D<T, U>> for Point3D<T, U> {
     }
 }
 
-impl<T: Copy, U> Into<[T; 3]> for Point3D<T, U> {
+impl<T, U> Into<[T; 3]> for Point3D<T, U> {
     fn into(self) -> [T; 3] {
-        self.to_array()
+        [self.x, self.y, self.z]
     }
 }
 
-impl<T: Copy, U> From<[T; 3]> for Point3D<T, U> {
-    fn from(array: [T; 3]) -> Self {
-        point3(array[0], array[1], array[2])
+impl<T, U> From<[T; 3]> for Point3D<T, U> {
+    fn from([x, y, z]: [T; 3]) -> Self {
+        point3(x, y, z)
     }
 }
 
-impl<T: Copy, U> Into<(T, T, T)> for Point3D<T, U> {
+impl<T, U> Into<(T, T, T)> for Point3D<T, U> {
     fn into(self) -> (T, T, T) {
-        self.to_tuple()
+        (self.x, self.y, self.z)
     }
 }
 

--- a/src/point.rs
+++ b/src/point.rs
@@ -90,7 +90,7 @@ impl<T, U> Hash for Point2D<T, U>
 
 mint_vec!(Point2D[x, y] = Point2);
 
-impl<T: Copy + Zero, U> Point2D<T, U> {
+impl<T: Zero, U> Point2D<T, U> {
     /// Constructor, setting all components to zero.
     #[inline]
     pub fn origin() -> Self {
@@ -101,7 +101,9 @@ impl<T: Copy + Zero, U> Point2D<T, U> {
     pub fn zero() -> Self {
         Self::origin()
     }
+}
 
+impl<T: Copy + Zero, U> Point2D<T, U> {
     /// Convert into a 3d point.
     #[inline]
     pub fn to_3d(&self) -> Point3D<T, U> {
@@ -137,15 +139,21 @@ impl<T, U> Point2D<T, U> {
             _unit: PhantomData,
         }
     }
-}
 
-impl<T: Copy, U> Point2D<T, U> {
-    /// Constructor taking properly  Lengths instead of scalar values.
+    /// Constructor taking properly Lengths instead of scalar values.
     #[inline]
     pub fn from_lengths(x: Length<T, U>, y: Length<T, U>) -> Self {
         point2(x.0, y.0)
     }
 
+    /// Tag a unitless value with units.
+    #[inline]
+    pub fn from_untyped(p: Point2D<T, UnknownUnit>) -> Self {
+        point2(p.x, p.y)
+    }
+}
+
+impl<T: Copy, U> Point2D<T, U> {
     /// Create a 3d point from this one, using the specified z value.
     #[inline]
     pub fn extend(&self, z: T) -> Point3D<T, U> {
@@ -174,12 +182,6 @@ impl<T: Copy, U> Point2D<T, U> {
     #[inline]
     pub fn to_untyped(&self) -> Point2D<T, UnknownUnit> {
         point2(self.x, self.y)
-    }
-
-    /// Tag a unitless value with units.
-    #[inline]
-    pub fn from_untyped(p: Point2D<T, UnknownUnit>) -> Self {
-        point2(p.x, p.y)
     }
 
     /// Cast the unit
@@ -553,7 +555,7 @@ impl<T, U> Hash for Point3D<T, U>
     }
 }
 
-impl<T: Copy + Zero, U> Point3D<T, U> {
+impl<T: Zero, U> Point3D<T, U> {
     /// Constructor, setting all components to zero.
     #[inline]
     pub fn origin() -> Self {
@@ -625,15 +627,21 @@ impl<T, U> Point3D<T, U> {
             _unit: PhantomData,
         }
     }
-}
 
-impl<T: Copy, U> Point3D<T, U> {
-    /// Constructor taking properly  Lengths instead of scalar values.
+    /// Constructor taking properly Lengths instead of scalar values.
     #[inline]
     pub fn from_lengths(x: Length<T, U>, y: Length<T, U>, z: Length<T, U>) -> Self {
         point3(x.0, y.0, z.0)
     }
 
+    /// Tag a unitless value with units.
+    #[inline]
+    pub fn from_untyped(p: Point3D<T, UnknownUnit>) -> Self {
+        point3(p.x, p.y, p.z)
+    }
+}
+
+impl<T: Copy, U> Point3D<T, U> {
     /// Cast this point into a vector.
     ///
     /// Equivalent to subtracting the origin to this point.
@@ -681,12 +689,6 @@ impl<T: Copy, U> Point3D<T, U> {
     #[inline]
     pub fn to_untyped(&self) -> Point3D<T, UnknownUnit> {
         point3(self.x, self.y, self.z)
-    }
-
-    /// Tag a unitless value with units.
-    #[inline]
-    pub fn from_untyped(p: Point3D<T, UnknownUnit>) -> Self {
-        point3(p.x, p.y, p.z)
     }
 
     /// Cast the unit

--- a/src/point.rs
+++ b/src/point.rs
@@ -209,7 +209,7 @@ impl<T: Copy + Add<T, Output = T>, U> Point2D<T, U> {
     }
 }
 
-impl<T: Copy + Add<T, Output = T>, U> Add<Size2D<T, U>> for Point2D<T, U> {
+impl<T: Add<T, Output = T>, U> Add<Size2D<T, U>> for Point2D<T, U> {
     type Output = Self;
     #[inline]
     fn add(self, other: Size2D<T, U>) -> Self {
@@ -231,7 +231,7 @@ impl<T: Copy + Sub<T, Output = T>, U> SubAssign<Vector2D<T, U>> for Point2D<T, U
     }
 }
 
-impl<T: Copy + Add<T, Output = T>, U> Add<Vector2D<T, U>> for Point2D<T, U> {
+impl<T: Add<T, Output = T>, U> Add<Vector2D<T, U>> for Point2D<T, U> {
     type Output = Self;
     #[inline]
     fn add(self, other: Vector2D<T, U>) -> Self {
@@ -239,7 +239,7 @@ impl<T: Copy + Add<T, Output = T>, U> Add<Vector2D<T, U>> for Point2D<T, U> {
     }
 }
 
-impl<T: Copy + Sub<T, Output = T>, U> Sub for Point2D<T, U> {
+impl<T: Sub<T, Output = T>, U> Sub for Point2D<T, U> {
     type Output = Vector2D<T, U>;
     #[inline]
     fn sub(self, other: Self) -> Vector2D<T, U> {
@@ -247,7 +247,7 @@ impl<T: Copy + Sub<T, Output = T>, U> Sub for Point2D<T, U> {
     }
 }
 
-impl<T: Copy + Sub<T, Output = T>, U> Sub<Vector2D<T, U>> for Point2D<T, U> {
+impl<T: Sub<T, Output = T>, U> Sub<Vector2D<T, U>> for Point2D<T, U> {
     type Output = Self;
     #[inline]
     fn sub(self, other: Vector2D<T, U>) -> Self {
@@ -361,7 +361,7 @@ impl<T: NumCast + Copy, U> Point2D<T, U> {
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
     #[inline]
-    pub fn cast<NewT: NumCast + Copy>(&self) -> Point2D<NewT, U> {
+    pub fn cast<NewT: NumCast>(&self) -> Point2D<NewT, U> {
         self.try_cast().unwrap()
     }
 
@@ -370,7 +370,7 @@ impl<T: NumCast + Copy, U> Point2D<T, U> {
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
-    pub fn try_cast<NewT: NumCast + Copy>(&self) -> Option<Point2D<NewT, U>> {
+    pub fn try_cast<NewT: NumCast>(&self) -> Option<Point2D<NewT, U>> {
         match (NumCast::from(self.x), NumCast::from(self.y)) {
             (Some(x), Some(y)) => Some(point2(x, y)),
             _ => None,
@@ -446,7 +446,7 @@ where
     }
 }
 
-impl<T: Copy + ApproxEq<T>, U> ApproxEq<Point2D<T, U>> for Point2D<T, U> {
+impl<T: ApproxEq<T>, U> ApproxEq<Point2D<T, U>> for Point2D<T, U> {
     #[inline]
     fn approx_epsilon() -> Self {
         point2(T::approx_epsilon(), T::approx_epsilon())
@@ -481,7 +481,7 @@ impl<T, U> Into<(T, T)> for Point2D<T, U> {
     }
 }
 
-impl<T: Copy, U> From<(T, T)> for Point2D<T, U> {
+impl<T, U> From<(T, T)> for Point2D<T, U> {
     fn from(tuple: (T, T)) -> Self {
         point2(tuple.0, tuple.1)
     }
@@ -610,7 +610,7 @@ impl<T: fmt::Display, U> fmt::Display for Point3D<T, U> {
     }
 }
 
-impl<T: Copy + Default, U> Default for Point3D<T, U> {
+impl<T: Default, U> Default for Point3D<T, U> {
     fn default() -> Self {
         Point3D::new(Default::default(), Default::default(), Default::default())
     }
@@ -724,7 +724,7 @@ impl<T: Copy + Sub<T, Output = T>, U> SubAssign<Vector3D<T, U>> for Point3D<T, U
     }
 }
 
-impl<T: Copy + Add<T, Output = T>, U> Add<Vector3D<T, U>> for Point3D<T, U> {
+impl<T: Add<T, Output = T>, U> Add<Vector3D<T, U>> for Point3D<T, U> {
     type Output = Self;
     #[inline]
     fn add(self, other: Vector3D<T, U>) -> Self {
@@ -732,7 +732,7 @@ impl<T: Copy + Add<T, Output = T>, U> Add<Vector3D<T, U>> for Point3D<T, U> {
     }
 }
 
-impl<T: Copy + Sub<T, Output = T>, U> Sub for Point3D<T, U> {
+impl<T: Sub<T, Output = T>, U> Sub for Point3D<T, U> {
     type Output = Vector3D<T, U>;
     #[inline]
     fn sub(self, other: Self) -> Vector3D<T, U> {
@@ -740,7 +740,7 @@ impl<T: Copy + Sub<T, Output = T>, U> Sub for Point3D<T, U> {
     }
 }
 
-impl<T: Copy + Sub<T, Output = T>, U> Sub<Vector3D<T, U>> for Point3D<T, U> {
+impl<T: Sub<T, Output = T>, U> Sub<Vector3D<T, U>> for Point3D<T, U> {
     type Output = Self;
     #[inline]
     fn sub(self, other: Vector3D<T, U>) -> Self {
@@ -845,7 +845,7 @@ impl<T: NumCast + Copy, U> Point3D<T, U> {
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
     #[inline]
-    pub fn cast<NewT: NumCast + Copy>(&self) -> Point3D<NewT, U> {
+    pub fn cast<NewT: NumCast>(&self) -> Point3D<NewT, U> {
         self.try_cast().unwrap()
     }
 
@@ -855,7 +855,7 @@ impl<T: NumCast + Copy, U> Point3D<T, U> {
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
     #[inline]
-    pub fn try_cast<NewT: NumCast + Copy>(&self) -> Option<Point3D<NewT, U>> {
+    pub fn try_cast<NewT: NumCast>(&self) -> Option<Point3D<NewT, U>> {
         match (
             NumCast::from(self.x),
             NumCast::from(self.y),
@@ -921,7 +921,7 @@ impl<T: NumCast + Copy, U> Point3D<T, U> {
     }
 }
 
-impl<T: Copy + ApproxEq<T>, U> ApproxEq<Point3D<T, U>> for Point3D<T, U> {
+impl<T: ApproxEq<T>, U> ApproxEq<Point3D<T, U>> for Point3D<T, U> {
     #[inline]
     fn approx_epsilon() -> Self {
         point3(
@@ -961,7 +961,7 @@ impl<T, U> Into<(T, T, T)> for Point3D<T, U> {
     }
 }
 
-impl<T: Copy, U> From<(T, T, T)> for Point3D<T, U> {
+impl<T, U> From<(T, T, T)> for Point3D<T, U> {
     fn from(tuple: (T, T, T)) -> Self {
         point3(tuple.0, tuple.1, tuple.2)
     }

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -104,7 +104,7 @@ where
 
 impl<T, U> Rect<T, U>
 where
-    T: Copy + Clone + PartialOrd + PartialEq + Add<T, Output = T> + Sub<T, Output = T>,
+    T: Copy + PartialOrd + PartialEq + Add<T, Output = T> + Sub<T, Output = T>,
 {
     #[inline]
     pub fn intersects(&self, other: &Self) -> bool {
@@ -222,7 +222,7 @@ where
 
 impl<T, U> Rect<T, U>
 where
-    T: Copy + Clone + Zero + PartialOrd + PartialEq + Add<T, Output = T> + Sub<T, Output = T>,
+    T: Copy + Zero + PartialOrd + PartialEq + Add<T, Output = T> + Sub<T, Output = T>,
 {
     /// Returns true if this rectangle contains the interior of rect. Always
     /// returns true if rect is empty, and always returns false if rect is
@@ -344,7 +344,7 @@ where
 
 impl<T, U> Rect<T, U>
 where
-    T: Copy + Clone + PartialOrd + Add<T, Output = T> + Sub<T, Output = T> + Zero,
+    T: Copy + PartialOrd + Add<T, Output = T> + Sub<T, Output = T> + Zero,
 {
     #[inline]
     pub fn union(&self, other: &Self) -> Self {
@@ -374,7 +374,7 @@ impl<T, U> Rect<T, U> {
     #[inline]
     pub fn scale<S: Copy>(&self, x: S, y: S) -> Self
     where
-        T: Copy + Clone + Mul<S, Output = T>,
+        T: Copy + Mul<S, Output = T>,
     {
         Rect::new(
             Point2D::new(self.origin.x * x, self.origin.y * y),
@@ -383,7 +383,7 @@ impl<T, U> Rect<T, U> {
     }
 }
 
-impl<T: Copy + Clone + Mul<T, Output = T>, U> Rect<T, U> {
+impl<T: Copy + Mul<T, Output = T>, U> Rect<T, U> {
     #[inline]
     pub fn area(&self) -> T {
         self.size.area()

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -47,9 +47,9 @@ impl<T: Hash, U> Hash for Rect<T, U> {
 
 impl<T: Copy, U> Copy for Rect<T, U> {}
 
-impl<T: Copy, U> Clone for Rect<T, U> {
+impl<T: Clone, U> Clone for Rect<T, U> {
     fn clone(&self) -> Self {
-        *self
+        Self::new(self.origin.clone(), self.size.clone())
     }
 }
 
@@ -81,6 +81,7 @@ impl<T: Default, U> Default for Rect<T, U> {
 
 impl<T, U> Rect<T, U> {
     /// Constructor.
+    #[inline]
     pub const fn new(origin: Point2D<T, U>, size: Size2D<T, U>) -> Self {
         Rect {
             origin,

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -91,7 +91,7 @@ impl<T, U> Rect<T, U> {
 
 impl<T, U> Rect<T, U>
 where
-    T: Copy + Zero
+    T: Zero
 {
     /// Creates a rect of the given size, at offset zero.
     pub fn from_size(size: Size2D<T, U>) -> Self {
@@ -479,7 +479,7 @@ impl<T0: NumCast + Copy, Unit> Rect<T0, Unit> {
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using round(), round_in or round_out() before casting.
-    pub fn cast<T1: NumCast + Copy>(&self) -> Rect<T1, Unit> {
+    pub fn cast<T1: NumCast>(&self) -> Rect<T1, Unit> {
         Rect::new(
             self.origin.cast(),
             self.size.cast(),
@@ -491,7 +491,7 @@ impl<T0: NumCast + Copy, Unit> Rect<T0, Unit> {
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using round(), round_in or round_out() before casting.
-    pub fn try_cast<T1: NumCast + Copy>(&self) -> Option<Rect<T1, Unit>> {
+    pub fn try_cast<T1: NumCast>(&self) -> Option<Rect<T1, Unit>> {
         match (self.origin.try_cast(), self.size.try_cast()) {
             (Some(origin), Some(size)) => Some(Rect::new(origin, size)),
             _ => None,
@@ -594,7 +594,7 @@ impl<T: NumCast + Copy, Unit> Rect<T, Unit> {
 }
 
 impl<T, U> From<Size2D<T, U>> for Rect<T, U>
-where T: Copy + Zero
+where T: Zero
 {
     fn from(size: Size2D<T, U>) -> Self {
         Self::from_size(size)

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -93,6 +93,11 @@ impl<T, U> Rect<T, U>
 where
     T: Zero
 {
+    /// Constructor, setting all sides to zero.
+    pub fn zero() -> Self {
+        Rect::new(Point2D::origin(), Size2D::zero())
+    }
+
     /// Creates a rect of the given size, at offset zero.
     pub fn from_size(size: Size2D<T, U>) -> Self {
         Rect {
@@ -390,25 +395,22 @@ impl<T: Copy + Mul<T, Output = T>, U> Rect<T, U> {
     }
 }
 
-impl<T: Copy + PartialEq + Zero, U> Rect<T, U> {
-    /// Constructor, setting all sides to zero.
-    pub fn zero() -> Self {
-        Rect::new(Point2D::origin(), Size2D::zero())
-    }
-
+impl<T: Zero + PartialEq, U> Rect<T, U> {
     /// Returns true if the size is zero, regardless of the origin's value.
     pub fn is_empty(&self) -> bool {
         self.size.width == Zero::zero() || self.size.height == Zero::zero()
     }
 }
 
-impl<T: Copy + Zero + PartialOrd, U> Rect<T, U> {
+impl<T: Zero + PartialOrd, U> Rect<T, U> {
 
     #[inline]
     pub fn is_empty_or_negative(&self) -> bool {
         self.size.is_empty_or_negative()
     }
+}
 
+impl<T: Copy + Zero + PartialOrd, U> Rect<T, U> {
     #[inline]
     pub fn to_non_empty(&self) -> Option<NonEmpty<Self>> {
         if self.is_empty_or_negative() {

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -95,8 +95,7 @@ where
 
 impl<T, Src, Dst> Rotation2D<T, Src, Dst>
 where
-    T: Copy
-        + Add<T, Output = T>
+    T:    Add<T, Output = T>
         + Sub<T, Output = T>
         + Mul<T, Output = T>
         + Div<T, Output = T>

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -96,7 +96,6 @@ where
 impl<T, Src, Dst> Rotation2D<T, Src, Dst>
 where
     T: Copy
-        + Clone
         + Add<T, Output = T>
         + Sub<T, Output = T>
         + Mul<T, Output = T>
@@ -176,7 +175,6 @@ where
 impl<T, Src, Dst> Rotation2D<T, Src, Dst>
 where
     T: Copy
-        + Clone
         + Add<T, Output = T>
         + Mul<T, Output = T>
         + Div<T, Output = T>

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -68,47 +68,47 @@ impl<T: Clone + One + Div<T, Output = T>, Src, Dst> Scale<T, Src, Dst> {
 }
 
 // scale0 * scale1
-impl<T: Clone + Mul<T, Output = T>, A, B, C> Mul<Scale<T, B, C>> for Scale<T, A, B> {
+impl<T: Mul<T, Output = T>, A, B, C> Mul<Scale<T, B, C>> for Scale<T, A, B> {
     type Output = Scale<T, A, C>;
     #[inline]
     fn mul(self, other: Scale<T, B, C>) -> Scale<T, A, C> {
-        Scale::new(self.get() * other.get())
+        Scale::new(self.0 * other.0)
     }
 }
 
 // scale0 + scale1
-impl<T: Clone + Add<T, Output = T>, Src, Dst> Add for Scale<T, Src, Dst> {
+impl<T: Add<T, Output = T>, Src, Dst> Add for Scale<T, Src, Dst> {
     type Output = Scale<T, Src, Dst>;
     #[inline]
     fn add(self, other: Scale<T, Src, Dst>) -> Scale<T, Src, Dst> {
-        Scale::new(self.get() + other.get())
+        Scale::new(self.0 + other.0)
     }
 }
 
 // scale0 - scale1
-impl<T: Clone + Sub<T, Output = T>, Src, Dst> Sub for Scale<T, Src, Dst> {
+impl<T: Sub<T, Output = T>, Src, Dst> Sub for Scale<T, Src, Dst> {
     type Output = Scale<T, Src, Dst>;
     #[inline]
     fn sub(self, other: Scale<T, Src, Dst>) -> Scale<T, Src, Dst> {
-        Scale::new(self.get() - other.get())
+        Scale::new(self.0 - other.0)
     }
 }
 
 impl<T: NumCast + Clone, Src, Dst0> Scale<T, Src, Dst0> {
     /// Cast from one numeric representation to another, preserving the units.
-    pub fn cast<T1: NumCast + Clone>(&self) -> Scale<T1, Src, Dst0> {
+    pub fn cast<T1: NumCast>(&self) -> Scale<T1, Src, Dst0> {
         self.try_cast().unwrap()
     }
 
     /// Fallible cast from one numeric representation to another, preserving the units.
-    pub fn try_cast<T1: NumCast + Clone>(&self) -> Option<Scale<T1, Src, Dst0>> {
+    pub fn try_cast<T1: NumCast>(&self) -> Option<Scale<T1, Src, Dst0>> {
         NumCast::from(self.get()).map(Scale::new)
     }
 }
 
 impl<T, Src, Dst> Scale<T, Src, Dst>
 where
-    T: Copy + Clone + Mul<T, Output = T> + Neg<Output = T> + PartialEq + One,
+    T: Copy + Mul<T, Output = T> + Neg<Output = T> + PartialEq + One,
 {
     /// Returns the given point transformed by this scale.
     #[inline]
@@ -146,7 +146,7 @@ where
     /// Returns true if this scale has no effect.
     #[inline]
     pub fn is_identity(&self) -> bool {
-        self.get() == T::one()
+        self.0 == T::one()
     }
 }
 

--- a/src/side_offsets.rs
+++ b/src/side_offsets.rs
@@ -144,7 +144,7 @@ where
 
 impl<T, U> Add for SideOffsets2D<T, U>
 where
-    T: Copy + Add<T, Output = T>,
+    T: Add<T, Output = T>,
 {
     type Output = Self;
     fn add(self, other: Self) -> Self {
@@ -157,7 +157,7 @@ where
     }
 }
 
-impl<T: Copy + Zero, U> SideOffsets2D<T, U> {
+impl<T: Zero, U> SideOffsets2D<T, U> {
     /// Constructor, setting all sides to zero.
     pub fn zero() -> Self {
         SideOffsets2D::new(Zero::zero(), Zero::zero(), Zero::zero(), Zero::zero())

--- a/src/side_offsets.rs
+++ b/src/side_offsets.rs
@@ -105,9 +105,7 @@ impl<T, U> SideOffsets2D<T, U> {
             _unit: PhantomData,
         }
     }
-}
 
-impl<T: Copy, U> SideOffsets2D<T, U> {
     /// Constructor taking a typed Length for each side.
     pub fn from_lengths(
         top: Length<T, U>,
@@ -117,7 +115,9 @@ impl<T: Copy, U> SideOffsets2D<T, U> {
     ) -> Self {
         SideOffsets2D::new(top.0, right.0, bottom.0, left.0)
     }
+}
 
+impl<T: Copy, U> SideOffsets2D<T, U> {
     /// Constructor setting the same value to all sides, taking a scalar value directly.
     pub fn new_all_same(all: T) -> Self {
         SideOffsets2D::new(all, all, all, all)

--- a/src/size.rs
+++ b/src/size.rs
@@ -123,6 +123,12 @@ impl<T, U> Size2D<T, U> {
     pub fn from_lengths(width: Length<T, U>, height: Length<T, U>) -> Self {
         Size2D::new(width.0, height.0)
     }
+
+    /// Tag a unitless value with units.
+    #[inline]
+    pub fn from_untyped(p: Size2D<T, UnknownUnit>) -> Self {
+        Size2D::new(p.width, p.height)
+    }
 }
 
 impl<T: Round, U> Size2D<T, U> {
@@ -269,11 +275,6 @@ impl<T: Copy, U> Size2D<T, U> {
     /// Drop the units, preserving only the numeric value.
     pub fn to_untyped(&self) -> Size2D<T, UnknownUnit> {
         Size2D::new(self.width, self.height)
-    }
-
-    /// Tag a unitless value with units.
-    pub fn from_untyped(p: Size2D<T, UnknownUnit>) -> Self {
-        Size2D::new(p.width, p.height)
     }
 
     /// Cast the unit

--- a/src/size.rs
+++ b/src/size.rs
@@ -483,21 +483,21 @@ impl<T, U> From<Vector2D<T, U>> for Size2D<T, U> {
     }
 }
 
-impl<T: Copy, U> Into<[T; 2]> for Size2D<T, U> {
+impl<T, U> Into<[T; 2]> for Size2D<T, U> {
     fn into(self) -> [T; 2] {
-        self.to_array()
+        [self.width, self.height]
     }
 }
 
-impl<T: Copy, U> From<[T; 2]> for Size2D<T, U> {
-    fn from(array: [T; 2]) -> Self {
-        size2(array[0], array[1])
+impl<T, U> From<[T; 2]> for Size2D<T, U> {
+    fn from([w, h]: [T; 2]) -> Self {
+        size2(w, h)
     }
 }
 
-impl<T: Copy, U> Into<(T, T)> for Size2D<T, U> {
+impl<T, U> Into<(T, T)> for Size2D<T, U> {
     fn into(self) -> (T, T) {
-        self.to_tuple()
+        (self.width, self.height)
     }
 }
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -119,12 +119,9 @@ impl<T, U> Size2D<T, U> {
             _unit: PhantomData,
         }
     }
-}
-
-impl<T: Clone, U> Size2D<T, U> {
     /// Constructor taking scalar strongly typed lengths.
     pub fn from_lengths(width: Length<T, U>, height: Length<T, U>) -> Self {
-        Size2D::new(width.get(), height.get())
+        Size2D::new(width.0, height.0)
     }
 }
 
@@ -169,7 +166,7 @@ impl<T: Copy + Sub<T, Output = T>, U> Sub for Size2D<T, U> {
     }
 }
 
-impl<T: Copy + Clone + Mul<T>, U> Size2D<T, U> {
+impl<T: Copy + Mul<T>, U> Size2D<T, U> {
     /// Returns result of multiplication of both components
     pub fn area(&self) -> T::Output {
         self.width * self.height
@@ -669,10 +666,10 @@ impl<T, U> Size3D<T, U> {
     }
 }
 
-impl<T: Clone, U> Size3D<T, U> {
+impl<T, U> Size3D<T, U> {
     /// Constructor taking scalar strongly typed lengths.
     pub fn from_lengths(width: Length<T, U>, height: Length<T, U>, depth: Length<T, U>) -> Self {
-        Size3D::new(width.get(), height.get(), depth.get())
+        Size3D::new(width.0, height.0, depth.0)
     }
 }
 
@@ -717,7 +714,7 @@ impl<T: Copy + Sub<T, Output = T>, U> Sub for Size3D<T, U> {
     }
 }
 
-impl<T: Copy + Clone + Mul<T, Output=T>, U> Size3D<T, U> {
+impl<T: Copy + Mul<T, Output=T>, U> Size3D<T, U> {
     /// Returns result of multiplication of all components
     pub fn volume(&self) -> T {
         self.width * self.height * self.depth

--- a/src/size.rs
+++ b/src/size.rs
@@ -158,14 +158,14 @@ impl<T: Floor, U> Size2D<T, U> {
     }
 }
 
-impl<T: Copy + Add<T, Output = T>, U> Add for Size2D<T, U> {
+impl<T: Add<T, Output = T>, U> Add for Size2D<T, U> {
     type Output = Self;
     fn add(self, other: Self) -> Self {
         Size2D::new(self.width + other.width, self.height + other.height)
     }
 }
 
-impl<T: Copy + Sub<T, Output = T>, U> Sub for Size2D<T, U> {
+impl<T: Sub<T, Output = T>, U> Sub for Size2D<T, U> {
     type Output = Self;
     fn sub(self, other: Self) -> Self {
         Size2D::new(self.width - other.width, self.height - other.height)
@@ -289,7 +289,7 @@ impl<T: NumCast + Copy, Unit> Size2D<T, Unit> {
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
-    pub fn cast<NewT: NumCast + Copy>(&self) -> Size2D<NewT, Unit> {
+    pub fn cast<NewT: NumCast>(&self) -> Size2D<NewT, Unit> {
         self.try_cast().unwrap()
     }
 
@@ -298,7 +298,7 @@ impl<T: NumCast + Copy, Unit> Size2D<T, Unit> {
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
-    pub fn try_cast<NewT: NumCast + Copy>(&self) -> Option<Size2D<NewT, Unit>> {
+    pub fn try_cast<NewT: NumCast>(&self) -> Option<Size2D<NewT, Unit>> {
         match (NumCast::from(self.width), NumCast::from(self.height)) {
             (Some(w), Some(h)) => Some(Size2D::new(w, h)),
             _ => None,
@@ -501,7 +501,7 @@ impl<T, U> Into<(T, T)> for Size2D<T, U> {
     }
 }
 
-impl<T: Copy, U> From<(T, T)> for Size2D<T, U> {
+impl<T, U> From<(T, T)> for Size2D<T, U> {
     fn from(tuple: (T, T)) -> Self {
         size2(tuple.0, tuple.1)
     }
@@ -701,14 +701,14 @@ impl<T: Floor, U> Size3D<T, U> {
     }
 }
 
-impl<T: Copy + Add<T, Output = T>, U> Add for Size3D<T, U> {
+impl<T: Add<T, Output = T>, U> Add for Size3D<T, U> {
     type Output = Self;
     fn add(self, other: Self) -> Self {
         Size3D::new(self.width + other.width, self.height + other.height, self.depth + other.depth)
     }
 }
 
-impl<T: Copy + Sub<T, Output = T>, U> Sub for Size3D<T, U> {
+impl<T: Sub<T, Output = T>, U> Sub for Size3D<T, U> {
     type Output = Self;
     fn sub(self, other: Self) -> Self {
         Size3D::new(self.width - other.width, self.height - other.height, self.depth - other.depth)

--- a/src/transform2d.rs
+++ b/src/transform2d.rs
@@ -297,7 +297,7 @@ where T: Copy +
 }
 
 impl<T, Src, Dst> Transform2D<T, Src, Dst>
-where T: Copy + Clone +
+where T: Copy +
          Add<T, Output=T> +
          Mul<T, Output=T> +
          Div<T, Output=T> +
@@ -477,7 +477,7 @@ where T: Copy + Clone +
 }
 
 impl<T, Src, Dst> Transform2D<T, Src, Dst>
-where T: Copy + Clone +
+where T: Copy +
          Add<T, Output=T> +
          Mul<T, Output=T> +
          Div<T, Output=T> +
@@ -514,7 +514,7 @@ where T: Copy + Clone +
 }
 
 impl <T, Src, Dst> Transform2D<T, Src, Dst>
-where T: Copy + Clone +
+where T: Copy +
          Add<T, Output=T> +
          Sub<T, Output=T> +
          Mul<T, Output=T> +

--- a/src/transform2d.rs
+++ b/src/transform2d.rs
@@ -252,12 +252,12 @@ impl<T: Copy, Src, Dst> Transform2D<T, Src, Dst> {
 
 impl<T0: NumCast + Copy, Src, Dst> Transform2D<T0, Src, Dst> {
     /// Cast from one numeric representation to another, preserving the units.
-    pub fn cast<T1: NumCast + Copy>(&self) -> Transform2D<T1, Src, Dst> {
+    pub fn cast<T1: NumCast>(&self) -> Transform2D<T1, Src, Dst> {
         self.try_cast().unwrap()
     }
 
     /// Fallible cast from one numeric representation to another, preserving the units.
-    pub fn try_cast<T1: NumCast + Copy>(&self) -> Option<Transform2D<T1, Src, Dst>> {
+    pub fn try_cast<T1: NumCast>(&self) -> Option<Transform2D<T1, Src, Dst>> {
         match (NumCast::from(self.m11), NumCast::from(self.m12),
                NumCast::from(self.m21), NumCast::from(self.m22),
                NumCast::from(self.m31), NumCast::from(self.m32)) {
@@ -556,7 +556,7 @@ impl<T: ApproxEq<T>, Src, Dst> Transform2D<T, Src, Dst> {
     }
 }
 
-impl<T: Copy + fmt::Debug, Src, Dst> fmt::Debug for Transform2D<T, Src, Dst>
+impl<T, Src, Dst> fmt::Debug for Transform2D<T, Src, Dst>
 where T: Copy + fmt::Debug +
          PartialEq +
          One + Zero {

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -923,12 +923,12 @@ impl<T: Copy, Src, Dst> Transform3D<T, Src, Dst> {
 
 impl<T0: NumCast + Copy, Src, Dst> Transform3D<T0, Src, Dst> {
     /// Cast from one numeric representation to another, preserving the units.
-    pub fn cast<T1: NumCast + Copy>(&self) -> Transform3D<T1, Src, Dst> {
+    pub fn cast<T1: NumCast>(&self) -> Transform3D<T1, Src, Dst> {
         self.try_cast().unwrap()
     }
 
     /// Fallible cast from one numeric representation to another, preserving the units.
-    pub fn try_cast<T1: NumCast + Copy>(&self) -> Option<Transform3D<T1, Src, Dst>> {
+    pub fn try_cast<T1: NumCast>(&self) -> Option<Transform3D<T1, Src, Dst>> {
         match (NumCast::from(self.m11), NumCast::from(self.m12),
                NumCast::from(self.m13), NumCast::from(self.m14),
                NumCast::from(self.m21), NumCast::from(self.m22),

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -221,7 +221,7 @@ impl<T, Src, Dst> Transform3D<T, Src, Dst> {
 }
 
 impl <T, Src, Dst> Transform3D<T, Src, Dst>
-where T: Copy + Clone +
+where T: Copy +
          PartialEq +
          One + Zero {
     #[inline]
@@ -245,7 +245,7 @@ where T: Copy + Clone +
 }
 
 impl <T, Src, Dst> Transform3D<T, Src, Dst>
-where T: Copy + Clone +
+where T: Copy +
          Add<T, Output=T> +
          Sub<T, Output=T> +
          Mul<T, Output=T> +

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -196,7 +196,7 @@ where
 impl<T, Src, Dst1, Dst2> Add<Translation2D<T, Dst1, Dst2>>
 for Translation2D<T, Src, Dst1>
 where
-    T: Copy + Add<T, Output = T>
+    T: Add<T, Output = T>
 {
     type Output = Translation2D<T, Src, Dst2>;
     fn add(self, other: Translation2D<T, Dst1, Dst2>) -> Translation2D<T, Src, Dst2> {
@@ -211,7 +211,7 @@ impl<T, Src, Dst1, Dst2>
     Sub<Translation2D<T, Dst1, Dst2>>
     for Translation2D<T, Src, Dst2>
 where
-    T: Copy + Sub<T, Output = T>
+    T: Sub<T, Output = T>
 {
     type Output = Translation2D<T, Src, Dst1>;
     fn sub(self, other: Translation2D<T, Dst1, Dst2>) -> Translation2D<T, Src, Dst1> {
@@ -242,8 +242,6 @@ where
 }
 
 impl<T, Src, Dst> From<Vector2D<T, Src>> for Translation2D<T, Src, Dst>
-where
-    T: Copy
 {
     fn from(v: Vector2D<T, Src>) -> Self {
         Translation2D::new(v.x, v.y)
@@ -251,8 +249,6 @@ where
 }
 
 impl<T, Src, Dst> Into<Vector2D<T, Src>> for Translation2D<T, Src, Dst>
-where
-    T: Copy
 {
     fn into(self) -> Vector2D<T, Src> {
         vec2(self.x, self.y)
@@ -277,7 +273,7 @@ where
 }
 
 impl <T, Src, Dst> Default for Translation2D<T, Src, Dst>
-    where T: Copy + Zero
+    where T: Zero
 {
     fn default() -> Self {
         Self::identity()
@@ -485,7 +481,7 @@ where
 impl<T, Src, Dst1, Dst2> Add<Translation3D<T, Dst1, Dst2>>
 for Translation3D<T, Src, Dst1>
 where
-    T: Copy + Add<T, Output = T>
+    T: Add<T, Output = T>
 {
     type Output = Translation3D<T, Src, Dst2>;
     fn add(self, other: Translation3D<T, Dst1, Dst2>) -> Translation3D<T, Src, Dst2> {
@@ -501,7 +497,7 @@ impl<T, Src, Dst1, Dst2>
     Sub<Translation3D<T, Dst1, Dst2>>
     for Translation3D<T, Src, Dst2>
 where
-    T: Copy + Sub<T, Output = T>
+    T: Sub<T, Output = T>
 {
     type Output = Translation3D<T, Src, Dst1>;
     fn sub(self, other: Translation3D<T, Dst1, Dst2>) -> Translation3D<T, Src, Dst1> {
@@ -533,8 +529,6 @@ where
 }
 
 impl<T, Src, Dst> From<Vector3D<T, Src>> for Translation3D<T, Src, Dst>
-where
-    T: Copy
 {
     fn from(v: Vector3D<T, Src>) -> Self {
         Translation3D::new(v.x, v.y, v.z)
@@ -542,8 +536,6 @@ where
 }
 
 impl<T, Src, Dst> Into<Vector3D<T, Src>> for Translation3D<T, Src, Dst>
-where
-    T: Copy
 {
     fn into(self) -> Vector3D<T, Src> {
         vec3(self.x, self.y, self.z)
@@ -568,7 +560,7 @@ where
 }
 
 impl <T, Src, Dst> Default for Translation3D<T, Src, Dst>
-    where T: Copy + Zero
+    where T: Zero
 {
     fn default() -> Self {
         Self::identity()

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -90,12 +90,24 @@ impl<T, Src, Dst> Translation2D<T, Src, Dst> {
             _unit: PhantomData,
         }
     }
+
+    /// No-op, just cast the unit.
+    #[inline]
+    pub fn transform_size(&self, s: Size2D<T, Src>) -> Size2D<T, Dst> {
+        Size2D::new(s.width, s.height)
+    }
 }
 
 impl<T, Src, Dst> Translation2D<T, Src, Dst>
 where
     T : Copy
 {
+    /// Cast into a 2D vector.
+    #[inline]
+    pub fn to_vector(&self) -> Vector2D<T, Src> {
+        vec2(self.x, self.y)
+    }
+
     /// Cast into an array with x and y.
     #[inline]
     pub fn to_array(&self) -> [T; 2] {
@@ -167,17 +179,6 @@ where
             origin: self.transform_point(r.origin),
             size: self.transform_size(r.size),
         }
-    }
-
-    /// No-op, just cast the unit.
-    #[inline]
-    pub fn transform_size(&self, s: Size2D<T, Src>) -> Size2D<T, Dst> {
-        Size2D::new(s.width, s.height)
-    }
-
-    /// Cast into a 2D vector.
-    pub fn to_vector(&self) -> Vector2D<T, Src> {
-        vec2(self.x, self.y)
     }
 }
 
@@ -373,12 +374,23 @@ impl<T, Src, Dst> Translation3D<T, Src, Dst> {
             _unit: PhantomData,
         }
     }
+
+    /// No-op, just cast the unit.
+    #[inline]
+    pub fn transform_size(self, s: Size2D<T, Src>) -> Size2D<T, Dst> {
+        Size2D::new(s.width, s.height)
+    }
 }
 
 impl<T, Src, Dst> Translation3D<T, Src, Dst>
 where
     T: Copy
 {
+    /// Cast into a 3D vector.
+    pub fn to_vector(&self) -> Vector3D<T, Src> {
+        vec3(self.x, self.y, self.z)
+    }
+
     /// Cast into an array with x, y and z.
     #[inline]
     pub fn to_array(&self) -> [T; 3] {
@@ -458,17 +470,6 @@ where
             origin: self.transform_point2d(&r.origin),
             size: self.transform_size(r.size),
         }
-    }
-
-    /// No-op, just cast the unit.
-    #[inline]
-    pub fn transform_size(self, s: Size2D<T, Src>) -> Size2D<T, Dst> {
-        Size2D::new(s.width, s.height)
-    }
-
-    /// Cast into a 3D vector.
-    pub fn to_vector(&self) -> Vector3D<T, Src> {
-        vec3(self.x, self.y, self.z)
     }
 }
 

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -143,12 +143,11 @@ where
 
 impl<T, Src, Dst> Translation2D<T, Src, Dst>
 where
-    T : Copy + Zero
+    T: Zero
 {
     #[inline]
     pub fn identity() -> Self {
-        let _0 = T::zero();
-        Translation2D::new(_0, _0)
+        Translation2D::new(T::zero(), T::zero())
     }
 }
 
@@ -158,7 +157,8 @@ where
 {
     #[inline]
     pub fn is_identity(&self) -> bool {
-        self.x == T::zero() && self.y == T::zero()
+        let _0 = T::zero();
+        self.x == _0 && self.y == _0
     }
 }
 
@@ -426,12 +426,11 @@ where
 
 impl<T, Src, Dst> Translation3D<T, Src, Dst>
 where
-    T: Copy + Zero
+    T: Zero
 {
     #[inline]
     pub fn identity() -> Self {
-        let _0 = T::zero();
-        Translation3D::new(_0, _0, _0)
+        Translation3D::new(T::zero(), T::zero(), T::zero())
     }
 }
 
@@ -441,7 +440,8 @@ where
 {
     #[inline]
     pub fn is_identity(&self) -> bool {
-        self.x == T::zero() && self.y == T::zero() && self.z == T::zero()
+        let _0 = T::zero();
+        self.x == _0 && self.y == _0 && self.z == _0
     }
 }
 

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -225,7 +225,6 @@ where
 impl<T, Src, Dst> Translation2D<T, Src, Dst>
 where
     T: Copy
-        + Clone
         + Add<T, Output = T>
         + Mul<T, Output = T>
         + Div<T, Output = T>
@@ -263,7 +262,6 @@ where
 impl<T, Src, Dst> Into<Transform2D<T, Src, Dst>> for Translation2D<T, Src, Dst>
 where
     T: Copy
-        + Clone
         + Add<T, Output = T>
         + Mul<T, Output = T>
         + Div<T, Output = T>
@@ -517,7 +515,7 @@ where
 
 impl<T, Src, Dst> Translation3D<T, Src, Dst>
 where
-    T: Copy + Clone +
+    T: Copy +
         Add<T, Output=T> +
         Sub<T, Output=T> +
         Mul<T, Output=T> +
@@ -554,7 +552,7 @@ where
 
 impl<T, Src, Dst> Into<Transform3D<T, Src, Dst>> for Translation3D<T, Src, Dst>
 where
-    T: Copy + Clone +
+    T: Copy +
         Add<T, Output=T> +
         Sub<T, Output=T> +
         Mul<T, Output=T> +

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -280,13 +280,17 @@ impl <T, Src, Dst> Default for Translation2D<T, Src, Dst>
     }
 }
 
-impl<T, Src, Dst> fmt::Debug for Translation2D<T, Src, Dst>
-where T: Copy + fmt::Debug {
+impl<T: fmt::Debug, Src, Dst> fmt::Debug for Translation2D<T, Src, Dst> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.to_array().fmt(f)
+        write!(f, "Translation({:?},{:?})", self.x, self.y)
     }
 }
 
+impl<T: fmt::Display, Src, Dst> fmt::Display for Translation2D<T, Src, Dst> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({},{})", self.x, self.y)
+    }
+}
 
 
 /// A 3d transformation from a space to another that can only express translations.
@@ -567,10 +571,15 @@ impl <T, Src, Dst> Default for Translation3D<T, Src, Dst>
     }
 }
 
-impl<T, Src, Dst> fmt::Debug for Translation3D<T, Src, Dst>
-where T: Copy + fmt::Debug {
+impl<T: fmt::Debug, Src, Dst> fmt::Debug for Translation3D<T, Src, Dst> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.to_array().fmt(f)
+        write!(f, "Translation({:?},{:?},{:?})", self.x, self.y, self.z)
+    }
+}
+
+impl<T: fmt::Display, Src, Dst> fmt::Display for Translation3D<T, Src, Dst> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({},{},{})", self.x, self.y, self.z)
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -616,21 +616,21 @@ impl<T: Copy + ApproxEq<T>, U> ApproxEq<Vector2D<T, U>> for Vector2D<T, U> {
     }
 }
 
-impl<T: Copy, U> Into<[T; 2]> for Vector2D<T, U> {
+impl<T, U> Into<[T; 2]> for Vector2D<T, U> {
     fn into(self) -> [T; 2] {
-        self.to_array()
+        [self.x, self.y]
     }
 }
 
-impl<T: Copy, U> From<[T; 2]> for Vector2D<T, U> {
-    fn from(array: [T; 2]) -> Self {
-        vec2(array[0], array[1])
+impl<T, U> From<[T; 2]> for Vector2D<T, U> {
+    fn from([x, y]: [T; 2]) -> Self {
+        vec2(x, y)
     }
 }
 
-impl<T: Copy, U> Into<(T, T)> for Vector2D<T, U> {
+impl<T, U> Into<(T, T)> for Vector2D<T, U> {
     fn into(self) -> (T, T) {
-        self.to_tuple()
+        (self.x, self.y)
     }
 }
 
@@ -640,9 +640,9 @@ impl<T: Copy, U> From<(T, T)> for Vector2D<T, U> {
     }
 }
 
-impl<T: Copy, U> From<Size2D<T, U>> for Vector2D<T, U> {
+impl<T, U> From<Size2D<T, U>> for Vector2D<T, U> {
     fn from(size: Size2D<T, U>) -> Self {
-        size.to_vector()
+        vec2(size.width, size.height)
     }
 }
 
@@ -1263,21 +1263,21 @@ impl<T: Copy + ApproxEq<T>, U> ApproxEq<Vector3D<T, U>> for Vector3D<T, U> {
     }
 }
 
-impl<T: Copy, U> Into<[T; 3]> for Vector3D<T, U> {
+impl<T, U> Into<[T; 3]> for Vector3D<T, U> {
     fn into(self) -> [T; 3] {
-        self.to_array()
+        [self.x, self.y, self.z]
     }
 }
 
-impl<T: Copy, U> From<[T; 3]> for Vector3D<T, U> {
-    fn from(array: [T; 3]) -> Self {
-        vec3(array[0], array[1], array[2])
+impl<T, U> From<[T; 3]> for Vector3D<T, U> {
+    fn from([x, y, z]: [T; 3]) -> Self {
+        vec3(x, y, z)
     }
 }
 
-impl<T: Copy, U> Into<(T, T, T)> for Vector3D<T, U> {
+impl<T, U> Into<(T, T, T)> for Vector3D<T, U> {
     fn into(self) -> (T, T, T) {
-        self.to_tuple()
+        (self.x, self.y, self.z)
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -94,13 +94,15 @@ impl<T, U> Hash for Vector2D<T, U>
     }
 }
 
-impl<T: Copy + Zero, U> Vector2D<T, U> {
+impl<T: Zero, U> Vector2D<T, U> {
     /// Constructor, setting all components to zero.
     #[inline]
     pub fn zero() -> Self {
         Vector2D::new(Zero::zero(), Zero::zero())
     }
+}
 
+impl<T: Copy + Zero, U> Vector2D<T, U> {
     /// Convert into a 3d vector.
     #[inline]
     pub fn to_3d(&self) -> Vector3D<T, U> {
@@ -252,20 +254,30 @@ where
 
 impl<T, U> Vector2D<T, U>
 where
-    T: Copy + Mul<T, Output = T> + Add<T, Output = T> + Sub<T, Output = T>,
+    T: Mul<T, Output = T> + Add<T, Output = T>,
 {
     /// Dot product.
     #[inline]
     pub fn dot(self, other: Self) -> T {
         self.x * other.x + self.y * other.y
     }
+}
 
+impl<T, U> Vector2D<T, U>
+where
+    T: Mul<T, Output = T> + Sub<T, Output = T>,
+{
     /// Returns the norm of the cross product [self.x, self.y, 0] x [other.x, other.y, 0]..
     #[inline]
     pub fn cross(self, other: Self) -> T {
         self.x * other.y - self.y * other.x
     }
+}
 
+impl<T, U> Vector2D<T, U>
+where
+    T: Copy + Mul<T, Output = T> + Add<T, Output = T> + Sub<T, Output = T>,
+{
     #[inline]
     pub fn normalize(self) -> Self
     where
@@ -728,13 +740,15 @@ impl<T, U> Hash for Vector3D<T, U>
     }
 }
 
-impl<T: Copy + Zero, U> Vector3D<T, U> {
+impl<T: Zero, U> Vector3D<T, U> {
     /// Constructor, setting all components to zero.
     #[inline]
     pub fn zero() -> Self {
         vec3(Zero::zero(), Zero::zero(), Zero::zero())
     }
+}
 
+impl<T: Copy + Zero, U> Vector3D<T, U> {
     #[inline]
     pub fn to_array_4d(&self) -> [T; 4] {
         [self.x, self.y, self.z, Zero::zero()]
@@ -880,14 +894,21 @@ where
     }
 }
 
-impl<T: Mul<T, Output = T> + Add<T, Output = T> + Sub<T, Output = T> + Copy, U>
-    Vector3D<T, U> {
+impl<T, U> Vector3D<T, U>
+where
+    T: Mul<T, Output = T> + Add<T, Output = T>
+{
     /// Dot product.
     #[inline]
     pub fn dot(self, other: Self) -> T {
         self.x * other.x + self.y * other.y + self.z * other.z
     }
+}
 
+impl<T, U> Vector3D<T, U>
+where
+    T: Copy + Mul<T, Output = T> + Sub<T, Output = T>
+{
     /// Cross product.
     #[inline]
     pub fn cross(self, other: Self) -> Self {
@@ -897,7 +918,12 @@ impl<T: Mul<T, Output = T> + Add<T, Output = T> + Sub<T, Output = T> + Copy, U>
             self.x * other.y - self.y * other.x,
         )
     }
+}
 
+impl<T, U> Vector3D<T, U>
+where
+    T: Copy + Mul<T, Output = T> + Add<T, Output = T> + Sub<T, Output = T>
+{
     #[inline]
     pub fn normalize(self) -> Self
     where
@@ -950,7 +976,7 @@ impl<T: Mul<T, Output = T> + Add<T, Output = T> + Sub<T, Output = T> + Copy, U>
 
 impl<T, U> Vector3D<T, U>
 where
-    T: Copy + Mul<T, Output = T> + Add<T, Output = T> + Sub<T, Output = T>
+    T: Mul<T, Output = T> + Add<T, Output = T> + Sub<T, Output = T>
     + PartialOrd + Float
 {
     /// Return this vector capped to a maximum length.
@@ -997,12 +1023,7 @@ where
         let one_t = T::one() - t;
         (*self) * one_t + other * t
     }
-}
 
-impl<T, U> Vector3D<T, U>
-where
-    T: Copy + One + Mul<T, Output = T> + Add<T, Output = T> + Sub<T, Output = T>,
-{
     /// Returns a reflection vector using an incident ray and a surface normal.
     #[inline]
     pub fn reflect(&self, normal: Self) -> Self {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -136,15 +136,21 @@ impl<T, U> Vector2D<T, U> {
             _unit: PhantomData,
         }
     }
-}
 
-impl<T: Copy, U> Vector2D<T, U> {
     /// Constructor taking properly  Lengths instead of scalar values.
     #[inline]
     pub fn from_lengths(x: Length<T, U>, y: Length<T, U>) -> Self {
         vec2(x.0, y.0)
     }
 
+    /// Tag a unit-less value with units.
+    #[inline]
+    pub fn from_untyped(p: Vector2D<T, UnknownUnit>) -> Self {
+        vec2(p.x, p.y)
+    }
+}
+
+impl<T: Copy, U> Vector2D<T, U> {
     /// Create a 3d vector from this one, using the specified z value.
     #[inline]
     pub fn extend(&self, z: T) -> Vector3D<T, U> {
@@ -179,12 +185,6 @@ impl<T: Copy, U> Vector2D<T, U> {
     #[inline]
     pub fn to_untyped(&self) -> Vector2D<T, UnknownUnit> {
         vec2(self.x, self.y)
-    }
-
-    /// Tag a unit-less value with units.
-    #[inline]
-    pub fn from_untyped(p: Vector2D<T, UnknownUnit>) -> Self {
-        vec2(p.x, p.y)
     }
 
     /// Cast the unit
@@ -775,15 +775,21 @@ impl<T, U> Vector3D<T, U> {
             _unit: PhantomData,
         }
     }
-}
 
-impl<T: Copy, U> Vector3D<T, U> {
     /// Constructor taking properly  Lengths instead of scalar values.
     #[inline]
     pub fn from_lengths(x: Length<T, U>, y: Length<T, U>, z: Length<T, U>) -> Vector3D<T, U> {
         vec3(x.0, y.0, z.0)
     }
 
+    /// Tag a unitless value with units.
+    #[inline]
+    pub fn from_untyped(p: Vector3D<T, UnknownUnit>) -> Self {
+        vec3(p.x, p.y, p.z)
+    }
+}
+
+impl<T: Copy, U> Vector3D<T, U> {
     /// Cast this vector into a point.
     ///
     /// Equivalent to adding this vector to the origin.
@@ -826,12 +832,6 @@ impl<T: Copy, U> Vector3D<T, U> {
     #[inline]
     pub fn to_untyped(&self) -> Vector3D<T, UnknownUnit> {
         vec3(self.x, self.y, self.z)
-    }
-
-    /// Tag a unitless value with units.
-    #[inline]
-    pub fn from_untyped(p: Vector3D<T, UnknownUnit>) -> Self {
-        vec3(p.x, p.y, p.z)
     }
 
     /// Cast the unit

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -209,7 +209,6 @@ impl<T: Copy, U> Vector2D<T, U> {
 impl<T, U> Vector2D<T, U>
 where
     T: Copy
-        + Clone
         + Add<T, Output = T>
         + Mul<T, Output = T>
         + Div<T, Output = T>
@@ -850,7 +849,6 @@ impl<T: Copy, U> Vector3D<T, U> {
 impl<T, U> Vector3D<T, U>
 where
     T: Copy
-        + Clone
         + Add<T, Output = T>
         + Mul<T, Output = T>
         + Div<T, Output = T>

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -240,7 +240,7 @@ where
 impl<T, U> Vector2D<T, U>
 where
     T: Copy + Mul<T, Output = T> + Add<T, Output = T> + Sub<T, Output = T>
-    + Trig + Copy + Sub<T, Output = T>,
+    + Trig,
 {
     /// Returns the signed angle between this vector and another vector.
     ///
@@ -379,7 +379,7 @@ where
     }
 }
 
-impl<T: Copy + Add<T, Output = T>, U> Add for Vector2D<T, U> {
+impl<T: Add<T, Output = T>, U> Add for Vector2D<T, U> {
     type Output = Self;
     fn add(self, other: Self) -> Self {
         Vector2D::new(self.x + other.x, self.y + other.y)
@@ -400,7 +400,7 @@ impl<T: Copy + Sub<T, Output = T>, U> SubAssign<Vector2D<T, U>> for Vector2D<T, 
     }
 }
 
-impl<T: Copy + Sub<T, Output = T>, U> Sub for Vector2D<T, U> {
+impl<T: Sub<T, Output = T>, U> Sub for Vector2D<T, U> {
     type Output = Self;
     #[inline]
     fn sub(self, other: Self) -> Self {
@@ -408,7 +408,7 @@ impl<T: Copy + Sub<T, Output = T>, U> Sub for Vector2D<T, U> {
     }
 }
 
-impl<T: Copy + Neg<Output = T>, U> Neg for Vector2D<T, U> {
+impl<T: Neg<Output = T>, U> Neg for Vector2D<T, U> {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
@@ -527,7 +527,7 @@ impl<T: NumCast + Copy, U> Vector2D<T, U> {
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
     #[inline]
-    pub fn cast<NewT: NumCast + Copy>(&self) -> Vector2D<NewT, U> {
+    pub fn cast<NewT: NumCast>(&self) -> Vector2D<NewT, U> {
         self.try_cast().unwrap()
     }
 
@@ -537,7 +537,7 @@ impl<T: NumCast + Copy, U> Vector2D<T, U> {
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
     #[inline]
-    pub fn try_cast<NewT: NumCast + Copy>(&self) -> Option<Vector2D<NewT, U>> {
+    pub fn try_cast<NewT: NumCast>(&self) -> Option<Vector2D<NewT, U>> {
         match (NumCast::from(self.x), NumCast::from(self.y)) {
             (Some(x), Some(y)) => Some(Vector2D::new(x, y)),
             _ => None,
@@ -599,7 +599,7 @@ impl<T: NumCast + Copy, U> Vector2D<T, U> {
     }
 }
 
-impl<T: Copy + ApproxEq<T>, U> ApproxEq<Vector2D<T, U>> for Vector2D<T, U> {
+impl<T: ApproxEq<T>, U> ApproxEq<Vector2D<T, U>> for Vector2D<T, U> {
     #[inline]
     fn approx_epsilon() -> Self {
         vec2(T::approx_epsilon(), T::approx_epsilon())
@@ -634,7 +634,7 @@ impl<T, U> Into<(T, T)> for Vector2D<T, U> {
     }
 }
 
-impl<T: Copy, U> From<(T, T)> for Vector2D<T, U> {
+impl<T, U> From<(T, T)> for Vector2D<T, U> {
     fn from(tuple: (T, T)) -> Self {
         vec2(tuple.0, tuple.1)
     }
@@ -869,7 +869,7 @@ where
 impl<T, U> Vector3D<T, U>
 where
     T: Copy + Mul<T, Output = T> + Add<T, Output = T> + Sub<T, Output = T>
-    + Trig + Copy + Sub<T, Output = T>
+    + Trig
     + Float
 {
     /// Returns the positive angle between this vector and another vector.
@@ -1011,7 +1011,7 @@ where
     }
 }
 
-impl<T: Copy + Add<T, Output = T>, U> Add for Vector3D<T, U> {
+impl<T: Add<T, Output = T>, U> Add for Vector3D<T, U> {
     type Output = Self;
     #[inline]
     fn add(self, other: Self) -> Self {
@@ -1019,7 +1019,7 @@ impl<T: Copy + Add<T, Output = T>, U> Add for Vector3D<T, U> {
     }
 }
 
-impl<T: Copy + Sub<T, Output = T>, U> Sub for Vector3D<T, U> {
+impl<T: Sub<T, Output = T>, U> Sub for Vector3D<T, U> {
     type Output = Self;
     #[inline]
     fn sub(self, other: Self) -> Self {
@@ -1041,7 +1041,7 @@ impl<T: Copy + Sub<T, Output = T>, U> SubAssign<Vector3D<T, U>> for Vector3D<T, 
     }
 }
 
-impl<T: Copy + Neg<Output = T>, U> Neg for Vector3D<T, U> {
+impl<T: Neg<Output = T>, U> Neg for Vector3D<T, U> {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
@@ -1165,7 +1165,7 @@ impl<T: NumCast + Copy, U> Vector3D<T, U> {
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
     #[inline]
-    pub fn cast<NewT: NumCast + Copy>(&self) -> Vector3D<NewT, U> {
+    pub fn cast<NewT: NumCast>(&self) -> Vector3D<NewT, U> {
         self.try_cast().unwrap()
     }
 
@@ -1175,7 +1175,7 @@ impl<T: NumCast + Copy, U> Vector3D<T, U> {
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
     #[inline]
-    pub fn try_cast<NewT: NumCast + Copy>(&self) -> Option<Vector3D<NewT, U>> {
+    pub fn try_cast<NewT: NumCast>(&self) -> Option<Vector3D<NewT, U>> {
         match (
             NumCast::from(self.x),
             NumCast::from(self.y),
@@ -1241,7 +1241,7 @@ impl<T: NumCast + Copy, U> Vector3D<T, U> {
     }
 }
 
-impl<T: Copy + ApproxEq<T>, U> ApproxEq<Vector3D<T, U>> for Vector3D<T, U> {
+impl<T: ApproxEq<T>, U> ApproxEq<Vector3D<T, U>> for Vector3D<T, U> {
     #[inline]
     fn approx_epsilon() -> Self {
         vec3(
@@ -1281,7 +1281,7 @@ impl<T, U> Into<(T, T, T)> for Vector3D<T, U> {
     }
 }
 
-impl<T: Copy, U> From<(T, T, T)> for Vector3D<T, U> {
+impl<T, U> From<(T, T, T)> for Vector3D<T, U> {
     fn from(tuple: (T, T, T)) -> Self {
         vec3(tuple.0, tuple.1, tuple.2)
     }
@@ -1371,7 +1371,7 @@ impl BoolVector2D {
     /// Returns point, each component of which or from `a`, or from `b` depending on truly value
     /// of corresponding vector component. `true` selects value from `a` and `false` from `b`.
     #[inline]
-    pub fn select_point<T: Copy, U>(&self, a: Point2D<T, U>, b: Point2D<T, U>) -> Point2D<T, U> {
+    pub fn select_point<T, U>(&self, a: Point2D<T, U>, b: Point2D<T, U>) -> Point2D<T, U> {
         point2(
             if self.x { a.x } else { b.x },
             if self.y { a.y } else { b.y },
@@ -1381,7 +1381,7 @@ impl BoolVector2D {
     /// Returns vector, each component of which or from `a`, or from `b` depending on truly value
     /// of corresponding vector component. `true` selects value from `a` and `false` from `b`.
     #[inline]
-    pub fn select_vector<T: Copy, U>(&self, a: Vector2D<T, U>, b: Vector2D<T, U>) -> Vector2D<T, U> {
+    pub fn select_vector<T, U>(&self, a: Vector2D<T, U>, b: Vector2D<T, U>) -> Vector2D<T, U> {
         vec2(
             if self.x { a.x } else { b.x },
             if self.y { a.y } else { b.y },
@@ -1391,7 +1391,7 @@ impl BoolVector2D {
     /// Returns size, each component of which or from `a`, or from `b` depending on truly value
     /// of corresponding vector component. `true` selects value from `a` and `false` from `b`.
     #[inline]
-    pub fn select_size<T: Copy, U>(&self, a: Size2D<T, U>, b: Size2D<T, U>) -> Size2D<T, U> {
+    pub fn select_size<T, U>(&self, a: Size2D<T, U>, b: Size2D<T, U>) -> Size2D<T, U> {
         size2(
             if self.x { a.width } else { b.width },
             if self.y { a.height } else { b.height },
@@ -1452,7 +1452,7 @@ impl BoolVector3D {
     /// Returns point, each component of which or from `a`, or from `b` depending on truly value
     /// of corresponding vector component. `true` selects value from `a` and `false` from `b`.
     #[inline]
-    pub fn select_point<T: Copy, U>(&self, a: Point3D<T, U>, b: Point3D<T, U>) -> Point3D<T, U> {
+    pub fn select_point<T, U>(&self, a: Point3D<T, U>, b: Point3D<T, U>) -> Point3D<T, U> {
         point3(
             if self.x { a.x } else { b.x },
             if self.y { a.y } else { b.y },
@@ -1463,7 +1463,7 @@ impl BoolVector3D {
     /// Returns vector, each component of which or from `a`, or from `b` depending on truly value
     /// of corresponding vector component. `true` selects value from `a` and `false` from `b`.
     #[inline]
-    pub fn select_vector<T: Copy, U>(&self, a: Vector3D<T, U>, b: Vector3D<T, U>) -> Vector3D<T, U> {
+    pub fn select_vector<T, U>(&self, a: Vector3D<T, U>, b: Vector3D<T, U>) -> Vector3D<T, U> {
         vec3(
             if self.x { a.x } else { b.x },
             if self.y { a.y } else { b.y },
@@ -1475,7 +1475,7 @@ impl BoolVector3D {
     /// of corresponding vector component. `true` selects value from `a` and `false` from `b`.
     #[inline]
     #[must_use]
-    pub fn select_size<T: Copy, U>(&self, a: Size3D<T, U>, b: Size3D<T, U>) -> Size3D<T, U> {
+    pub fn select_size<T, U>(&self, a: Size3D<T, U>, b: Size3D<T, U>) -> Size3D<T, U> {
         size3(
             if self.x { a.width } else { b.width },
             if self.y { a.height } else { b.height },


### PR DESCRIPTION
The implementation of many traits is far from perfect, in a set of places there are restrictions on types that are not required at all for work. Overall, they look more or less random, added only to shut up the compiler. This is an attempt to relax some of these restrictions