### PR TITLE
Various doc fixes

### DIFF
--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -317,9 +317,6 @@ where
     T: Copy + One + Add<Output = T> + Sub<Output = T> + Mul<Output = T>,
 {
     /// Linearly interpolate between this box and another box.
-    ///
-    /// When `t` is `One::one()`, returned value equals to `other`,
-    /// otherwise equals to `self`.
     #[inline]
     pub fn lerp(&self, other: Self, t: T) -> Self {
         Self::new(

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -299,9 +299,6 @@ where
     T: Copy + One + Add<Output = T> + Sub<Output = T> + Mul<Output = T>,
 {
     /// Linearly interpolate between this box3d and another box3d.
-    ///
-    /// When `t` is `One::one()`, returned value equals to `other`,
-    /// otherwise equals to `self`.
     #[inline]
     pub fn lerp(&self, other: Self, t: T) -> Self {
         Self::new(

--- a/src/length.rs
+++ b/src/length.rs
@@ -98,22 +98,19 @@ impl<T: Clone, U> Length<T, U> {
 
     /// Linearly interpolate between this length and another length.
     ///
-    /// When `t` is `One::one()`, returned value equals to `other`,
-    /// otherwise equals to `self`.
-    ///
     /// # Example
     ///
     /// ```rust
     /// use euclid::default::Length;
     ///
-    /// let first = Length::new(0.0);
-    /// let last  = Length::new(8.0);
+    /// let from = Length::new(0.0);
+    /// let to = Length::new(8.0);
     ///
-    /// assert_eq!(first.lerp(last, -1.0), Length::new(-8.0));
-    /// assert_eq!(first.lerp(last,  0.0), Length::new( 0.0));
-    /// assert_eq!(first.lerp(last,  0.5), Length::new( 4.0));
-    /// assert_eq!(first.lerp(last,  1.0), Length::new( 8.0));
-    /// assert_eq!(first.lerp(last,  2.0), Length::new(16.0));
+    /// assert_eq!(from.lerp(to, -1.0), Length::new(-8.0));
+    /// assert_eq!(from.lerp(to,  0.0), Length::new( 0.0));
+    /// assert_eq!(from.lerp(to,  0.5), Length::new( 4.0));
+    /// assert_eq!(from.lerp(to,  1.0), Length::new( 8.0));
+    /// assert_eq!(from.lerp(to,  2.0), Length::new(16.0));
     /// ```
     #[inline]
     pub fn lerp(&self, other: Self, t: T) -> Self

--- a/src/length.rs
+++ b/src/length.rs
@@ -77,7 +77,7 @@ where
 }
 
 impl<T, U> Length<T, U> {
-    /// Associates a number with a unit of measure, creating type-safe wrapper
+    /// Associate a value with a unit of measure.
     #[inline]
     pub const fn new(x: T) -> Self {
         Length(x, PhantomData)
@@ -85,7 +85,7 @@ impl<T, U> Length<T, U> {
 }
 
 impl<T: Clone, U> Length<T, U> {
-    /// Unpacks this type-safe wrapper into underlying value, cloning its
+    /// Unpack the underlying value from the wrapper, cloning it.
     pub fn get(&self) -> T {
         self.0.clone()
     }

--- a/src/point.rs
+++ b/src/point.rs
@@ -339,23 +339,20 @@ impl<T: Copy, U> Point2D<T, U> {
 
     /// Linearly interpolate between this point and another point.
     ///
-    /// When `t` is `One::one()`, returned value equals to `other`,
-    /// otherwise equals to `self`.
-    ///
     /// # Example
     ///
     /// ```rust
     /// use euclid::point2;
     /// use euclid::default::Point2D;
     ///
-    /// let first: Point2D<_> = point2(0.0, 10.0);
-    /// let last:  Point2D<_> = point2(8.0, -4.0);
+    /// let from: Point2D<_> = point2(0.0, 10.0);
+    /// let to:  Point2D<_> = point2(8.0, -4.0);
     ///
-    /// assert_eq!(first.lerp(last, -1.0), point2(-8.0,  24.0));
-    /// assert_eq!(first.lerp(last,  0.0), point2( 0.0,  10.0));
-    /// assert_eq!(first.lerp(last,  0.5), point2( 4.0,   3.0));
-    /// assert_eq!(first.lerp(last,  1.0), point2( 8.0,  -4.0));
-    /// assert_eq!(first.lerp(last,  2.0), point2(16.0, -18.0));
+    /// assert_eq!(from.lerp(to, -1.0), point2(-8.0,  24.0));
+    /// assert_eq!(from.lerp(to,  0.0), point2( 0.0,  10.0));
+    /// assert_eq!(from.lerp(to,  0.5), point2( 4.0,   3.0));
+    /// assert_eq!(from.lerp(to,  1.0), point2( 8.0,  -4.0));
+    /// assert_eq!(from.lerp(to,  2.0), point2(16.0, -18.0));
     /// ```
     #[inline]
     pub fn lerp(&self, other: Self, t: T) -> Self
@@ -1037,23 +1034,20 @@ impl<T: Copy, U> Point3D<T, U> {
 
     /// Linearly interpolate between this point and another point.
     ///
-    /// When `t` is `One::one()`, returned value equals to `other`,
-    /// otherwise equals to `self`.
-    ///
     /// # Example
     ///
     /// ```rust
     /// use euclid::point3;
     /// use euclid::default::Point3D;
     ///
-    /// let first: Point3D<_> = point3(0.0, 10.0, -1.0);
-    /// let last:  Point3D<_> = point3(8.0, -4.0,  0.0);
+    /// let from: Point3D<_> = point3(0.0, 10.0, -1.0);
+    /// let to:  Point3D<_> = point3(8.0, -4.0,  0.0);
     ///
-    /// assert_eq!(first.lerp(last, -1.0), point3(-8.0,  24.0, -2.0));
-    /// assert_eq!(first.lerp(last,  0.0), point3( 0.0,  10.0, -1.0));
-    /// assert_eq!(first.lerp(last,  0.5), point3( 4.0,   3.0, -0.5));
-    /// assert_eq!(first.lerp(last,  1.0), point3( 8.0,  -4.0,  0.0));
-    /// assert_eq!(first.lerp(last,  2.0), point3(16.0, -18.0,  1.0));
+    /// assert_eq!(from.lerp(to, -1.0), point3(-8.0,  24.0, -2.0));
+    /// assert_eq!(from.lerp(to,  0.0), point3( 0.0,  10.0, -1.0));
+    /// assert_eq!(from.lerp(to,  0.5), point3( 4.0,   3.0, -0.5));
+    /// assert_eq!(from.lerp(to,  1.0), point3( 8.0,  -4.0,  0.0));
+    /// assert_eq!(from.lerp(to,  2.0), point3(16.0, -18.0,  1.0));
     /// ```
     #[inline]
     pub fn lerp(&self, other: Self, t: T) -> Self

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -329,9 +329,6 @@ where
     T: Copy + One + Add<Output = T> + Sub<Output = T> + Mul<Output = T>,
 {
     /// Linearly interpolate between this rectangle and another rectangle.
-    ///
-    /// When `t` is `One::one()`, returned value equals to `other`,
-    /// otherwise equals to `self`.
     #[inline]
     pub fn lerp(&self, other: Self, t: T) -> Self {
         Self::new(

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -395,7 +395,7 @@ where
 
     #[inline]
     pub fn square_norm(&self) -> T {
-        (self.i * self.i + self.j * self.j + self.k * self.k + self.r * self.r)
+        self.i * self.i + self.j * self.j + self.k * self.k + self.r * self.r
     }
 
     /// Returns a unit quaternion from this one.

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -456,9 +456,6 @@ where
     }
 
     /// Basic Linear interpolation between this rotation and another rotation.
-    ///
-    /// When `t` is `One::one()`, returned value equals to `other`,
-    /// otherwise equals to `self`.
     #[inline]
     pub fn lerp(&self, other: &Self, t: T) -> Self {
         let one_t = T::one() - t;

--- a/src/size.rs
+++ b/src/size.rs
@@ -244,23 +244,20 @@ impl<T: Copy, U> Size2D<T, U> {
 
     /// Linearly interpolate each component between this size and another size.
     ///
-    /// When `t` is `One::one()`, returned value equals to `other`,
-    /// otherwise equals to `self`.
-    ///
     /// # Example
     ///
     /// ```rust
     /// use euclid::size2;
     /// use euclid::default::Size2D;
     ///
-    /// let first: Size2D<_> = size2(0.0, 10.0);
-    /// let last:  Size2D<_> = size2(8.0, -4.0);
+    /// let from: Size2D<_> = size2(0.0, 10.0);
+    /// let to:  Size2D<_> = size2(8.0, -4.0);
     ///
-    /// assert_eq!(first.lerp(last, -1.0), size2(-8.0,  24.0));
-    /// assert_eq!(first.lerp(last,  0.0), size2( 0.0,  10.0));
-    /// assert_eq!(first.lerp(last,  0.5), size2( 4.0,   3.0));
-    /// assert_eq!(first.lerp(last,  1.0), size2( 8.0,  -4.0));
-    /// assert_eq!(first.lerp(last,  2.0), size2(16.0, -18.0));
+    /// assert_eq!(from.lerp(to, -1.0), size2(-8.0,  24.0));
+    /// assert_eq!(from.lerp(to,  0.0), size2( 0.0,  10.0));
+    /// assert_eq!(from.lerp(to,  0.5), size2( 4.0,   3.0));
+    /// assert_eq!(from.lerp(to,  1.0), size2( 8.0,  -4.0));
+    /// assert_eq!(from.lerp(to,  2.0), size2(16.0, -18.0));
     /// ```
     #[inline]
     pub fn lerp(&self, other: Self, t: T) -> Self
@@ -1080,23 +1077,20 @@ impl<T: Copy, U> Size3D<T, U> {
 
     /// Linearly interpolate between this size and another size.
     ///
-    /// When `t` is `One::one()`, returned value equals to `other`,
-    /// otherwise equals to `self`.
-    ///
     /// # Example
     ///
     /// ```rust
     /// use euclid::size3;
     /// use euclid::default::Size3D;
     ///
-    /// let first: Size3D<_> = size3(0.0, 10.0, -1.0);
-    /// let last:  Size3D<_> = size3(8.0, -4.0,  0.0);
+    /// let from: Size3D<_> = size3(0.0, 10.0, -1.0);
+    /// let to:  Size3D<_> = size3(8.0, -4.0,  0.0);
     ///
-    /// assert_eq!(first.lerp(last, -1.0), size3(-8.0,  24.0, -2.0));
-    /// assert_eq!(first.lerp(last,  0.0), size3( 0.0,  10.0, -1.0));
-    /// assert_eq!(first.lerp(last,  0.5), size3( 4.0,   3.0, -0.5));
-    /// assert_eq!(first.lerp(last,  1.0), size3( 8.0,  -4.0,  0.0));
-    /// assert_eq!(first.lerp(last,  2.0), size3(16.0, -18.0,  1.0));
+    /// assert_eq!(from.lerp(to, -1.0), size3(-8.0,  24.0, -2.0));
+    /// assert_eq!(from.lerp(to,  0.0), size3( 0.0,  10.0, -1.0));
+    /// assert_eq!(from.lerp(to,  0.5), size3( 4.0,   3.0, -0.5));
+    /// assert_eq!(from.lerp(to,  1.0), size3( 8.0,  -4.0,  0.0));
+    /// assert_eq!(from.lerp(to,  2.0), size3(16.0, -18.0,  1.0));
     /// ```
     #[inline]
     pub fn lerp(&self, other: Self, t: T) -> Self

--- a/src/size.rs
+++ b/src/size.rs
@@ -450,7 +450,7 @@ impl<T: PartialEq, U> Size2D<T, U> {
 
 
 impl<T: Round, U> Round for Size2D<T, U> {
-    /// See [`Size2D::round()`](#method.round)
+    /// See [`Size2D::round()`](#method.round).
     #[inline]
     fn round(self) -> Self {
         (&self).round()
@@ -458,7 +458,7 @@ impl<T: Round, U> Round for Size2D<T, U> {
 }
 
 impl<T: Ceil, U> Ceil for Size2D<T, U> {
-    /// See [`Size2D::ceil()`](#method.ceil)
+    /// See [`Size2D::ceil()`](#method.ceil).
     #[inline]
     fn ceil(self) -> Self {
         (&self).ceil()
@@ -466,7 +466,7 @@ impl<T: Ceil, U> Ceil for Size2D<T, U> {
 }
 
 impl<T: Floor, U> Floor for Size2D<T, U> {
-    /// See [`Size2D::floor()`](#method.floor)
+    /// See [`Size2D::floor()`](#method.floor).
     #[inline]
     fn floor(self) -> Self {
         (&self).floor()
@@ -1279,7 +1279,7 @@ impl<T: PartialEq, U> Size3D<T, U> {
 
 
 impl<T: Round, U> Round for Size3D<T, U> {
-    /// See [`Size3D::round()`](#method.round)
+    /// See [`Size3D::round()`](#method.round).
     #[inline]
     fn round(self) -> Self {
         (&self).round()
@@ -1287,7 +1287,7 @@ impl<T: Round, U> Round for Size3D<T, U> {
 }
 
 impl<T: Ceil, U> Ceil for Size3D<T, U> {
-    /// See [`Size3D::ceil()`](#method.ceil)
+    /// See [`Size3D::ceil()`](#method.ceil).
     #[inline]
     fn ceil(self) -> Self {
         (&self).ceil()
@@ -1295,7 +1295,7 @@ impl<T: Ceil, U> Ceil for Size3D<T, U> {
 }
 
 impl<T: Floor, U> Floor for Size3D<T, U> {
-    /// See [`Size3D::floor()`](#method.floor)
+    /// See [`Size3D::floor()`](#method.floor).
     #[inline]
     fn floor(self) -> Self {
         (&self).floor()

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -446,23 +446,20 @@ where
 {
     /// Linearly interpolate each component between this vector and another vector.
     ///
-    /// When `t` is `One::one()`, returned value equals to `other`,
-    /// otherwise equals to `self`.
-    ///
     /// # Example
     ///
     /// ```rust
     /// use euclid::vec2;
     /// use euclid::default::Vector2D;
     ///
-    /// let first: Vector2D<_> = vec2(0.0, 10.0);
-    /// let last:  Vector2D<_> = vec2(8.0, -4.0);
+    /// let from: Vector2D<_> = vec2(0.0, 10.0);
+    /// let to:  Vector2D<_> = vec2(8.0, -4.0);
     ///
-    /// assert_eq!(first.lerp(last, -1.0), vec2(-8.0,  24.0));
-    /// assert_eq!(first.lerp(last,  0.0), vec2( 0.0,  10.0));
-    /// assert_eq!(first.lerp(last,  0.5), vec2( 4.0,   3.0));
-    /// assert_eq!(first.lerp(last,  1.0), vec2( 8.0,  -4.0));
-    /// assert_eq!(first.lerp(last,  2.0), vec2(16.0, -18.0));
+    /// assert_eq!(from.lerp(to, -1.0), vec2(-8.0,  24.0));
+    /// assert_eq!(from.lerp(to,  0.0), vec2( 0.0,  10.0));
+    /// assert_eq!(from.lerp(to,  0.5), vec2( 4.0,   3.0));
+    /// assert_eq!(from.lerp(to,  1.0), vec2( 8.0,  -4.0));
+    /// assert_eq!(from.lerp(to,  2.0), vec2(16.0, -18.0));
     /// ```
     #[inline]
     pub fn lerp(&self, other: Self, t: T) -> Self {
@@ -1227,23 +1224,20 @@ where
 {
     /// Linearly interpolate each component between this vector and another vector.
     ///
-    /// When `t` is `One::one()`, returned value equals to `other`,
-    /// otherwise equals to `self`.
-    ///
     /// # Example
     ///
     /// ```rust
     /// use euclid::vec3;
     /// use euclid::default::Vector3D;
     ///
-    /// let first: Vector3D<_> = vec3(0.0, 10.0, -1.0);
-    /// let last:  Vector3D<_> = vec3(8.0, -4.0,  0.0);
+    /// let from: Vector3D<_> = vec3(0.0, 10.0, -1.0);
+    /// let to:  Vector3D<_> = vec3(8.0, -4.0,  0.0);
     ///
-    /// assert_eq!(first.lerp(last, -1.0), vec3(-8.0,  24.0, -2.0));
-    /// assert_eq!(first.lerp(last,  0.0), vec3( 0.0,  10.0, -1.0));
-    /// assert_eq!(first.lerp(last,  0.5), vec3( 4.0,   3.0, -0.5));
-    /// assert_eq!(first.lerp(last,  1.0), vec3( 8.0,  -4.0,  0.0));
-    /// assert_eq!(first.lerp(last,  2.0), vec3(16.0, -18.0,  1.0));
+    /// assert_eq!(from.lerp(to, -1.0), vec3(-8.0,  24.0, -2.0));
+    /// assert_eq!(from.lerp(to,  0.0), vec3( 0.0,  10.0, -1.0));
+    /// assert_eq!(from.lerp(to,  0.5), vec3( 4.0,   3.0, -0.5));
+    /// assert_eq!(from.lerp(to,  1.0), vec3( 8.0,  -4.0,  0.0));
+    /// assert_eq!(from.lerp(to,  2.0), vec3(16.0, -18.0,  1.0));
     /// ```
     #[inline]
     pub fn lerp(&self, other: Self, t: T) -> Self {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -33,9 +33,9 @@ use serde;
 /// A 2d Vector tagged with a unit.
 #[repr(C)]
 pub struct Vector2D<T, U> {
-    /// The `x` (traditionally, horizontal) coordinate
+    /// The `x` (traditionally, horizontal) coordinate.
     pub x: T,
-    /// The `y` (traditionally, vertical) coordinate
+    /// The `y` (traditionally, vertical) coordinate.
     pub y: T,
     #[doc(hidden)]
     pub _unit: PhantomData<U>,
@@ -234,7 +234,7 @@ impl<T: Copy, U> Vector2D<T, U> {
         vec2(self.x, self.y)
     }
 
-    /// Cast the unit
+    /// Cast the unit.
     #[inline]
     pub fn cast_unit<V>(&self) -> Vector2D<T, V> {
         vec2(self.x, self.y)
@@ -343,7 +343,7 @@ where
         + One
         + Zero
 {
-    /// Creates translation by this vector in vector units
+    /// Creates translation by this vector in vector units.
     #[inline]
     pub fn to_transform(&self) -> Transform2D<T, U, U> {
         Transform2D::create_translation(self.x, self.y)
@@ -355,7 +355,7 @@ where
     T: Copy + Mul<T, Output = T> + Add<T, Output = T>,
 {
 
-    /// Returns length square.
+    /// Returns the vector's length squared.
     #[inline]
     pub fn square_length(&self) -> T {
         self.x * self.x + self.y * self.y
@@ -390,7 +390,7 @@ impl<T: Float, U> Vector2D<T, U> {
         self.square_length().sqrt()
     }
 
-    /// Returns the vector with length of one unit
+    /// Returns the vector with length of one unit.
     #[inline]
     #[must_use]
     pub fn normalize(self) -> Self {
@@ -562,7 +562,7 @@ impl<T: NumCast + Copy, U> Vector2D<T, U> {
         }
     }
 
-    // Convenience functions for common casts
+    // Convenience functions for common casts.
 
     /// Cast into an `f32` vector.
     #[inline]
@@ -802,11 +802,11 @@ impl<T, U> From<Size2D<T, U>> for Vector2D<T, U> {
 /// A 3d Vector tagged with a unit.
 #[repr(C)]
 pub struct Vector3D<T, U> {
-    /// The `x` (traditionally, horizontal) coordinate
+    /// The `x` (traditionally, horizontal) coordinate.
     pub x: T,
-    /// The `y` (traditionally, vertical) coordinate
+    /// The `y` (traditionally, vertical) coordinate.
     pub y: T,
-    /// The `z` (traditionally, depth) coordinate
+    /// The `z` (traditionally, depth) coordinate.
     pub z: T,
     #[doc(hidden)]
     pub _unit: PhantomData<U>,
@@ -1039,7 +1039,7 @@ impl<T: Copy, U> Vector3D<T, U> {
         vec3(self.x, self.y, self.z)
     }
 
-    /// Cast the unit
+    /// Cast the unit.
     #[inline]
     pub fn cast_unit<V>(&self) -> Vector3D<T, V> {
         vec3(self.x, self.y, self.z)
@@ -1133,7 +1133,7 @@ impl<T, U> Vector3D<T, U>
 where
     T: Copy + Mul<T, Output = T> + Add<T, Output = T>
 {
-    /// Returns length square.
+    /// Returns the vector's length squared.
     #[inline]
     pub fn square_length(&self) -> T {
         self.x * self.x + self.y * self.y + self.z * self.z
@@ -1356,7 +1356,7 @@ impl<T: NumCast + Copy, U> Vector3D<T, U> {
         }
     }
 
-    // Convenience functions for common casts
+    // Convenience functions for common casts.
 
     /// Cast into an `f32` vector.
     #[inline]
@@ -1601,29 +1601,18 @@ impl<T, U> From<(T, T, T)> for Vector3D<T, U> {
 }
 
 
-/// Result of boolean operations on [`Size2D`] or [`Vector2D`].
-///
-/// [`Size2D`]: struct.Size2D.html
-/// [`Vector2D`]: struct.Vector2D.html
+/// A 2d vector of booleans, useful for component-wise logic operations.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct BoolVector2D {
-    /// Result of boolean operation on `x` vector coordinates or `width` component of size
     pub x: bool,
-    /// Result of boolean operation on `y` vector coordinates or `height` component of size
     pub y: bool,
 }
 
-/// Result of boolean operations on [`Size3D`] or [`Vector3D`].
-///
-/// [`Size3D`]: struct.Size3D.html
-/// [`Vector3D`]: struct.Vector3D.html
+/// A 3d vector of booleans, useful for component-wise logic operations.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct BoolVector3D {
-    /// Result of boolean operation on `x` vector coordinates or `width` component of size
     pub x: bool,
-    /// Result of boolean operation on `y` vector coordinates or `height` component of size
     pub y: bool,
-    /// Result of boolean operation on `z` vector coordinates or `depth` component of size
     pub z: bool,
 }
 
@@ -1788,7 +1777,7 @@ impl BoolVector3D {
         )
     }
 
-    /// Returns a 2d vector using this vector's x and y coordinates
+    /// Returns a 2d vector using this vector's x and y coordinates.
     #[inline]
     pub fn xy(&self) -> BoolVector2D {
         BoolVector2D {
@@ -1797,7 +1786,7 @@ impl BoolVector3D {
         }
     }
 
-    /// Returns a 2d vector using this vector's x and z coordinates
+    /// Returns a 2d vector using this vector's x and z coordinates.
     #[inline]
     pub fn xz(&self) -> BoolVector2D {
         BoolVector2D {
@@ -1806,7 +1795,7 @@ impl BoolVector3D {
         }
     }
 
-    /// Returns a 2d vector using this vector's y and z coordinates
+    /// Returns a 2d vector using this vector's y and z coordinates.
     #[inline]
     pub fn yz(&self) -> BoolVector2D {
         BoolVector2D {


### PR DESCRIPTION
Most of it is just adding points at the end of sentences and removing a part of `lerp` doc which was either confusingly phrased or completely wrong.

Also addresses a compiler warning about unnecessary parentheses.