### PR TITLE
Return true in the presence of NaN in is_empty_or_negative.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.20.13"
+version = "0.20.14"
 authors = ["The Servo Project Developers"]
 edition = "2018"
 description = "Geometry primitives"

--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -127,7 +127,7 @@ where
     /// Returns true if the size is zero or negative.
     #[inline]
     pub fn is_empty_or_negative(&self) -> bool {
-        self.max.x <= self.min.x || self.max.y <= self.min.y
+        !(self.max.x > self.min.x && self.max.y > self.min.y)
     }
 
     /// Returns `true` if the two boxes intersect.
@@ -839,5 +839,14 @@ mod tests {
             let b = Box2D::from_points(&[Point2D::from(coords_neg), Point2D::from(coords_pos)]);
             assert!(b.is_empty());
         }
+    }
+
+    #[test]
+    fn test_nan_empty_or_negative() {
+        use std::f32::NAN;
+        assert!(Box2D { min: point2(NAN, 2.0), max: point2(1.0, 3.0) }.is_empty_or_negative());
+        assert!(Box2D { min: point2(0.0, NAN), max: point2(1.0, 2.0) }.is_empty_or_negative());
+        assert!(Box2D { min: point2(1.0, -2.0), max: point2(NAN, 2.0) }.is_empty_or_negative());
+        assert!(Box2D { min: point2(1.0, -2.0), max: point2(0.0, NAN) }.is_empty_or_negative());
     }
 }

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -105,7 +105,7 @@ where
     /// Returns true if the size is zero or negative.
     #[inline]
     pub fn is_empty_or_negative(&self) -> bool {
-        self.max.x <= self.min.x || self.max.y <= self.min.y || self.max.z <= self.min.z
+        !(self.max.x > self.min.x && self.max.y > self.min.y && self.max.z > self.min.z)
     }
 
     #[inline]
@@ -879,5 +879,16 @@ mod tests {
             let b = Box3D::from_points(&[Point3D::from(coords_neg), Point3D::from(coords_pos)]);
             assert!(b.is_empty());
         }
+    }
+
+    #[test]
+    fn test_nan_empty_or_negative() {
+        use std::f32::NAN;
+        assert!(Box3D { min: point3(NAN, 2.0, 1.0), max: point3(1.0, 3.0, 5.0) }.is_empty_or_negative());
+        assert!(Box3D { min: point3(0.0, NAN, 1.0), max: point3(1.0, 2.0, 5.0) }.is_empty_or_negative());
+        assert!(Box3D { min: point3(1.0, -2.0, NAN), max: point3(3.0, 2.0, 5.0) }.is_empty_or_negative());
+        assert!(Box3D { min: point3(1.0, -2.0, 1.0), max: point3(NAN, 2.0, 5.0) }.is_empty_or_negative());
+        assert!(Box3D { min: point3(1.0, -2.0, 1.0), max: point3(0.0, NAN, 5.0) }.is_empty_or_negative());
+        assert!(Box3D { min: point3(1.0, -2.0, 1.0), max: point3(0.0, 1.0, NAN) }.is_empty_or_negative());
     }
 }

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -905,4 +905,12 @@ mod tests {
         let r: Rect<f32> = rect(1.0, 2.0, 3.0, 4.0);
         assert_eq!(r.center(), point2(2.5, 4.0));
     }
+
+    #[test]
+    fn test_nan() {
+        let r1: Rect<f32> = rect(-2.0, 5.0, 4.0, std::f32::NAN);
+        let r2: Rect<f32> = rect(std::f32::NAN, -1.0, 3.0, 10.0);
+
+        assert_eq!(r1.intersection(&r2), None);
+    }
 }

--- a/src/size.rs
+++ b/src/size.rs
@@ -432,7 +432,9 @@ impl<T: PartialOrd, U> Size2D<T, U> {
         T: Zero,
     {
         let zero = T::zero();
-        self.width <= zero || self.height <= zero
+        // The condition is experessed this way so that we return true in
+        // the presence of NaN. 
+        !(self.width > zero && self.height > zero)
     }
 }
 
@@ -857,6 +859,14 @@ mod size2d {
 
             assert_eq!(s1, Size2DMm::new(1.0, 2.0));
         }
+
+        #[test]
+        pub fn test_nan_empty() {
+            use std::f32::NAN;
+            assert!(Size2D::new(NAN, 2.0).is_empty_or_negative());
+            assert!(Size2D::new(0.0, NAN).is_empty_or_negative());
+            assert!(Size2D::new(NAN, -2.0).is_empty_or_negative());
+        }
     }
 }
 
@@ -1269,7 +1279,7 @@ impl<T: PartialOrd, U> Size3D<T, U> {
         T: Zero,
     {
         let zero = T::zero();
-        self.width <= zero || self.height <= zero || self.depth <= zero
+        !(self.width > zero && self.height > zero && self.depth <= zero)
     }
 }
 
@@ -1693,6 +1703,14 @@ mod size3d {
             s1 /= scale;
 
             assert_eq!(s1, Size3DMm::new(1.0, 2.0, 3.0));
+        }
+
+        #[test]
+        pub fn test_nan_empty() {
+            use std::f32::NAN;
+            assert!(Size3D::new(NAN, 2.0, 3.0).is_empty_or_negative());
+            assert!(Size3D::new(0.0, NAN, 0.0).is_empty_or_negative());
+            assert!(Size3D::new(1.0, 2.0, NAN).is_empty_or_negative());
         }
     }
 }


### PR DESCRIPTION
Fixes #443 in which rect intersections don't behave as expected if there is a NaN (is_empty_or_negative returned false causing us to return broken intersection rect).
Beyond intersections, we use `is_empty_or_negative` to differentiate between rects with positive non-zero area and everything else which we treat as empty or invalid-in-the-sense-that-it-doesnt-contribute-to-rendering rectangles. NaN should be part of this cathegory.

for euclid 0.21 I plan to remove `is_empty_or_negative` and simply implement `is_empty` everywhere with the semantics of "every thing that is not a valid non-zero area rectangle" since that's what's useful. It's a breaking unfortunately but there's a number them motivating a 0.21 bump.

See also https://bugzilla.mozilla.org/show_bug.cgi?id=1650990 