### PR TITLE
Some refactoring, *Assign operators and box transform methods for Translations

### DIFF
--- a/src/translation.rs
+++ b/src/translation.rs
@@ -91,6 +91,34 @@ impl<T, Src, Dst> Translation2D<T, Src, Dst> {
         }
     }
 
+    /// Creates no-op translation (both `x` and `y` is `zero()`).
+    #[inline]
+    pub fn identity() -> Self
+    where
+        T: Zero,
+    {
+        Self::new(T::zero(), T::zero())
+    }
+
+    /// Check if translation does nothing (both x and y is `zero()`).
+    ///
+    /// ```rust
+    /// use euclid::default::Translation2D;
+    ///
+    /// assert_eq!(Translation2D::<f32>::identity().is_identity(), true);
+    /// assert_eq!(Translation2D::new(0, 0).is_identity(), true);
+    /// assert_eq!(Translation2D::new(1, 0).is_identity(), false);
+    /// assert_eq!(Translation2D::new(0, 1).is_identity(), false);
+    /// ```
+    #[inline]
+    pub fn is_identity(&self) -> bool
+    where
+        T: Zero + PartialEq
+    {
+        let _0 = T::zero();
+        self.x == _0 && self.y == _0
+    }
+
     /// No-op, just cast the unit.
     #[inline]
     pub fn transform_size(&self, s: Size2D<T, Src>) -> Size2D<T, Dst> {
@@ -98,10 +126,7 @@ impl<T, Src, Dst> Translation2D<T, Src, Dst> {
     }
 }
 
-impl<T, Src, Dst> Translation2D<T, Src, Dst>
-where
-    T : Copy
-{
+impl<T: Copy, Src, Dst> Translation2D<T, Src, Dst> {
     /// Cast into a 2D vector.
     #[inline]
     pub fn to_vector(&self) -> Vector2D<T, Src> {
@@ -138,27 +163,6 @@ where
             y: t.y,
             _unit: PhantomData,
         }
-    }
-}
-
-impl<T, Src, Dst> Translation2D<T, Src, Dst>
-where
-    T: Zero
-{
-    #[inline]
-    pub fn identity() -> Self {
-        Translation2D::new(T::zero(), T::zero())
-    }
-}
-
-impl<T, Src, Dst> Translation2D<T, Src, Dst>
-where
-    T: Zero + PartialEq
-{
-    #[inline]
-    pub fn is_identity(&self) -> bool {
-        let _0 = T::zero();
-        self.x == _0 && self.y == _0
     }
 }
 
@@ -373,6 +377,35 @@ impl<T, Src, Dst> Translation3D<T, Src, Dst> {
         }
     }
 
+    /// Creates no-op translation (`x`, `y` and `z` is `zero()`).
+    #[inline]
+    pub fn identity() -> Self
+    where
+        T: Zero,
+    {
+        Translation3D::new(T::zero(), T::zero(), T::zero())
+    }
+
+    /// Check if translation does nothing (`x`, `y` and `z` is `zero()`).
+    ///
+    /// ```rust
+    /// use euclid::default::Translation3D;
+    ///
+    /// assert_eq!(Translation3D::<f32>::identity().is_identity(), true);
+    /// assert_eq!(Translation3D::new(0, 0, 0).is_identity(), true);
+    /// assert_eq!(Translation3D::new(1, 0, 0).is_identity(), false);
+    /// assert_eq!(Translation3D::new(0, 1, 0).is_identity(), false);
+    /// assert_eq!(Translation3D::new(0, 0, 1).is_identity(), false);
+    /// ```
+    #[inline]
+    pub fn is_identity(&self) -> bool
+    where
+        T: Zero + PartialEq
+    {
+        let _0 = T::zero();
+        self.x == _0 && self.y == _0 && self.z == _0
+    }
+
     /// No-op, just cast the unit.
     #[inline]
     pub fn transform_size(self, s: Size2D<T, Src>) -> Size2D<T, Dst> {
@@ -380,10 +413,7 @@ impl<T, Src, Dst> Translation3D<T, Src, Dst> {
     }
 }
 
-impl<T, Src, Dst> Translation3D<T, Src, Dst>
-where
-    T: Copy
-{
+impl<T: Copy, Src, Dst> Translation3D<T, Src, Dst> {
     /// Cast into a 3D vector.
     #[inline]
     pub fn to_vector(&self) -> Vector3D<T, Src> {
@@ -422,27 +452,6 @@ where
             z: t.z,
             _unit: PhantomData,
         }
-    }
-}
-
-impl<T, Src, Dst> Translation3D<T, Src, Dst>
-where
-    T: Zero
-{
-    #[inline]
-    pub fn identity() -> Self {
-        Translation3D::new(T::zero(), T::zero(), T::zero())
-    }
-}
-
-impl<T, Src, Dst> Translation3D<T, Src, Dst>
-where
-    T: Zero + PartialEq
-{
-    #[inline]
-    pub fn is_identity(&self) -> bool {
-        let _0 = T::zero();
-        self.x == _0 && self.y == _0 && self.z == _0
     }
 }
 

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -12,7 +12,7 @@ use {Size2D, Rect, vec2, point2, vec3, point3};
 use UnknownUnit;
 use num::*;
 use trig::Trig;
-use core::ops::{Add, Sub, Neg, Mul, Div};
+use core::ops::{Add, AddAssign, Sub, SubAssign, Neg, Mul, Div};
 use core::marker::PhantomData;
 use core::fmt;
 use core::cmp::{Eq, PartialEq};
@@ -208,6 +208,13 @@ impl<T: Add, Src, Dst1, Dst2> Add<Translation2D<T, Dst1, Dst2>> for Translation2
     }
 }
 
+impl<T: AddAssign, Src, Dst> AddAssign<Translation2D<T, Dst, Dst>> for Translation2D<T, Src, Dst> {
+    fn add_assign(&mut self, other: Translation2D<T, Dst, Dst>) {
+        self.x += other.x;
+        self.y += other.y;
+    }
+}
+
 
 impl<T: Sub, Src, Dst1, Dst2> Sub<Translation2D<T, Dst1, Dst2>> for Translation2D<T, Src, Dst2> {
     type Output = Translation2D<T::Output, Src, Dst1>;
@@ -217,6 +224,13 @@ impl<T: Sub, Src, Dst1, Dst2> Sub<Translation2D<T, Dst1, Dst2>> for Translation2
             self.x - other.x,
             self.y - other.y,
         )
+    }
+}
+
+impl<T: SubAssign, Src, Dst> SubAssign<Translation2D<T, Dst, Dst>> for Translation2D<T, Src, Dst> {
+    fn sub_assign(&mut self, other: Translation2D<T, Dst, Dst>) {
+        self.x -= other.x;
+        self.y -= other.y;
     }
 }
 
@@ -503,6 +517,14 @@ impl<T: Add, Src, Dst1, Dst2> Add<Translation3D<T, Dst1, Dst2>> for Translation3
     }
 }
 
+impl<T: AddAssign, Src, Dst> AddAssign<Translation3D<T, Dst, Dst>> for Translation3D<T, Src, Dst> {
+    fn add_assign(&mut self, other: Translation3D<T, Dst, Dst>) {
+        self.x += other.x;
+        self.y += other.y;
+        self.z += other.z;
+    }
+}
+
 
 impl<T: Sub, Src, Dst1, Dst2> Sub<Translation3D<T, Dst1, Dst2>> for Translation3D<T, Src, Dst2> {
     type Output = Translation3D<T::Output, Src, Dst1>;
@@ -513,6 +535,14 @@ impl<T: Sub, Src, Dst1, Dst2> Sub<Translation3D<T, Dst1, Dst2>> for Translation3
             self.y - other.y,
             self.z - other.z,
         )
+    }
+}
+
+impl<T: SubAssign, Src, Dst> SubAssign<Translation3D<T, Dst, Dst>> for Translation3D<T, Src, Dst> {
+    fn sub_assign(&mut self, other: Translation3D<T, Dst, Dst>) {
+        self.x -= other.x;
+        self.y -= other.y;
+        self.z -= other.z;
     }
 }
 
@@ -636,6 +666,25 @@ mod _2d {
         }
 
         #[test]
+        pub fn test_add_assign() {
+            let mut t = Translation2D::new(1.0, 2.0);
+            t += Translation2D::new(3.0, 4.0);
+            assert_eq!(t, Translation2D::new(4.0, 6.0));
+
+            let mut t = Translation2D::new(1.0, 2.0);
+            t += Translation2D::new(0.0, 0.0);
+            assert_eq!(t, Translation2D::new(1.0, 2.0));
+
+            let mut t = Translation2D::new(1.0, 2.0);
+            t += Translation2D::new(-3.0, -4.0);
+            assert_eq!(t, Translation2D::new(-2.0, -2.0));
+
+            let mut t = Translation2D::new(0.0, 0.0);
+            t += Translation2D::new(0.0, 0.0);
+            assert_eq!(t, Translation2D::new(0.0, 0.0));
+        }
+
+        #[test]
         pub fn test_sub() {
             let t1 = Translation2D::new(1.0, 2.0);
             let t2 = Translation2D::new(3.0, 4.0);
@@ -652,6 +701,25 @@ mod _2d {
             let t1 = Translation2D::new(0.0, 0.0);
             let t2 = Translation2D::new(0.0, 0.0);
             assert_eq!(t1 - t2, Translation2D::new(0.0, 0.0));
+        }
+
+        #[test]
+        pub fn test_sub_assign() {
+            let mut t = Translation2D::new(1.0, 2.0);
+            t -= Translation2D::new(3.0, 4.0);
+            assert_eq!(t, Translation2D::new(-2.0, -2.0));
+
+            let mut t = Translation2D::new(1.0, 2.0);
+            t -= Translation2D::new(0.0, 0.0);
+            assert_eq!(t, Translation2D::new(1.0, 2.0));
+
+            let mut t = Translation2D::new(1.0, 2.0);
+            t -= Translation2D::new(-3.0, -4.0);
+            assert_eq!(t, Translation2D::new(4.0, 6.0));
+
+            let mut t = Translation2D::new(0.0, 0.0);
+            t -= Translation2D::new(0.0, 0.0);
+            assert_eq!(t, Translation2D::new(0.0, 0.0));
         }
     }
 }
@@ -704,6 +772,25 @@ mod _3d {
         }
 
         #[test]
+        pub fn test_add_assign() {
+            let mut t = Translation3D::new(1.0, 2.0, 3.0);
+            t += Translation3D::new(4.0, 5.0, 6.0);
+            assert_eq!(t, Translation3D::new(5.0, 7.0, 9.0));
+
+            let mut t = Translation3D::new(1.0, 2.0, 3.0);
+            t += Translation3D::new(0.0, 0.0, 0.0);
+            assert_eq!(t, Translation3D::new(1.0, 2.0, 3.0));
+
+            let mut t = Translation3D::new( 1.0,  2.0,  3.0);
+            t += Translation3D::new(-4.0, -5.0, -6.0);
+            assert_eq!(t, Translation3D::new(-3.0, -3.0, -3.0));
+
+            let mut t = Translation3D::new(0.0, 0.0, 0.0);
+            t += Translation3D::new(0.0, 0.0, 0.0);
+            assert_eq!(t, Translation3D::new(0.0, 0.0, 0.0));
+        }
+
+        #[test]
         pub fn test_sub() {
             let t1 = Translation3D::new(1.0, 2.0, 3.0);
             let t2 = Translation3D::new(4.0, 5.0, 6.0);
@@ -720,6 +807,25 @@ mod _3d {
             let t1 = Translation3D::new(0.0, 0.0, 0.0);
             let t2 = Translation3D::new(0.0, 0.0, 0.0);
             assert_eq!(t1 - t2, Translation3D::new(0.0, 0.0, 0.0));
+        }
+
+        #[test]
+        pub fn test_sub_assign() {
+            let mut t = Translation3D::new(1.0, 2.0, 3.0);
+            t -= Translation3D::new(4.0, 5.0, 6.0);
+            assert_eq!(t, Translation3D::new(-3.0, -3.0, -3.0));
+
+            let mut t = Translation3D::new(1.0, 2.0, 3.0);
+            t -= Translation3D::new(0.0, 0.0, 0.0);
+            assert_eq!(t, Translation3D::new(1.0, 2.0, 3.0));
+
+            let mut t = Translation3D::new( 1.0,  2.0,  3.0);
+            t -= Translation3D::new(-4.0, -5.0, -6.0);
+            assert_eq!(t, Translation3D::new(5.0, 7.0, 9.0));
+
+            let mut t = Translation3D::new(0.0, 0.0, 0.0);
+            t -= Translation3D::new(0.0, 0.0, 0.0);
+            assert_eq!(t, Translation3D::new(0.0, 0.0, 0.0));
         }
     }
 }

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -8,7 +8,7 @@
 // except according to those terms.
 
 use {Vector2D, Point2D, Vector3D, Point3D, Transform2D, Transform3D};
-use {Size2D, Rect, vec2, point2, vec3, point3};
+use {Box2D, Box3D, Size2D, Rect, vec2, point2, vec3, point3};
 use UnknownUnit;
 use num::*;
 use trig::Trig;
@@ -183,6 +183,18 @@ impl<T: Copy, Src, Dst> Translation2D<T, Src, Dst> {
         Rect {
             origin: self.transform_point(r.origin),
             size: self.transform_size(r.size),
+        }
+    }
+
+    /// Translate a 2D box and cast its unit.
+    #[inline]
+    pub fn transform_box(&self, r: &Box2D<T, Src>) -> Box2D<T::Output, Dst>
+    where
+        T: Add,
+    {
+        Box2D {
+            min: self.transform_point(r.min),
+            max: self.transform_point(r.max),
         }
     }
 
@@ -480,6 +492,30 @@ impl<T: Copy, Src, Dst> Translation3D<T, Src, Dst> {
         T: Add,
     {
         point2(p.x + self.x, p.y + self.y)
+    }
+
+    /// Translate a 2D box and cast its unit.
+    #[inline]
+    pub fn transform_box2d(&self, b: &Box2D<T, Src>) -> Box2D<T::Output, Dst>
+    where
+        T: Add,
+    {
+        Box2D {
+            min: self.transform_point2d(&b.min),
+            max: self.transform_point2d(&b.max),
+        }
+    }
+
+    /// Translate a 3D box and cast its unit.
+    #[inline]
+    pub fn transform_box3d(&self, b: &Box3D<T, Src>) -> Box3D<T::Output, Dst>
+    where
+        T: Add,
+    {
+        Box3D {
+            min: self.transform_point3d(&b.min),
+            max: self.transform_point3d(&b.max),
+        }
     }
 
     /// Translate a rectangle and cast its unit.

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -164,38 +164,38 @@ impl<T: Copy, Src, Dst> Translation2D<T, Src, Dst> {
             _unit: PhantomData,
         }
     }
-}
 
-impl<T, Src, Dst> Translation2D<T, Src, Dst>
-where
-    T: Copy + Add<T, Output = T>
-{
     /// Translate a point and cast its unit.
     #[inline]
-    pub fn transform_point(&self, p: Point2D<T, Src>) -> Point2D<T, Dst> {
+    pub fn transform_point(&self, p: Point2D<T, Src>) -> Point2D<T::Output, Dst>
+    where
+        T: Add,
+    {
         point2(p.x + self.x, p.y + self.y)
     }
 
     /// Translate a rectangle and cast its unit.
     #[inline]
-    pub fn transform_rect(&self, r: &Rect<T, Src>) -> Rect<T, Dst> {
+    pub fn transform_rect(&self, r: &Rect<T, Src>) -> Rect<T::Output, Dst>
+    where
+        T: Add<Output = T>,
+    {
         Rect {
             origin: self.transform_point(r.origin),
             size: self.transform_size(r.size),
         }
     }
-}
 
-impl<T, Src, Dst> Translation2D<T, Src, Dst>
-where
-    T: Copy + Neg<Output = T>
-{
     /// Return the inverse transformation.
     #[inline]
-    pub fn inverse(&self) -> Translation2D<T, Dst, Src> {
+    pub fn inverse(&self) -> Translation2D<T::Output, Dst, Src>
+    where
+        T: Neg,
+    {
         Translation2D::new(-self.x, -self.y)
     }
 }
+
 
 impl<T, Src, Dst1, Dst2> Add<Translation2D<T, Dst1, Dst2>>
 for Translation2D<T, Src, Dst1>
@@ -453,44 +453,47 @@ impl<T: Copy, Src, Dst> Translation3D<T, Src, Dst> {
             _unit: PhantomData,
         }
     }
-}
 
-impl<T, Src, Dst> Translation3D<T, Src, Dst>
-where
-    T: Copy + Add<T, Output = T>
-{
     /// Translate a point and cast its unit.
     #[inline]
-    pub fn transform_point3d(&self, p: &Point3D<T, Src>) -> Point3D<T, Dst> {
+    pub fn transform_point3d(&self, p: &Point3D<T, Src>) -> Point3D<T::Output, Dst>
+    where
+        T: Add,
+    {
         point3(p.x + self.x, p.y + self.y, p.z + self.z)
     }
 
     /// Translate a point and cast its unit.
     #[inline]
-    pub fn transform_point2d(&self, p: &Point2D<T, Src>) -> Point2D<T, Dst> {
+    pub fn transform_point2d(&self, p: &Point2D<T, Src>) -> Point2D<T::Output, Dst>
+    where
+        T: Add,
+    {
         point2(p.x + self.x, p.y + self.y)
     }
 
     /// Translate a rectangle and cast its unit.
     #[inline]
-    pub fn transform_rect(&self, r: &Rect<T, Src>) -> Rect<T, Dst> {
+    pub fn transform_rect(&self, r: &Rect<T, Src>) -> Rect<T, Dst>
+    where
+        T: Add<Output = T>,
+    {
         Rect {
             origin: self.transform_point2d(&r.origin),
             size: self.transform_size(r.size),
         }
     }
-}
 
-impl<T, Src, Dst> Translation3D<T, Src, Dst>
-where
-    T: Copy + Neg<Output = T>
-{
     /// Return the inverse transformation.
     #[inline]
-    pub fn inverse(&self) -> Translation3D<T, Dst, Src> {
+    pub fn inverse(&self) -> Translation3D<T::Output, Dst, Src>
+    where
+        T: Neg,
+    {
         Translation3D::new(-self.x, -self.y, -self.z)
     }
 }
+
 
 impl<T, Src, Dst1, Dst2> Add<Translation3D<T, Dst1, Dst2>>
 for Translation3D<T, Src, Dst1>


### PR DESCRIPTION
As a continuation of [our discourse](https://github.com/servo/euclid/pull/411#discussion_r395735133) about by value vs by reference: added translation methods for Boxes takes its by reference, but as [godbolt](https://rust.godbolt.org/z/Kgqdjd) shows, even without forced `#[inline]` directive compiler smart enough to inline such small function and the code the same in both cases. Therefore, I'm still in favour of taking everything by value in methods that almost only change unit. For now I'm, however, use reference as in surrounding code.