### PR TITLE
(breaking change) Define round(x) as floor(x + 0.5)

### DIFF
--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -673,7 +673,7 @@ mod tests {
     #[test]
     fn test_round() {
         let b = Box2D::from_points(&[point2(-25.5, -40.4), point2(60.3, 36.5)]).round();
-        assert_eq!(b.min.x, -26.0);
+        assert_eq!(b.min.x, -25.0);
         assert_eq!(b.min.y, -40.0);
         assert_eq!(b.max.x, 60.0);
         assert_eq!(b.max.y, 37.0);

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -738,7 +738,7 @@ mod tests {
     fn test_round() {
         let b =
             Box3D::from_points(&[point3(-25.5, -40.4, -70.9), point3(60.3, 36.5, 89.8)]).round();
-        assert!(b.min.x == -26.0);
+        assert!(b.min.x == -25.0);
         assert!(b.min.y == -40.0);
         assert!(b.min.z == -71.0);
         assert!(b.max.x == 60.0);

--- a/src/num.rs
+++ b/src/num.rs
@@ -97,7 +97,7 @@ macro_rules! num_float {
         impl Round for $ty {
             #[inline]
             fn round(self) -> $ty {
-                num_traits::Float::round(self)
+                (self + 0.5).floor()
             }
         }
         impl Floor for $ty {


### PR DESCRIPTION
Fixes #369 