### PR TITLE
(breaking change) Merge is_empty and is_empty_or_negative.

### DIFF
--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -101,9 +101,9 @@ where
         self.max.x < self.min.x || self.max.y < self.min.y || self.max.z < self.min.z
     }
 
-    /// Returns true if the size is zero or negative.
+    /// Returns true if the size is zero, negative or NaN.
     #[inline]
-    pub fn is_empty_or_negative(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         !(self.max.x > self.min.x && self.max.y > self.min.y && self.max.z > self.min.z)
     }
 
@@ -135,7 +135,7 @@ where
     /// nonempty but this box3d is empty.
     #[inline]
     pub fn contains_box(&self, other: &Self) -> bool {
-        other.is_empty_or_negative()
+        other.is_empty()
             || (self.min.x <= other.min.x
                 && other.max.x <= self.max.x
                 && self.min.y <= other.min.y
@@ -151,7 +151,7 @@ where
 {
     #[inline]
     pub fn to_non_empty(&self) -> Option<NonEmpty<Self>> {
-        if self.is_empty_or_negative() {
+        if self.is_empty() {
             return None;
         }
 
@@ -372,17 +372,6 @@ where
     /// Constructor, setting all sides to zero.
     pub fn zero() -> Self {
         Box3D::new(Point3D::zero(), Point3D::zero())
-    }
-}
-
-impl<T, U> Box3D<T, U>
-where
-    T: PartialEq,
-{
-    /// Returns true if the volume is zero.
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.min.x == self.max.x || self.min.y == self.max.y || self.min.z == self.max.z
     }
 }
 
@@ -891,11 +880,11 @@ mod tests {
     #[test]
     fn test_nan_empty_or_negative() {
         use std::f32::NAN;
-        assert!(Box3D { min: point3(NAN, 2.0, 1.0), max: point3(1.0, 3.0, 5.0) }.is_empty_or_negative());
-        assert!(Box3D { min: point3(0.0, NAN, 1.0), max: point3(1.0, 2.0, 5.0) }.is_empty_or_negative());
-        assert!(Box3D { min: point3(1.0, -2.0, NAN), max: point3(3.0, 2.0, 5.0) }.is_empty_or_negative());
-        assert!(Box3D { min: point3(1.0, -2.0, 1.0), max: point3(NAN, 2.0, 5.0) }.is_empty_or_negative());
-        assert!(Box3D { min: point3(1.0, -2.0, 1.0), max: point3(0.0, NAN, 5.0) }.is_empty_or_negative());
-        assert!(Box3D { min: point3(1.0, -2.0, 1.0), max: point3(0.0, 1.0, NAN) }.is_empty_or_negative());
+        assert!(Box3D { min: point3(NAN, 2.0, 1.0), max: point3(1.0, 3.0, 5.0) }.is_empty());
+        assert!(Box3D { min: point3(0.0, NAN, 1.0), max: point3(1.0, 2.0, 5.0) }.is_empty());
+        assert!(Box3D { min: point3(1.0, -2.0, NAN), max: point3(3.0, 2.0, 5.0) }.is_empty());
+        assert!(Box3D { min: point3(1.0, -2.0, 1.0), max: point3(NAN, 2.0, 5.0) }.is_empty());
+        assert!(Box3D { min: point3(1.0, -2.0, 1.0), max: point3(0.0, NAN, 5.0) }.is_empty());
+        assert!(Box3D { min: point3(1.0, -2.0, 1.0), max: point3(0.0, 1.0, NAN) }.is_empty());
     }
 }

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -28,6 +28,22 @@ use core::hash::{Hash, Hasher};
 use core::ops::{Add, Div, DivAssign, Mul, MulAssign, Range, Sub};
 
 /// A 2d Rectangle optionally tagged with a unit.
+///
+/// # Representation
+///
+/// `Rect` is represented by an origin point and a size.
+///
+/// See [`Rect`] for a rectangle represented by two endpoints.
+///
+/// # Empty rectangle
+///
+/// A rectangle is considered empty (see [`is_empty`]) if any of the following is true:
+/// - it's area is empty,
+/// - it's area is negative (`size.x < 0` or `size.y < 0`),
+/// - it contains NaNs.
+///
+/// [`is_empty`]: #method.is_empty
+/// [`Box2D`]: struct.Box2D.html
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
@@ -211,7 +227,7 @@ where
     #[inline]
     pub fn intersection(&self, other: &Self) -> Option<Self> {
         let box2d = self.to_box2d().intersection(&other.to_box2d());
-        if box2d.is_empty_or_negative() {
+        if box2d.is_empty() {
             return None;
         }
 
@@ -245,7 +261,7 @@ where
     /// nonempty but this rectangle is empty.
     #[inline]
     pub fn contains_rect(&self, rect: &Self) -> bool {
-        rect.is_empty_or_negative()
+        rect.is_empty()
             || (self.min_x() <= rect.min_x()
                 && rect.max_x() <= self.max_x()
                 && self.min_y() <= rect.min_y()
@@ -378,24 +394,17 @@ impl<T: Copy + Mul<T, Output = T>, U> Rect<T, U> {
     }
 }
 
-impl<T: Zero + PartialEq, U> Rect<T, U> {
-    /// Returns true if the size is zero, regardless of the origin's value.
-    pub fn is_empty(&self) -> bool {
-        self.size.width == Zero::zero() || self.size.height == Zero::zero()
-    }
-}
-
 impl<T: Zero + PartialOrd, U> Rect<T, U> {
     #[inline]
-    pub fn is_empty_or_negative(&self) -> bool {
-        self.size.is_empty_or_negative()
+    pub fn is_empty(&self) -> bool {
+        self.size.is_empty()
     }
 }
 
 impl<T: Copy + Zero + PartialOrd, U> Rect<T, U> {
     #[inline]
     pub fn to_non_empty(&self) -> Option<NonEmpty<Self>> {
-        if self.is_empty_or_negative() {
+        if self.is_empty() {
             return None;
         }
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -429,8 +429,8 @@ impl<T: PartialOrd, U> Size2D<T, U> {
         }
     }
 
-    /// Returns `true` if any component of size is zero or negative.
-    pub fn is_empty_or_negative(&self) -> bool
+    /// Returns `true` if any component of size is zero, negative, or NaN.
+    pub fn is_empty(&self) -> bool
     where
         T: Zero,
     {
@@ -856,9 +856,9 @@ mod size2d {
         #[test]
         pub fn test_nan_empty() {
             use std::f32::NAN;
-            assert!(Size2D::new(NAN, 2.0).is_empty_or_negative());
-            assert!(Size2D::new(0.0, NAN).is_empty_or_negative());
-            assert!(Size2D::new(NAN, -2.0).is_empty_or_negative());
+            assert!(Size2D::new(NAN, 2.0).is_empty());
+            assert!(Size2D::new(0.0, NAN).is_empty());
+            assert!(Size2D::new(NAN, -2.0).is_empty());
         }
     }
 }
@@ -1278,8 +1278,8 @@ impl<T: PartialOrd, U> Size3D<T, U> {
         }
     }
 
-    /// Returns `true` if any component of size is zero or negative.
-    pub fn is_empty_or_negative(&self) -> bool
+    /// Returns `true` if any component of size is zero, negative or NaN.
+    pub fn is_empty(&self) -> bool
     where
         T: Zero,
     {
@@ -1710,9 +1710,9 @@ mod size3d {
         #[test]
         pub fn test_nan_empty() {
             use std::f32::NAN;
-            assert!(Size3D::new(NAN, 2.0, 3.0).is_empty_or_negative());
-            assert!(Size3D::new(0.0, NAN, 0.0).is_empty_or_negative());
-            assert!(Size3D::new(1.0, 2.0, NAN).is_empty_or_negative());
+            assert!(Size3D::new(NAN, 2.0, 3.0).is_empty());
+            assert!(Size3D::new(0.0, NAN, 0.0).is_empty());
+            assert!(Size3D::new(1.0, 2.0, NAN).is_empty());
         }
     }
 }


### PR DESCRIPTION
For all practical use is_empty_or_negative is what people mean to use, whereas only checking for zero area via is_empty is error prone.