### PR TITLE
Propagate formatting parameters to each components for more types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.20.9"
+version = "0.20.10"
 authors = ["The Servo Project Developers"]
 description = "Geometry primitives"
 documentation = "https://docs.rs/euclid/"

--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -63,13 +63,10 @@ impl<T: Eq, U> Eq for Box2D<T, U> {}
 
 impl<T: fmt::Debug, U> fmt::Debug for Box2D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Box2D(")?;
-        fmt::Debug::fmt(&self.min, f)?;
-        write!(f, ", ")?;
-        fmt::Debug::fmt(&self.max, f)?;
-        write!(f, ")")?;
-
-        Ok(())
+        f.debug_tuple("Box2D")
+            .field(&self.min)
+            .field(&self.max)
+            .finish()
     }
 }
 
@@ -79,9 +76,7 @@ impl<T: fmt::Display, U> fmt::Display for Box2D<T, U> {
         fmt::Display::fmt(&self.min, f)?;
         write!(f, ", ")?;
         fmt::Display::fmt(&self.max, f)?;
-        write!(f, ")")?;
-
-        Ok(())
+        write!(f, ")")
     }
 }
 

--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -63,13 +63,25 @@ impl<T: Eq, U> Eq for Box2D<T, U> {}
 
 impl<T: fmt::Debug, U> fmt::Debug for Box2D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Box2D({:?}, {:?})", self.min, self.max)
+        write!(f, "Box2D(")?;
+        fmt::Debug::fmt(&self.min, f)?;
+        write!(f, ", ")?;
+        fmt::Debug::fmt(&self.max, f)?;
+        write!(f, ")")?;
+
+        Ok(())
     }
 }
 
 impl<T: fmt::Display, U> fmt::Display for Box2D<T, U> {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "Box2D({}, {})", self.min, self.max)
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Box2D(")?;
+        fmt::Display::fmt(&self.min, f)?;
+        write!(f, ", ")?;
+        fmt::Display::fmt(&self.max, f)?;
+        write!(f, ")")?;
+
+        Ok(())
     }
 }
 

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -61,13 +61,25 @@ impl<T: Eq, U> Eq for Box3D<T, U> {}
 
 impl<T: fmt::Debug, U> fmt::Debug for Box3D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Box3D({:?}, {:?})", self.min, self.max)
+        write!(f, "Box3D(")?;
+        fmt::Debug::fmt(&self.min, f)?;
+        write!(f, ", ")?;
+        fmt::Debug::fmt(&self.max, f)?;
+        write!(f, ")")?;
+
+        Ok(())
     }
 }
 
 impl<T: fmt::Display, U> fmt::Display for Box3D<T, U> {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "Box3D({}, {})", self.min, self.max)
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Box3D(")?;
+        fmt::Display::fmt(&self.min, f)?;
+        write!(f, ", ")?;
+        fmt::Display::fmt(&self.max, f)?;
+        write!(f, ")")?;
+
+        Ok(())
     }
 }
 

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -61,13 +61,10 @@ impl<T: Eq, U> Eq for Box3D<T, U> {}
 
 impl<T: fmt::Debug, U> fmt::Debug for Box3D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Box3D(")?;
-        fmt::Debug::fmt(&self.min, f)?;
-        write!(f, ", ")?;
-        fmt::Debug::fmt(&self.max, f)?;
-        write!(f, ")")?;
-
-        Ok(())
+        f.debug_tuple("Box3D")
+            .field(&self.min)
+            .field(&self.max)
+            .finish()
     }
 }
 
@@ -77,9 +74,7 @@ impl<T: fmt::Display, U> fmt::Display for Box3D<T, U> {
         fmt::Display::fmt(&self.min, f)?;
         write!(f, ", ")?;
         fmt::Display::fmt(&self.max, f)?;
-        write!(f, ")")?;
-
-        Ok(())
+        write!(f, ")")
     }
 }
 

--- a/src/homogen.rs
+++ b/src/homogen.rs
@@ -155,13 +155,33 @@ impl<T: One, U> From<Point3D<T, U>> for HomogeneousVector<T, U> {
 
 impl<T: fmt::Debug, U> fmt::Debug for HomogeneousVector<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "({:?},{:?},{:?},{:?})", self.x, self.y, self.z, self.w)
+        write!(f, "(")?;
+        fmt::Debug::fmt(&self.x, f)?;
+        write!(f, ",")?;
+        fmt::Debug::fmt(&self.y, f)?;
+        write!(f, ",")?;
+        fmt::Debug::fmt(&self.z, f)?;
+        write!(f, ",")?;
+        fmt::Debug::fmt(&self.w, f)?;
+        write!(f, ")")?;
+
+        Ok(())
     }
 }
 
 impl<T: fmt::Display, U> fmt::Display for HomogeneousVector<T, U> {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "({},{},{},{})", self.x, self.y, self.z, self.w)
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "(")?;
+        fmt::Display::fmt(&self.x, f)?;
+        write!(f, ",")?;
+        fmt::Display::fmt(&self.y, f)?;
+        write!(f, ",")?;
+        fmt::Display::fmt(&self.z, f)?;
+        write!(f, ",")?;
+        fmt::Display::fmt(&self.w, f)?;
+        write!(f, ")")?;
+
+        Ok(())
     }
 }
 

--- a/src/homogen.rs
+++ b/src/homogen.rs
@@ -155,17 +155,12 @@ impl<T: One, U> From<Point3D<T, U>> for HomogeneousVector<T, U> {
 
 impl<T: fmt::Debug, U> fmt::Debug for HomogeneousVector<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "(")?;
-        fmt::Debug::fmt(&self.x, f)?;
-        write!(f, ",")?;
-        fmt::Debug::fmt(&self.y, f)?;
-        write!(f, ",")?;
-        fmt::Debug::fmt(&self.z, f)?;
-        write!(f, ",")?;
-        fmt::Debug::fmt(&self.w, f)?;
-        write!(f, ")")?;
-
-        Ok(())
+        f.debug_tuple("")
+            .field(&self.x)
+            .field(&self.y)
+            .field(&self.z)
+            .field(&self.w)
+            .finish()
     }
 }
 
@@ -179,9 +174,7 @@ impl<T: fmt::Display, U> fmt::Display for HomogeneousVector<T, U> {
         fmt::Display::fmt(&self.z, f)?;
         write!(f, ",")?;
         fmt::Display::fmt(&self.w, f)?;
-        write!(f, ")")?;
-
-        Ok(())
+        write!(f, ")")
     }
 }
 

--- a/src/point.rs
+++ b/src/point.rs
@@ -93,13 +93,10 @@ mint_vec!(Point2D[x, y] = Point2);
 
 impl<T: fmt::Debug, U> fmt::Debug for Point2D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "(")?;
-        fmt::Debug::fmt(&self.x, f)?;
-        write!(f, ",")?;
-        fmt::Debug::fmt(&self.y, f)?;
-        write!(f, ")")?;
-
-        Ok(())
+        f.debug_tuple("")
+            .field(&self.x)
+            .field(&self.y)
+            .finish()
     }
 }
 
@@ -109,9 +106,7 @@ impl<T: fmt::Display, U> fmt::Display for Point2D<T, U> {
         fmt::Display::fmt(&self.x, formatter)?;
         write!(formatter, ",")?;
         fmt::Display::fmt(&self.y, formatter)?;
-        write!(formatter, ")")?;
-
-        Ok(())
+        write!(formatter, ")")
     }
 }
 
@@ -775,15 +770,11 @@ impl<T, U> Hash for Point3D<T, U>
 
 impl<T: fmt::Debug, U> fmt::Debug for Point3D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "(")?;
-        fmt::Debug::fmt(&self.x, f)?;
-        write!(f, ",")?;
-        fmt::Debug::fmt(&self.y, f)?;
-        write!(f, ",")?;
-        fmt::Debug::fmt(&self.z, f)?;
-        write!(f, ")")?;
-
-        Ok(())
+        f.debug_tuple("")
+            .field(&self.x)
+            .field(&self.y)
+            .field(&self.z)
+            .finish()
     }
 }
 
@@ -795,9 +786,7 @@ impl<T: fmt::Display, U> fmt::Display for Point3D<T, U> {
         fmt::Display::fmt(&self.y, f)?;
         write!(f, ",")?;
         fmt::Display::fmt(&self.z, f)?;
-        write!(f, ")")?;
-
-        Ok(())
+        write!(f, ")")
     }
 }
 
@@ -1704,7 +1693,7 @@ mod point2d {
         pub fn test_point_debug_formatting() {
             let n = 1.23456789;
             let p1 = Point2D::new(n, -n);
-            let should_be = format!("({:.4},{:.4})", n, -n);
+            let should_be = format!("({:.4}, {:.4})", n, -n);
 
             let got = format!("{:.4?}", p1);
 

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -67,9 +67,7 @@ impl<T: fmt::Debug, U> fmt::Debug for Rect<T, U> {
         fmt::Debug::fmt(&self.size, f)?;
         write!(f, " at ")?;
         fmt::Debug::fmt(&self.origin, f)?;
-        write!(f, ")")?;
-
-        Ok(())
+        write!(f, ")")
     }
 }
 
@@ -79,9 +77,7 @@ impl<T: fmt::Display, U> fmt::Display for Rect<T, U> {
         fmt::Display::fmt(&self.size, f)?;
         write!(f, " at ")?;
         fmt::Display::fmt(&self.origin, f)?;
-        write!(f, ")")?;
-
-        Ok(())
+        write!(f, ")")
     }
 }
 

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -63,13 +63,25 @@ impl<T: Eq, U> Eq for Rect<T, U> {}
 
 impl<T: fmt::Debug, U> fmt::Debug for Rect<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Rect({:?} at {:?})", self.size, self.origin)
+        write!(f, "Rect(")?;
+        fmt::Debug::fmt(&self.size, f)?;
+        write!(f, " at ")?;
+        fmt::Debug::fmt(&self.origin, f)?;
+        write!(f, ")")?;
+
+        Ok(())
     }
 }
 
 impl<T: fmt::Display, U> fmt::Display for Rect<T, U> {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "Rect({} at {})", self.size, self.origin)
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Rect(")?;
+        fmt::Display::fmt(&self.size, f)?;
+        write!(f, " at ")?;
+        fmt::Display::fmt(&self.origin, f)?;
+        write!(f, ")")?;
+
+        Ok(())
     }
 }
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -97,9 +97,7 @@ impl<T: fmt::Debug, U> fmt::Debug for Size2D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&self.width, f)?;
         write!(f, "x")?;
-        fmt::Debug::fmt(&self.height, f)?;
-
-        Ok(())
+        fmt::Debug::fmt(&self.height, f)
     }
 }
 
@@ -109,9 +107,7 @@ impl<T: fmt::Display, U> fmt::Display for Size2D<T, U> {
         fmt::Display::fmt(&self.width, f)?;
         write!(f, "x")?;
         fmt::Display::fmt(&self.height, f)?;
-        write!(f, ")")?;
-
-        Ok(())
+        write!(f, ")")
     }
 }
 
@@ -944,9 +940,7 @@ impl<T: fmt::Debug, U> fmt::Debug for Size3D<T, U> {
         write!(f, "x")?;
         fmt::Debug::fmt(&self.height, f)?;
         write!(f, "x")?;
-        fmt::Debug::fmt(&self.depth, f)?;
-
-        Ok(())
+        fmt::Debug::fmt(&self.depth, f)
     }
 }
 
@@ -958,9 +952,7 @@ impl<T: fmt::Display, U> fmt::Display for Size3D<T, U> {
         fmt::Display::fmt(&self.height, f)?;
         write!(f, "x")?;
         fmt::Display::fmt(&self.depth, f)?;
-        write!(f, ")")?;
-
-        Ok(())
+        write!(f, ")")
     }
 }
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -95,13 +95,23 @@ impl<T, U> Hash for Size2D<T, U>
 
 impl<T: fmt::Debug, U> fmt::Debug for Size2D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}×{:?}", self.width, self.height)
+        fmt::Debug::fmt(&self.width, f)?;
+        write!(f, "x")?;
+        fmt::Debug::fmt(&self.height, f)?;
+
+        Ok(())
     }
 }
 
 impl<T: fmt::Display, U> fmt::Display for Size2D<T, U> {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "({}x{})", self.width, self.height)
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "(")?;
+        fmt::Display::fmt(&self.width, f)?;
+        write!(f, "x")?;
+        fmt::Display::fmt(&self.height, f)?;
+        write!(f, ")")?;
+
+        Ok(())
     }
 }
 
@@ -930,13 +940,27 @@ impl<T, U> Hash for Size3D<T, U>
 
 impl<T: fmt::Debug, U> fmt::Debug for Size3D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}×{:?}×{:?}", self.width, self.height, self.depth)
+        fmt::Debug::fmt(&self.width, f)?;
+        write!(f, "x")?;
+        fmt::Debug::fmt(&self.height, f)?;
+        write!(f, "x")?;
+        fmt::Debug::fmt(&self.depth, f)?;
+
+        Ok(())
     }
 }
 
 impl<T: fmt::Display, U> fmt::Display for Size3D<T, U> {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "({}x{}x{})", self.width, self.height, self.depth)
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "(")?;
+        fmt::Display::fmt(&self.width, f)?;
+        write!(f, "x")?;
+        fmt::Display::fmt(&self.height, f)?;
+        write!(f, "x")?;
+        fmt::Display::fmt(&self.depth, f)?;
+        write!(f, ")")?;
+
+        Ok(())
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -103,13 +103,10 @@ impl<T: Zero, U> Zero for Vector2D<T, U> {
 
 impl<T: fmt::Debug, U> fmt::Debug for Vector2D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "(")?;
-        fmt::Debug::fmt(&self.x, f)?;
-        write!(f, ",")?;
-        fmt::Debug::fmt(&self.y, f)?;
-        write!(f, ")")?;
-
-        Ok(())
+        f.debug_tuple("")
+            .field(&self.x)
+            .field(&self.y)
+            .finish()
     }
 }
 
@@ -891,15 +888,11 @@ impl<T: Zero, U> Zero for Vector3D<T, U> {
 
 impl<T: fmt::Debug, U> fmt::Debug for Vector3D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "(")?;
-        fmt::Debug::fmt(&self.x, f)?;
-        write!(f, ",")?;
-        fmt::Debug::fmt(&self.y, f)?;
-        write!(f, ",")?;
-        fmt::Debug::fmt(&self.z, f)?;
-        write!(f, ")")?;
-
-        Ok(())
+        f.debug_tuple("")
+            .field(&self.x)
+            .field(&self.y)
+            .field(&self.z)
+            .finish()
     }
 }
 
@@ -911,9 +904,7 @@ impl<T: fmt::Display, U> fmt::Display for Vector3D<T, U> {
         fmt::Display::fmt(&self.y, f)?;
         write!(f, ",")?;
         fmt::Display::fmt(&self.z, f)?;
-        write!(f, ")")?;
-
-        Ok(())
+        write!(f, ")")
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -103,13 +103,25 @@ impl<T: Zero, U> Zero for Vector2D<T, U> {
 
 impl<T: fmt::Debug, U> fmt::Debug for Vector2D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "({:?},{:?})", self.x, self.y)
+        write!(f, "(")?;
+        fmt::Debug::fmt(&self.x, f)?;
+        write!(f, ",")?;
+        fmt::Debug::fmt(&self.y, f)?;
+        write!(f, ")")?;
+
+        Ok(())
     }
 }
 
 impl<T: fmt::Display, U> fmt::Display for Vector2D<T, U> {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "({},{})", self.x, self.y)
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "(")?;
+        fmt::Display::fmt(&self.x, f)?;
+        write!(f, ",")?;
+        fmt::Display::fmt(&self.y, f)?;
+        write!(f, ")")?;
+
+        Ok(())
     }
 }
 
@@ -879,13 +891,29 @@ impl<T: Zero, U> Zero for Vector3D<T, U> {
 
 impl<T: fmt::Debug, U> fmt::Debug for Vector3D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "({:?},{:?},{:?})", self.x, self.y, self.z)
+        write!(f, "(")?;
+        fmt::Debug::fmt(&self.x, f)?;
+        write!(f, ",")?;
+        fmt::Debug::fmt(&self.y, f)?;
+        write!(f, ",")?;
+        fmt::Debug::fmt(&self.z, f)?;
+        write!(f, ")")?;
+
+        Ok(())
     }
 }
 
 impl<T: fmt::Display, U> fmt::Display for Vector3D<T, U> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "({},{},{})", self.x, self.y, self.z)
+        write!(f, "(")?;
+        fmt::Display::fmt(&self.x, f)?;
+        write!(f, ",")?;
+        fmt::Display::fmt(&self.y, f)?;
+        write!(f, ",")?;
+        fmt::Display::fmt(&self.z, f)?;
+        write!(f, ")")?;
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Following up on #419, ensure the Debug and Display implementations propagate formatting parameters for more of euclid's types.

This allows people to control, for example, the number of digits in the formatting syntax like `println!("{:.3?}", rect);`.