### PR TITLE
Add implementations for Mul, Div, and Scale for SideOffsets2D

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.20.11"
+version = "0.20.12"
 authors = ["The Servo Project Developers"]
 edition = "2018"
 description = "Geometry primitives"


### PR DESCRIPTION
I'm planning to use `SideOffsets2D` to handle filter inflation in WebRender, but I noticed impls for using `Scale` with `SideOffsets2D` were missing.