### PR TITLE
Replace all `Into` impls with `From` impls

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -19,10 +19,10 @@ macro_rules! mint_vec {
             }
         }
         #[cfg(feature = "mint")]
-        impl<T, U> Into<mint::$std_name<T>> for $name<T, U> {
-            fn into(self) -> mint::$std_name<T> {
+        impl<T, U> From<$name<T, U>> for mint::$std_name<T> {
+            fn from(v: $name<T, U>) -> Self {
                 mint::$std_name {
-                    $( $field: self.$field, )*
+                    $( $field: v.$field, )*
                 }
             }
         }

--- a/src/point.rs
+++ b/src/point.rs
@@ -753,9 +753,9 @@ impl<T: Euclid, U> Point2D<T, U> {
     }
 }
 
-impl<T, U> Into<[T; 2]> for Point2D<T, U> {
-    fn into(self) -> [T; 2] {
-        [self.x, self.y]
+impl<T, U> From<Point2D<T, U>> for [T; 2] {
+    fn from(p: Point2D<T, U>) -> Self {
+        [p.x, p.y]
     }
 }
 
@@ -765,9 +765,9 @@ impl<T, U> From<[T; 2]> for Point2D<T, U> {
     }
 }
 
-impl<T, U> Into<(T, T)> for Point2D<T, U> {
-    fn into(self) -> (T, T) {
-        (self.x, self.y)
+impl<T, U> From<Point2D<T, U>> for (T, T) {
+    fn from(p: Point2D<T, U>) -> Self {
+        (p.x, p.y)
     }
 }
 
@@ -1567,9 +1567,9 @@ impl<T: Euclid, U> Point3D<T, U> {
     }
 }
 
-impl<T, U> Into<[T; 3]> for Point3D<T, U> {
-    fn into(self) -> [T; 3] {
-        [self.x, self.y, self.z]
+impl<T, U> From<Point3D<T, U>> for [T; 3] {
+    fn from(p: Point3D<T, U>) -> Self {
+        [p.x, p.y, p.z]
     }
 }
 
@@ -1579,9 +1579,9 @@ impl<T, U> From<[T; 3]> for Point3D<T, U> {
     }
 }
 
-impl<T, U> Into<(T, T, T)> for Point3D<T, U> {
-    fn into(self) -> (T, T, T) {
-        (self.x, self.y, self.z)
+impl<T, U> From<Point3D<T, U>> for (T, T, T) {
+    fn from(p: Point3D<T, U>) -> Self {
+        (p.x, p.y, p.z)
     }
 }
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -678,12 +678,12 @@ impl<T, U> From<mint::Vector2<T>> for Size2D<T, U> {
     }
 }
 #[cfg(feature = "mint")]
-impl<T, U> Into<mint::Vector2<T>> for Size2D<T, U> {
+impl<T, U> From<Size2D<T, U>> for mint::Vector2<T> {
     #[inline]
-    fn into(self) -> mint::Vector2<T> {
+    fn from(s: Size2D<T, U>) -> Self {
         mint::Vector2 {
-            x: self.width,
-            y: self.height,
+            x: s.width,
+            y: s.height,
         }
     }
 }
@@ -695,10 +695,10 @@ impl<T, U> From<Vector2D<T, U>> for Size2D<T, U> {
     }
 }
 
-impl<T, U> Into<[T; 2]> for Size2D<T, U> {
+impl<T, U> From<Size2D<T, U>> for [T; 2] {
     #[inline]
-    fn into(self) -> [T; 2] {
-        [self.width, self.height]
+    fn from(s: Size2D<T, U>) -> Self {
+        [s.width, s.height]
     }
 }
 
@@ -709,10 +709,10 @@ impl<T, U> From<[T; 2]> for Size2D<T, U> {
     }
 }
 
-impl<T, U> Into<(T, T)> for Size2D<T, U> {
+impl<T, U> From<Size2D<T, U>> for (T, T) {
     #[inline]
-    fn into(self) -> (T, T) {
-        (self.width, self.height)
+    fn from(s: Size2D<T, U>) -> Self {
+        (s.width, s.height)
     }
 }
 
@@ -1605,13 +1605,13 @@ impl<T, U> From<mint::Vector3<T>> for Size3D<T, U> {
     }
 }
 #[cfg(feature = "mint")]
-impl<T, U> Into<mint::Vector3<T>> for Size3D<T, U> {
+impl<T, U> From<Size3D<T, U>> for mint::Vector3<T> {
     #[inline]
-    fn into(self) -> mint::Vector3<T> {
+    fn from(s: Size3D<T, U>) -> Self {
         mint::Vector3 {
-            x: self.width,
-            y: self.height,
-            z: self.depth,
+            x: s.width,
+            y: s.height,
+            z: s.depth,
         }
     }
 }
@@ -1623,10 +1623,10 @@ impl<T, U> From<Vector3D<T, U>> for Size3D<T, U> {
     }
 }
 
-impl<T, U> Into<[T; 3]> for Size3D<T, U> {
+impl<T, U> From<Size3D<T, U>> for [T; 3] {
     #[inline]
-    fn into(self) -> [T; 3] {
-        [self.width, self.height, self.depth]
+    fn from(s: Size3D<T, U>) -> Self {
+        [s.width, s.height, s.depth]
     }
 }
 
@@ -1637,10 +1637,10 @@ impl<T, U> From<[T; 3]> for Size3D<T, U> {
     }
 }
 
-impl<T, U> Into<(T, T, T)> for Size3D<T, U> {
+impl<T, U> From<Size3D<T, U>> for (T, T, T) {
     #[inline]
-    fn into(self) -> (T, T, T) {
-        (self.width, self.height, self.depth)
+    fn from(s: Size3D<T, U>) -> Self {
+        (s.width, s.height, s.depth)
     }
 }
 

--- a/src/transform2d.rs
+++ b/src/transform2d.rs
@@ -659,12 +659,12 @@ impl<T, Src, Dst> From<mint::RowMatrix3x2<T>> for Transform2D<T, Src, Dst> {
     }
 }
 #[cfg(feature = "mint")]
-impl<T, Src, Dst> Into<mint::RowMatrix3x2<T>> for Transform2D<T, Src, Dst> {
-    fn into(self) -> mint::RowMatrix3x2<T> {
+impl<T, Src, Dst> From<Transform2D<T, Src, Dst>> for mint::RowMatrix3x2<T> {
+    fn from(t: Transform2D<T, Src, Dst>) -> Self {
         mint::RowMatrix3x2 {
-            x: mint::Vector2 { x: self.m11, y: self.m12 },
-            y: mint::Vector2 { x: self.m21, y: self.m22 },
-            z: mint::Vector2 { x: self.m31, y: self.m32 },
+            x: mint::Vector2 { x: t.m11, y: t.m12 },
+            y: mint::Vector2 { x: t.m21, y: t.m22 },
+            z: mint::Vector2 { x: t.m31, y: t.m32 },
         }
     }
 }

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -1141,13 +1141,13 @@ impl<T, Src, Dst> From<mint::RowMatrix4<T>> for Transform3D<T, Src, Dst> {
     }
 }
 #[cfg(feature = "mint")]
-impl<T, Src, Dst> Into<mint::RowMatrix4<T>> for Transform3D<T, Src, Dst> {
-    fn into(self) -> mint::RowMatrix4<T> {
+impl<T, Src, Dst> From<Transform3D<T, Src, Dst>> for mint::RowMatrix4<T> {
+    fn from(t: Transform3D<T, Src, Dst>) -> Self {
         mint::RowMatrix4 {
-            x: mint::Vector4 { x: self.m11, y: self.m12, z: self.m13, w: self.m14 },
-            y: mint::Vector4 { x: self.m21, y: self.m22, z: self.m23, w: self.m24 },
-            z: mint::Vector4 { x: self.m31, y: self.m32, z: self.m33, w: self.m34 },
-            w: mint::Vector4 { x: self.m41, y: self.m42, z: self.m43, w: self.m44 },
+            x: mint::Vector4 { x: t.m11, y: t.m12, z: t.m13, w: t.m14 },
+            y: mint::Vector4 { x: t.m21, y: t.m22, z: t.m23, w: t.m24 },
+            z: mint::Vector4 { x: t.m31, y: t.m32, z: t.m33, w: t.m34 },
+            w: mint::Vector4 { x: t.m41, y: t.m42, z: t.m43, w: t.m44 },
         }
     }
 }

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -296,18 +296,18 @@ impl<T, Src, Dst> From<Vector2D<T, Src>> for Translation2D<T, Src, Dst> {
     }
 }
 
-impl<T, Src, Dst> Into<Vector2D<T, Src>> for Translation2D<T, Src, Dst> {
-    fn into(self) -> Vector2D<T, Src> {
-        vec2(self.x, self.y)
+impl<T, Src, Dst> From<Translation2D<T, Src, Dst>> for Vector2D<T, Src> {
+    fn from(t: Translation2D<T, Src, Dst>) -> Self {
+        vec2(t.x, t.y)
     }
 }
 
-impl<T, Src, Dst> Into<Transform2D<T, Src, Dst>> for Translation2D<T, Src, Dst>
+impl<T, Src, Dst> From<Translation2D<T, Src, Dst>> for Transform2D<T, Src, Dst>
 where
     T: Zero + One,
 {
-    fn into(self) -> Transform2D<T, Src, Dst> {
-        Transform2D::translation(self.x, self.y)
+    fn from(t: Translation2D<T, Src, Dst>) -> Self {
+        Transform2D::translation(t.x, t.y)
     }
 }
 
@@ -624,18 +624,18 @@ impl<T, Src, Dst> From<Vector3D<T, Src>> for Translation3D<T, Src, Dst> {
     }
 }
 
-impl<T, Src, Dst> Into<Vector3D<T, Src>> for Translation3D<T, Src, Dst> {
-    fn into(self) -> Vector3D<T, Src> {
-        vec3(self.x, self.y, self.z)
+impl<T, Src, Dst> From<Translation3D<T, Src, Dst>> for Vector3D<T, Src> {
+    fn from(t: Translation3D<T, Src, Dst>) -> Self {
+        vec3(t.x, t.y, t.z)
     }
 }
 
-impl<T, Src, Dst> Into<Transform3D<T, Src, Dst>> for Translation3D<T, Src, Dst>
+impl<T, Src, Dst> From<Translation3D<T, Src, Dst>> for Transform3D<T, Src, Dst>
 where
     T: Zero + One,
 {
-    fn into(self) -> Transform3D<T, Src, Dst> {
-        Transform3D::translation(self.x, self.y, self.z)
+    fn from(t: Translation3D<T, Src, Dst>) -> Self {
+        Transform3D::translation(t.x, t.y, t.z)
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -876,9 +876,9 @@ impl<T: ApproxEq<T>, U> ApproxEq<Vector2D<T, U>> for Vector2D<T, U> {
     }
 }
 
-impl<T, U> Into<[T; 2]> for Vector2D<T, U> {
-    fn into(self) -> [T; 2] {
-        [self.x, self.y]
+impl<T, U> From<Vector2D<T, U>> for [T; 2] {
+    fn from(v: Vector2D<T, U>) -> Self {
+        [v.x, v.y]
     }
 }
 
@@ -888,9 +888,9 @@ impl<T, U> From<[T; 2]> for Vector2D<T, U> {
     }
 }
 
-impl<T, U> Into<(T, T)> for Vector2D<T, U> {
-    fn into(self) -> (T, T) {
-        (self.x, self.y)
+impl<T, U> From<Vector2D<T, U>> for (T, T) {
+    fn from(v: Vector2D<T, U>) -> Self {
+        (v.x, v.y)
     }
 }
 
@@ -901,8 +901,8 @@ impl<T, U> From<(T, T)> for Vector2D<T, U> {
 }
 
 impl<T, U> From<Size2D<T, U>> for Vector2D<T, U> {
-    fn from(size: Size2D<T, U>) -> Self {
-        vec2(size.width, size.height)
+    fn from(s: Size2D<T, U>) -> Self {
+        vec2(s.width, s.height)
     }
 }
 
@@ -1774,9 +1774,9 @@ impl<T: ApproxEq<T>, U> ApproxEq<Vector3D<T, U>> for Vector3D<T, U> {
     }
 }
 
-impl<T, U> Into<[T; 3]> for Vector3D<T, U> {
-    fn into(self) -> [T; 3] {
-        [self.x, self.y, self.z]
+impl<T, U> From<Vector3D<T, U>> for [T; 3] {
+    fn from(v: Vector3D<T, U>) -> Self {
+        [v.x, v.y, v.z]
     }
 }
 
@@ -1786,9 +1786,9 @@ impl<T, U> From<[T; 3]> for Vector3D<T, U> {
     }
 }
 
-impl<T, U> Into<(T, T, T)> for Vector3D<T, U> {
-    fn into(self) -> (T, T, T) {
-        (self.x, self.y, self.z)
+impl<T, U> From<Vector3D<T, U>> for (T, T, T) {
+    fn from(v: Vector3D<T, U>) -> Self {
+        (v.x, v.y, v.z)
     }
 }
 


### PR DESCRIPTION
As per `Into`'s documentation, `Into` should not be implemented, if
possible, and `From` should be implemented instead. This is more
flexible, as there is a blanket impl that implements `Into` for all
`From`.