### PR TITLE
Provide `approx_eq` and implement `ApproxEq` for Transform2D and Transform3D

### DIFF
--- a/src/approxeq.rs
+++ b/src/approxeq.rs
@@ -9,9 +9,18 @@
 
 /// Trait for testing approximate equality
 pub trait ApproxEq<Eps> {
+    /// Default epsilon value
     fn approx_epsilon() -> Eps;
-    fn approx_eq(&self, other: &Self) -> bool;
+
+    /// Returns `true` is this object is approximately equal to the other one, using
+    /// a provided epsilon value.
     fn approx_eq_eps(&self, other: &Self, approx_epsilon: &Eps) -> bool;
+
+    /// Returns `true` is this object is approximately equal to the other one, using
+    /// the `approx_epsilon()` epsilon value.
+    fn approx_eq(&self, other: &Self) -> bool {
+        self.approx_eq_eps(other, &Self::approx_epsilon())
+    }
 }
 
 macro_rules! approx_eq {
@@ -20,10 +29,6 @@ macro_rules! approx_eq {
             #[inline]
             fn approx_epsilon() -> $ty {
                 $eps
-            }
-            #[inline]
-            fn approx_eq(&self, other: &$ty) -> bool {
-                self.approx_eq_eps(other, &$eps)
             }
             #[inline]
             fn approx_eq_eps(&self, other: &$ty, approx_epsilon: &$ty) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@
 //! All euclid types are marked `#[repr(C)]` in order to facilitate exposing them to
 //! foreign function interfaces (provided the underlying scalar type is also `repr(C)`).
 //!
+#![deny(unconditional_recursion)]
 
 #[cfg(feature = "serde")]
 #[macro_use]

--- a/src/point.rs
+++ b/src/point.rs
@@ -661,11 +661,6 @@ impl<T: ApproxEq<T>, U> ApproxEq<Point2D<T, U>> for Point2D<T, U> {
     }
 
     #[inline]
-    fn approx_eq(&self, other: &Self) -> bool {
-        self.x.approx_eq(&other.x) && self.y.approx_eq(&other.y)
-    }
-
-    #[inline]
     fn approx_eq_eps(&self, other: &Self, eps: &Self) -> bool {
         self.x.approx_eq_eps(&other.x, &eps.x) && self.y.approx_eq_eps(&other.y, &eps.y)
     }
@@ -1382,11 +1377,6 @@ impl<T: ApproxEq<T>, U> ApproxEq<Point3D<T, U>> for Point3D<T, U> {
             T::approx_epsilon(),
             T::approx_epsilon(),
         )
-    }
-
-    #[inline]
-    fn approx_eq(&self, other: &Self) -> bool {
-        self.x.approx_eq(&other.x) && self.y.approx_eq(&other.y) && self.z.approx_eq(&other.z)
     }
 
     #[inline]

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -667,10 +667,6 @@ where
         T::approx_epsilon()
     }
 
-    fn approx_eq(&self, other: &Self) -> bool {
-        self.approx_eq_eps(other, &Self::approx_epsilon())
-    }
-
     fn approx_eq_eps(&self, other: &Self, eps: &T) -> bool {
         (self.i.approx_eq_eps(&other.i, eps) && self.j.approx_eq_eps(&other.j, eps)
             && self.k.approx_eq_eps(&other.k, eps) && self.r.approx_eq_eps(&other.r, eps))

--- a/src/transform2d.rs
+++ b/src/transform2d.rs
@@ -160,6 +160,31 @@ impl<T, Src, Dst> Transform2D<T, Src, Dst> {
             _unit: PhantomData,
         }
     }
+
+
+    /// Returns true is this transform is approximately equal to the other one, using
+    /// T's default epsilon value.
+    ///
+    /// The same as [`ApproxEq::approx_eq()`] but available without importing trait.
+    ///
+    /// [`ApproxEq::approx_eq()`]: ./approxeq/trait.ApproxEq.html#method.approx_eq
+    #[inline]
+    pub fn approx_eq(&self, other: &Self) -> bool
+    where T : ApproxEq<T> {
+        <Self as ApproxEq<T>>::approx_eq(&self, &other)
+    }
+
+    /// Returns true is this transform is approximately equal to the other one, using
+    /// a provided epsilon value.
+    ///
+    /// The same as [`ApproxEq::approx_eq_eps()`] but available without importing trait.
+    ///
+    /// [`ApproxEq::approx_eq_eps()`]: ./approxeq/trait.ApproxEq.html#method.approx_eq_eps
+    #[inline]
+    pub fn approx_eq_eps(&self, other: &Self, eps: &T) -> bool
+    where T : ApproxEq<T> {
+        <Self as ApproxEq<T>>::approx_eq_eps(&self, &other, &eps)
+    }
 }
 
 impl<T: Copy, Src, Dst> Transform2D<T, Src, Dst> {
@@ -546,18 +571,13 @@ impl <T, Src, Dst> Default for Transform2D<T, Src, Dst>
     }
 }
 
-impl<T: ApproxEq<T>, Src, Dst> Transform2D<T, Src, Dst> {
-    /// Returns true is this transform is approximately equal to the other one, using
-    /// T's default epsilon value.
-    pub fn approx_eq(&self, other: &Self) -> bool {
-        self.m11.approx_eq(&other.m11) && self.m12.approx_eq(&other.m12) &&
-        self.m21.approx_eq(&other.m21) && self.m22.approx_eq(&other.m22) &&
-        self.m31.approx_eq(&other.m31) && self.m32.approx_eq(&other.m32)
-    }
+impl<T: ApproxEq<T>, Src, Dst> ApproxEq<T> for Transform2D<T, Src, Dst> {
+    #[inline]
+    fn approx_epsilon() -> T { T::approx_epsilon() }
 
     /// Returns true is this transform is approximately equal to the other one, using
     /// a provided epsilon value.
-    pub fn approx_eq_eps(&self, other: &Self, eps: &T) -> bool {
+    fn approx_eq_eps(&self, other: &Self, eps: &T) -> bool {
         self.m11.approx_eq_eps(&other.m11, eps) && self.m12.approx_eq_eps(&other.m12, eps) &&
         self.m21.approx_eq_eps(&other.m21, eps) && self.m22.approx_eq_eps(&other.m22, eps) &&
         self.m31.approx_eq_eps(&other.m31, eps) && self.m32.approx_eq_eps(&other.m32, eps)

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -325,30 +325,26 @@ where T: Copy +
 
     /// Returns true is this transform is approximately equal to the other one, using
     /// T's default epsilon value.
+    ///
+    /// The same as [`ApproxEq::approx_eq()`] but available without importing trait.
+    ///
+    /// [`ApproxEq::approx_eq()`]: ./approxeq/trait.ApproxEq.html#method.approx_eq
+    #[inline]
     pub fn approx_eq(&self, other: &Self) -> bool
     where T : ApproxEq<T> {
-        self.m11.approx_eq(&other.m11) && self.m12.approx_eq(&other.m12) &&
-        self.m13.approx_eq(&other.m13) && self.m14.approx_eq(&other.m14) &&
-        self.m21.approx_eq(&other.m21) && self.m22.approx_eq(&other.m22) &&
-        self.m23.approx_eq(&other.m23) && self.m24.approx_eq(&other.m24) &&
-        self.m31.approx_eq(&other.m31) && self.m32.approx_eq(&other.m32) &&
-        self.m33.approx_eq(&other.m33) && self.m34.approx_eq(&other.m34) &&
-        self.m41.approx_eq(&other.m41) && self.m42.approx_eq(&other.m42) &&
-        self.m43.approx_eq(&other.m43) && self.m44.approx_eq(&other.m44)
+        <Self as ApproxEq<T>>::approx_eq(&self, &other)
     }
 
     /// Returns true is this transform is approximately equal to the other one, using
     /// a provided epsilon value.
+    ///
+    /// The same as [`ApproxEq::approx_eq_eps()`] but available without importing trait.
+    ///
+    /// [`ApproxEq::approx_eq_eps()`]: ./approxeq/trait.ApproxEq.html#method.approx_eq_eps
+    #[inline]
     pub fn approx_eq_eps(&self, other: &Self, eps: &T) -> bool
     where T : ApproxEq<T> {
-        self.m11.approx_eq_eps(&other.m11, eps) && self.m12.approx_eq_eps(&other.m12, eps) &&
-        self.m13.approx_eq_eps(&other.m13, eps) && self.m14.approx_eq_eps(&other.m14, eps) &&
-        self.m21.approx_eq_eps(&other.m21, eps) && self.m22.approx_eq_eps(&other.m22, eps) &&
-        self.m23.approx_eq_eps(&other.m23, eps) && self.m24.approx_eq_eps(&other.m24, eps) &&
-        self.m31.approx_eq_eps(&other.m31, eps) && self.m32.approx_eq_eps(&other.m32, eps) &&
-        self.m33.approx_eq_eps(&other.m33, eps) && self.m34.approx_eq_eps(&other.m34, eps) &&
-        self.m41.approx_eq_eps(&other.m41, eps) && self.m42.approx_eq_eps(&other.m42, eps) &&
-        self.m43.approx_eq_eps(&other.m43, eps) && self.m44.approx_eq_eps(&other.m44, eps)
+        <Self as ApproxEq<T>>::approx_eq_eps(&self, &other, &eps)
     }
 
     /// Returns the same transform with a different destination unit.
@@ -955,6 +951,22 @@ impl<T: NumCast + Copy, Src, Dst> Transform3D<T, Src, Dst> {
             },
             _ => None
         }
+    }
+}
+
+impl<T: ApproxEq<T>, Src, Dst> ApproxEq<T> for Transform3D<T, Src, Dst> {
+    #[inline]
+    fn approx_epsilon() -> T { T::approx_epsilon() }
+
+    fn approx_eq_eps(&self, other: &Self, eps: &T) -> bool {
+        self.m11.approx_eq_eps(&other.m11, eps) && self.m12.approx_eq_eps(&other.m12, eps) &&
+        self.m13.approx_eq_eps(&other.m13, eps) && self.m14.approx_eq_eps(&other.m14, eps) &&
+        self.m21.approx_eq_eps(&other.m21, eps) && self.m22.approx_eq_eps(&other.m22, eps) &&
+        self.m23.approx_eq_eps(&other.m23, eps) && self.m24.approx_eq_eps(&other.m24, eps) &&
+        self.m31.approx_eq_eps(&other.m31, eps) && self.m32.approx_eq_eps(&other.m32, eps) &&
+        self.m33.approx_eq_eps(&other.m33, eps) && self.m34.approx_eq_eps(&other.m34, eps) &&
+        self.m41.approx_eq_eps(&other.m41, eps) && self.m42.approx_eq_eps(&other.m42, eps) &&
+        self.m43.approx_eq_eps(&other.m43, eps) && self.m44.approx_eq_eps(&other.m44, eps)
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -637,11 +637,6 @@ impl<T: ApproxEq<T>, U> ApproxEq<Vector2D<T, U>> for Vector2D<T, U> {
     }
 
     #[inline]
-    fn approx_eq(&self, other: &Self) -> bool {
-        self.x.approx_eq(&other.x) && self.y.approx_eq(&other.y)
-    }
-
-    #[inline]
     fn approx_eq_eps(&self, other: &Self, eps: &Self) -> bool {
         self.x.approx_eq_eps(&other.x, &eps.x) && self.y.approx_eq_eps(&other.y, &eps.y)
     }
@@ -1308,11 +1303,6 @@ impl<T: ApproxEq<T>, U> ApproxEq<Vector3D<T, U>> for Vector3D<T, U> {
             T::approx_epsilon(),
             T::approx_epsilon(),
         )
-    }
-
-    #[inline]
-    fn approx_eq(&self, other: &Self) -> bool {
-        self.x.approx_eq(&other.x) && self.y.approx_eq(&other.y) && self.z.approx_eq(&other.z)
     }
 
     #[inline]


### PR DESCRIPTION
Other geometry primitives implements that trait, so for consistency I implement it for Transform objects too.

This is small breaking change in `Transform2D` and `Transform3D` -- now you must import `approxeq::ApproxEq` if you want to compare transforms approximately.