### PR TITLE
Implement ApproxEq for more types

### DIFF
--- a/src/angle.rs
+++ b/src/angle.rs
@@ -199,59 +199,51 @@ impl<T: ApproxEq<T>> ApproxEq<T> for Angle<T> {
 
 #[test]
 fn wrap_angles() {
-    use approxeq::ApproxEq;
     use core::f32::consts::{FRAC_PI_2, PI};
 
-    assert!(Angle::radians(0.0).positive().radians.approx_eq(&0.0));
+    assert!(Angle::radians(0.0).positive().approx_eq(&Angle::zero()));
     assert!(
         Angle::radians(FRAC_PI_2)
             .positive()
-            .radians
-            .approx_eq(&FRAC_PI_2)
+            .approx_eq(&Angle::frac_pi_2())
     );
     assert!(
         Angle::radians(-FRAC_PI_2)
             .positive()
-            .radians
-            .approx_eq(&(3.0 * FRAC_PI_2))
+            .approx_eq(&Angle::radians(3.0 * FRAC_PI_2))
     );
     assert!(
         Angle::radians(3.0 * FRAC_PI_2)
             .positive()
-            .radians
-            .approx_eq(&(3.0 * FRAC_PI_2))
+            .approx_eq(&Angle::radians(3.0 * FRAC_PI_2))
     );
     assert!(
         Angle::radians(5.0 * FRAC_PI_2)
             .positive()
-            .radians
-            .approx_eq(&FRAC_PI_2)
+            .approx_eq(&Angle::frac_pi_2())
     );
-    assert!(Angle::radians(2.0 * PI).positive().radians.approx_eq(&0.0));
-    assert!(Angle::radians(-2.0 * PI).positive().radians.approx_eq(&0.0));
-    assert!(Angle::radians(PI).positive().radians.approx_eq(&PI));
-    assert!(Angle::radians(-PI).positive().radians.approx_eq(&PI));
+    assert!(Angle::radians(2.0 * PI).positive().approx_eq(&Angle::zero()));
+    assert!(Angle::radians(-2.0 * PI).positive().approx_eq(&Angle::zero()));
+    assert!(Angle::radians(PI).positive().approx_eq(&Angle::pi()));
+    assert!(Angle::radians(-PI).positive().approx_eq(&Angle::pi()));
 
     assert!(
         Angle::radians(FRAC_PI_2)
             .signed()
-            .radians
-            .approx_eq(&FRAC_PI_2)
+            .approx_eq(&Angle::frac_pi_2())
     );
     assert!(
         Angle::radians(3.0 * FRAC_PI_2)
             .signed()
-            .radians
-            .approx_eq(&-FRAC_PI_2)
+            .approx_eq(&-Angle::frac_pi_2())
     );
     assert!(
         Angle::radians(5.0 * FRAC_PI_2)
             .signed()
-            .radians
-            .approx_eq(&FRAC_PI_2)
+            .approx_eq(&Angle::frac_pi_2())
     );
-    assert!(Angle::radians(2.0 * PI).signed().radians.approx_eq(&0.0));
-    assert!(Angle::radians(-2.0 * PI).signed().radians.approx_eq(&0.0));
-    assert!(Angle::radians(-PI).signed().radians.approx_eq(&PI));
-    assert!(Angle::radians(PI).signed().radians.approx_eq(&PI));
+    assert!(Angle::radians(2.0 * PI).signed().approx_eq(&Angle::zero()));
+    assert!(Angle::radians(-2.0 * PI).signed().approx_eq(&Angle::zero()));
+    assert!(Angle::radians(-PI).signed().approx_eq(&Angle::pi()));
+    assert!(Angle::radians(PI).signed().approx_eq(&Angle::pi()));
 }

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -12,6 +12,7 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, Sub, S
 use core::cmp::{Eq, PartialEq};
 use core::hash::{Hash};
 use trig::Trig;
+use approxeq::ApproxEq;
 #[cfg(feature = "serde")]
 use serde;
 
@@ -181,6 +182,18 @@ impl<T: Neg<Output = T>> Neg for Angle<T> {
     type Output = Self;
     fn neg(self) -> Self {
         Angle::radians(-self.radians)
+    }
+}
+
+impl<T: ApproxEq<T>> ApproxEq<T> for Angle<T> {
+    #[inline]
+    fn approx_epsilon() -> T {
+        T::approx_epsilon()
+    }
+
+    #[inline]
+    fn approx_eq_eps(&self, other: &Angle<T>, approx_epsilon: &T) -> bool {
+        self.radians.approx_eq_eps(&other.radians, approx_epsilon)
     }
 }
 

--- a/src/length.rs
+++ b/src/length.rs
@@ -10,6 +10,7 @@
 
 use scale::Scale;
 use num::Zero;
+use approxeq::ApproxEq;
 
 use num_traits::{NumCast, Saturating};
 use num::One;
@@ -284,6 +285,18 @@ where
     pub fn lerp(&self, other: Self, t: T) -> Self {
         let one_t = T::one() - t;
         Length::new(one_t * self.get() + t * other.get())
+    }
+}
+
+impl<U, T: ApproxEq<T>> ApproxEq<T> for Length<T, U> {
+    #[inline]
+    fn approx_epsilon() -> T {
+        T::approx_epsilon()
+    }
+
+    #[inline]
+    fn approx_eq_eps(&self, other: &Length<T, U>, approx_epsilon: &T) -> bool {
+        self.0.approx_eq_eps(&other.0, approx_epsilon)
     }
 }
 


### PR DESCRIPTION
This adds a couple `ApproxEq<T>` implementations I needed access to.