### PR TITLE
(breaking change) Move away from pre_transform/post_transform terminology

### DIFF
--- a/src/rigid.rs
+++ b/src/rigid.rs
@@ -139,18 +139,6 @@ impl<T: Float + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
         }
     }
 
-    /// Returns the multiplication of the two transforms such that
-    /// self's transformation applies after other's transformation.
-    ///
-    /// i.e., this produces `other * self` in row-vector notation
-    #[inline]
-    pub fn pre_transform<Src2>(
-        &self,
-        other: &RigidTransform3D<T, Src2, Src>,
-    ) -> RigidTransform3D<T, Src2, Dst> {
-        other.then(&self)
-    }
-
     /// Inverts the transformation
     #[inline]
     pub fn inverse(&self) -> RigidTransform3D<T, Dst, Src> {

--- a/src/rigid.rs
+++ b/src/rigid.rs
@@ -114,7 +114,7 @@ impl<T: Float + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
     ///
     /// i.e., this produces `self * other` in row-vector notation
     #[inline]
-    pub fn post_transform<Dst2>(
+    pub fn then<Dst2>(
         &self,
         other: &RigidTransform3D<T, Dst, Dst2>,
     ) -> RigidTransform3D<T, Src, Dst2> {
@@ -131,7 +131,7 @@ impl<T: Float + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
         // T' * T2 = T'' = vector addition of translations T2 and T'
 
         let t_prime = other.rotation.transform_vector3d(self.translation);
-        let r_prime = self.rotation.post_rotate(&other.rotation);
+        let r_prime = self.rotation.then(&other.rotation);
         let t_prime2 = t_prime + other.translation;
         RigidTransform3D {
             rotation: r_prime,
@@ -148,7 +148,7 @@ impl<T: Float + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
         &self,
         other: &RigidTransform3D<T, Src2, Src>,
     ) -> RigidTransform3D<T, Src2, Dst> {
-        other.post_transform(&self)
+        other.then(&self)
     }
 
     /// Inverts the transformation
@@ -173,9 +173,7 @@ impl<T: Float + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
     where
         T: Trig,
     {
-        self.translation
-            .to_transform()
-            .pre_transform(&self.rotation.to_transform())
+        self.rotation.to_transform().then(&self.translation.to_transform())
     }
 
     /// Drop the units, preserving only the numeric value.
@@ -223,16 +221,12 @@ mod test {
 
         let rigid = RigidTransform3D::new(rotation, translation);
         assert!(rigid.to_transform().approx_eq(
-            &translation
-                .to_transform()
-                .pre_transform(&rotation.to_transform())
+            &rotation.to_transform().then(&translation.to_transform())
         ));
 
         let rigid = RigidTransform3D::new_from_reversed(translation, rotation);
         assert!(rigid.to_transform().approx_eq(
-            &translation
-                .to_transform()
-                .post_transform(&rotation.to_transform())
+            &translation.to_transform().then(&rotation.to_transform())
         ));
     }
 
@@ -245,7 +239,7 @@ mod test {
         let (t2, r2) = rigid.decompose_reversed();
         assert!(rigid
             .to_transform()
-            .approx_eq(&t2.to_transform().post_transform(&r2.to_transform())));
+            .approx_eq(&t2.to_transform().then(&r2.to_transform())));
     }
 
     #[test]
@@ -256,7 +250,7 @@ mod test {
         let rigid = RigidTransform3D::new(rotation, translation);
         let inverse = rigid.inverse();
         assert!(rigid
-            .post_transform(&inverse)
+            .then(&inverse)
             .to_transform()
             .approx_eq(&Transform3D::identity()));
         assert!(inverse
@@ -274,12 +268,12 @@ mod test {
         let rigid2 = RigidTransform3D::new(rotation2, translation2);
 
         assert!(rigid
-            .post_transform(&rigid2)
+            .then(&rigid2)
             .to_transform()
-            .approx_eq(&rigid.to_transform().post_transform(&rigid2.to_transform())));
-        assert!(rigid
-            .pre_transform(&rigid2)
+            .approx_eq(&rigid.to_transform().then(&rigid2.to_transform())));
+        assert!(rigid2
+            .then(&rigid)
             .to_transform()
-            .approx_eq(&rigid.to_transform().pre_transform(&rigid2.to_transform())));
+            .approx_eq(&rigid2.to_transform().then(&rigid.to_transform())));
     }
 }

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -181,20 +181,11 @@ impl<T: Float, Src, Dst> Rotation2D<T, Src, Dst> {
 
     /// Returns a rotation representing the other rotation followed by this rotation.
     #[inline]
-    pub fn pre_rotate<NewSrc>(
+    pub fn then<NewSrc>(
         &self,
         other: &Rotation2D<T, NewSrc, Src>,
     ) -> Rotation2D<T, NewSrc, Dst> {
         Rotation2D::radians(self.angle + other.angle)
-    }
-
-    /// Returns a rotation representing this rotation followed by the other rotation.
-    #[inline]
-    pub fn post_rotate<NewDst>(
-        &self,
-        other: &Rotation2D<T, Dst, NewDst>,
-    ) -> Rotation2D<T, Src, NewDst> {
-        other.pre_rotate(self)
     }
 
     /// Returns the given 2d point transformed by this rotation.
@@ -657,33 +648,22 @@ where
         )
     }
 
-    /// Returns a rotation representing the other rotation followed by this rotation.
-    pub fn pre_rotate<NewSrc>(
-        &self,
-        other: &Rotation3D<T, NewSrc, Src>,
-    ) -> Rotation3D<T, NewSrc, Dst>
-    where
-        T: ApproxEq<T>,
-    {
-        debug_assert!(self.is_normalized());
-        Rotation3D::quaternion(
-            self.i * other.r + self.r * other.i + self.j * other.k - self.k * other.j,
-            self.j * other.r + self.r * other.j + self.k * other.i - self.i * other.k,
-            self.k * other.r + self.r * other.k + self.i * other.j - self.j * other.i,
-            self.r * other.r - self.i * other.i - self.j * other.j - self.k * other.k,
-        )
-    }
-
     /// Returns a rotation representing this rotation followed by the other rotation.
     #[inline]
-    pub fn post_rotate<NewDst>(
+    pub fn then<NewDst>(
         &self,
         other: &Rotation3D<T, Dst, NewDst>,
     ) -> Rotation3D<T, Src, NewDst>
     where
         T: ApproxEq<T>,
     {
-        other.pre_rotate(self)
+        debug_assert!(self.is_normalized());
+        Rotation3D::quaternion(
+            other.i * self.r + other.r * self.i + other.j * self.k - other.k * self.j,
+            other.j * self.r + other.r * self.j + other.k * self.i - other.i * self.k,
+            other.k * self.r + other.r * self.k + other.i * self.j - other.j * self.i,
+            other.r * self.r - other.i * self.i - other.j * self.j - other.k * self.k,
+        )
     }
 
     // add, sub and mul are used internally for intermediate computation but aren't public
@@ -827,18 +807,18 @@ fn pre_post() {
 
     // Check that the order of transformations is correct (corresponds to what
     // we do in Transform3D).
-    let p1 = r1.post_rotate(&r2).post_rotate(&r3).transform_point3d(p);
+    let p1 = r1.then(&r2).then(&r3).transform_point3d(p);
     let p2 = t1
-        .post_transform(&t2)
-        .post_transform(&t3)
+        .then(&t2)
+        .then(&t3)
         .transform_point3d(p);
 
     assert!(p1.approx_eq(&p2.unwrap()));
 
     // Check that changing the order indeed matters.
     let p3 = t3
-        .post_transform(&t1)
-        .post_transform(&t2)
+        .then(&t1)
+        .then(&t2)
         .transform_point3d(p);
     assert!(!p1.approx_eq(&p3.unwrap()));
 }
@@ -1008,7 +988,7 @@ fn from_euler() {
     // Now check that the yaw pitch and roll transformations when combined are applied in
     // the proper order: roll -> pitch -> yaw.
     let ypr_e = Rotation3D::euler(angle, angle, angle);
-    let ypr_q = roll_rq.post_rotate(&pitch_rq).post_rotate(&yaw_rq);
+    let ypr_q = roll_rq.then(&pitch_rq).then(&yaw_rq);
     let ypr_pe = ypr_e.transform_point3d(p);
     let ypr_pq = ypr_q.transform_point3d(p);
 

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -501,38 +501,28 @@ where
     ///
     /// Assuming row vectors, this is equivalent to self * mat
     #[must_use]
-    pub fn post_transform<NewDst>(&self, mat: &Transform3D<T, Dst, NewDst>) -> Transform3D<T, Src, NewDst> {
+    pub fn then<NewDst>(&self, other: &Transform3D<T, Dst, NewDst>) -> Transform3D<T, Src, NewDst> {
         Transform3D::row_major(
-            self.m11 * mat.m11  +  self.m12 * mat.m21  +  self.m13 * mat.m31  +  self.m14 * mat.m41,
-            self.m11 * mat.m12  +  self.m12 * mat.m22  +  self.m13 * mat.m32  +  self.m14 * mat.m42,
-            self.m11 * mat.m13  +  self.m12 * mat.m23  +  self.m13 * mat.m33  +  self.m14 * mat.m43,
-            self.m11 * mat.m14  +  self.m12 * mat.m24  +  self.m13 * mat.m34  +  self.m14 * mat.m44,
+            self.m11 * other.m11  +  self.m12 * other.m21  +  self.m13 * other.m31  +  self.m14 * other.m41,
+            self.m11 * other.m12  +  self.m12 * other.m22  +  self.m13 * other.m32  +  self.m14 * other.m42,
+            self.m11 * other.m13  +  self.m12 * other.m23  +  self.m13 * other.m33  +  self.m14 * other.m43,
+            self.m11 * other.m14  +  self.m12 * other.m24  +  self.m13 * other.m34  +  self.m14 * other.m44,
 
-            self.m21 * mat.m11  +  self.m22 * mat.m21  +  self.m23 * mat.m31  +  self.m24 * mat.m41,
-            self.m21 * mat.m12  +  self.m22 * mat.m22  +  self.m23 * mat.m32  +  self.m24 * mat.m42,
-            self.m21 * mat.m13  +  self.m22 * mat.m23  +  self.m23 * mat.m33  +  self.m24 * mat.m43,
-            self.m21 * mat.m14  +  self.m22 * mat.m24  +  self.m23 * mat.m34  +  self.m24 * mat.m44,
+            self.m21 * other.m11  +  self.m22 * other.m21  +  self.m23 * other.m31  +  self.m24 * other.m41,
+            self.m21 * other.m12  +  self.m22 * other.m22  +  self.m23 * other.m32  +  self.m24 * other.m42,
+            self.m21 * other.m13  +  self.m22 * other.m23  +  self.m23 * other.m33  +  self.m24 * other.m43,
+            self.m21 * other.m14  +  self.m22 * other.m24  +  self.m23 * other.m34  +  self.m24 * other.m44,
 
-            self.m31 * mat.m11  +  self.m32 * mat.m21  +  self.m33 * mat.m31  +  self.m34 * mat.m41,
-            self.m31 * mat.m12  +  self.m32 * mat.m22  +  self.m33 * mat.m32  +  self.m34 * mat.m42,
-            self.m31 * mat.m13  +  self.m32 * mat.m23  +  self.m33 * mat.m33  +  self.m34 * mat.m43,
-            self.m31 * mat.m14  +  self.m32 * mat.m24  +  self.m33 * mat.m34  +  self.m34 * mat.m44,
+            self.m31 * other.m11  +  self.m32 * other.m21  +  self.m33 * other.m31  +  self.m34 * other.m41,
+            self.m31 * other.m12  +  self.m32 * other.m22  +  self.m33 * other.m32  +  self.m34 * other.m42,
+            self.m31 * other.m13  +  self.m32 * other.m23  +  self.m33 * other.m33  +  self.m34 * other.m43,
+            self.m31 * other.m14  +  self.m32 * other.m24  +  self.m33 * other.m34  +  self.m34 * other.m44,
 
-            self.m41 * mat.m11  +  self.m42 * mat.m21  +  self.m43 * mat.m31  +  self.m44 * mat.m41,
-            self.m41 * mat.m12  +  self.m42 * mat.m22  +  self.m43 * mat.m32  +  self.m44 * mat.m42,
-            self.m41 * mat.m13  +  self.m42 * mat.m23  +  self.m43 * mat.m33  +  self.m44 * mat.m43,
-            self.m41 * mat.m14  +  self.m42 * mat.m24  +  self.m43 * mat.m34  +  self.m44 * mat.m44,
+            self.m41 * other.m11  +  self.m42 * other.m21  +  self.m43 * other.m31  +  self.m44 * other.m41,
+            self.m41 * other.m12  +  self.m42 * other.m22  +  self.m43 * other.m32  +  self.m44 * other.m42,
+            self.m41 * other.m13  +  self.m42 * other.m23  +  self.m43 * other.m33  +  self.m44 * other.m43,
+            self.m41 * other.m14  +  self.m42 * other.m24  +  self.m43 * other.m34  +  self.m44 * other.m44,
         )
-    }
-
-    /// Returns the multiplication of the two matrices such that mat's transformation
-    /// applies before self's transformation.
-    ///
-    /// Assuming row vectors, this is equivalent to mat * self
-    #[inline]
-    #[must_use]
-    pub fn pre_transform<NewSrc>(&self, mat: &Transform3D<T, NewSrc, Src>) -> Transform3D<T, NewSrc, Dst> {
-        mat.post_transform(self)
     }
 }
 
@@ -568,16 +558,16 @@ where
     where
         T: Copy + Add<Output = T> + Mul<Output = T>,
     {
-        self.pre_transform(&Transform3D::translation(v.x, v.y, v.z))
+        Transform3D::translation(v.x, v.y, v.z).then(self)
     }
 
     /// Returns a transform with a translation applied after self's transformation.
     #[must_use]
-    pub fn post_translate(&self, v: Vector3D<T, Dst>) -> Self
+    pub fn then_translate(&self, v: Vector3D<T, Dst>) -> Self
     where
         T: Copy + Add<Output = T> + Mul<Output = T>,
     {
-        self.post_transform(&Transform3D::translation(v.x, v.y, v.z))
+        self.then(&Transform3D::translation(v.x, v.y, v.z))
     }
 }
 
@@ -626,14 +616,14 @@ where
 
     /// Returns a transform with a rotation applied after self's transformation.
     #[must_use]
-    pub fn post_rotate(&self, x: T, y: T, z: T, theta: Angle<T>) -> Self {
-        self.post_transform(&Transform3D::rotation(x, y, z, theta))
+    pub fn then_rotate(&self, x: T, y: T, z: T, theta: Angle<T>) -> Self {
+        self.then(&Transform3D::rotation(x, y, z, theta))
     }
 
     /// Returns a transform with a rotation applied before self's transformation.
     #[must_use]
     pub fn pre_rotate(&self, x: T, y: T, z: T, theta: Angle<T>) -> Self {
-        self.pre_transform(&Transform3D::rotation(x, y, z, theta))
+        Transform3D::rotation(x, y, z, theta).then(self)
     }
 }
 
@@ -679,11 +669,11 @@ where
 
     /// Returns a transform with a scale applied after self's transformation.
     #[must_use]
-    pub fn post_scale(&self, x: T, y: T, z: T) -> Self
+    pub fn then_scale(&self, x: T, y: T, z: T) -> Self
     where
         T: Copy + Add<Output = T> + Mul<Output = T>,
     {
-        self.post_transform(&Transform3D::scale(x, y, z))
+        self.then(&Transform3D::scale(x, y, z))
     }
 }
 
@@ -1157,14 +1147,14 @@ mod tests {
     pub fn test_translation() {
         let t1 = Mf32::translation(1.0, 2.0, 3.0);
         let t2 = Mf32::identity().pre_translate(vec3(1.0, 2.0, 3.0));
-        let t3 = Mf32::identity().post_translate(vec3(1.0, 2.0, 3.0));
+        let t3 = Mf32::identity().then_translate(vec3(1.0, 2.0, 3.0));
         assert_eq!(t1, t2);
         assert_eq!(t1, t3);
 
         assert_eq!(t1.transform_point3d(point3(1.0, 1.0, 1.0)), Some(point3(2.0, 3.0, 4.0)));
         assert_eq!(t1.transform_point2d(point2(1.0, 1.0)), Some(point2(2.0, 3.0)));
 
-        assert_eq!(t1.post_transform(&t1), Mf32::translation(2.0, 4.0, 6.0));
+        assert_eq!(t1.then(&t1), Mf32::translation(2.0, 4.0, 6.0));
 
         assert!(!t1.is_2d());
         assert_eq!(Mf32::translation(1.0, 2.0, 3.0).to_2d(), Transform2D::translation(1.0, 2.0));
@@ -1174,14 +1164,14 @@ mod tests {
     pub fn test_rotation() {
         let r1 = Mf32::rotation(0.0, 0.0, 1.0, rad(FRAC_PI_2));
         let r2 = Mf32::identity().pre_rotate(0.0, 0.0, 1.0, rad(FRAC_PI_2));
-        let r3 = Mf32::identity().post_rotate(0.0, 0.0, 1.0, rad(FRAC_PI_2));
+        let r3 = Mf32::identity().then_rotate(0.0, 0.0, 1.0, rad(FRAC_PI_2));
         assert_eq!(r1, r2);
         assert_eq!(r1, r3);
 
         assert!(r1.transform_point3d(point3(1.0, 2.0, 3.0)).unwrap().approx_eq(&point3(-2.0, 1.0, 3.0)));
         assert!(r1.transform_point2d(point2(1.0, 2.0)).unwrap().approx_eq(&point2(-2.0, 1.0)));
 
-        assert!(r1.post_transform(&r1).approx_eq(&Mf32::rotation(0.0, 0.0, 1.0, rad(FRAC_PI_2*2.0))));
+        assert!(r1.then(&r1).approx_eq(&Mf32::rotation(0.0, 0.0, 1.0, rad(FRAC_PI_2*2.0))));
 
         assert!(r1.is_2d());
         assert!(r1.to_2d().approx_eq(&Transform2D::rotation(rad(FRAC_PI_2))));
@@ -1191,14 +1181,14 @@ mod tests {
     pub fn test_scale() {
         let s1 = Mf32::scale(2.0, 3.0, 4.0);
         let s2 = Mf32::identity().pre_scale(2.0, 3.0, 4.0);
-        let s3 = Mf32::identity().post_scale(2.0, 3.0, 4.0);
+        let s3 = Mf32::identity().then_scale(2.0, 3.0, 4.0);
         assert_eq!(s1, s2);
         assert_eq!(s1, s3);
 
         assert!(s1.transform_point3d(point3(2.0, 2.0, 2.0)).unwrap().approx_eq(&point3(4.0, 6.0, 8.0)));
         assert!(s1.transform_point2d(point2(2.0, 2.0)).unwrap().approx_eq(&point2(4.0, 6.0)));
 
-        assert_eq!(s1.post_transform(&s1), Mf32::scale(4.0, 9.0, 16.0));
+        assert_eq!(s1.then(&s1), Mf32::scale(4.0, 9.0, 16.0));
 
         assert!(!s1.is_2d());
         assert_eq!(Mf32::scale(2.0, 3.0, 0.0).to_2d(), Transform2D::scale(2.0, 3.0));
@@ -1206,11 +1196,10 @@ mod tests {
 
 
     #[test]
-    pub fn test_pre_post_scale() {
-        let m = Mf32::rotation(0.0, 0.0, 1.0, rad(FRAC_PI_2)).post_translate(vec3(6.0, 7.0, 8.0));
+    pub fn test_pre_then_scale() {
+        let m = Mf32::rotation(0.0, 0.0, 1.0, rad(FRAC_PI_2)).then_translate(vec3(6.0, 7.0, 8.0));
         let s = Mf32::scale(2.0, 3.0, 4.0);
-        assert_eq!(m.post_transform(&s), m.post_scale(2.0, 3.0, 4.0));
-        assert_eq!(m.pre_transform(&s), m.pre_scale(2.0, 3.0, 4.0));
+        assert_eq!(m.then(&s), m.then_scale(2.0, 3.0, 4.0));
     }
 
 
@@ -1276,28 +1265,32 @@ mod tests {
     pub fn test_inverse_scale() {
         let m1 = Mf32::scale(1.5, 0.3, 2.1);
         let m2 = m1.inverse().unwrap();
-        assert!(m1.pre_transform(&m2).approx_eq(&Mf32::identity()));
+        assert!(m1.then(&m2).approx_eq(&Mf32::identity()));
+        assert!(m2.then(&m1).approx_eq(&Mf32::identity()));
     }
 
     #[test]
     pub fn test_inverse_translate() {
         let m1 = Mf32::translation(-132.0, 0.3, 493.0);
         let m2 = m1.inverse().unwrap();
-        assert!(m1.pre_transform(&m2).approx_eq(&Mf32::identity()));
+        assert!(m1.then(&m2).approx_eq(&Mf32::identity()));
+        assert!(m2.then(&m1).approx_eq(&Mf32::identity()));
     }
 
     #[test]
     pub fn test_inverse_rotate() {
         let m1 = Mf32::rotation(0.0, 1.0, 0.0, rad(1.57));
         let m2 = m1.inverse().unwrap();
-        assert!(m1.pre_transform(&m2).approx_eq(&Mf32::identity()));
+        assert!(m1.then(&m2).approx_eq(&Mf32::identity()));
+        assert!(m2.then(&m1).approx_eq(&Mf32::identity()));
     }
 
     #[test]
     pub fn test_inverse_transform_point_2d() {
         let m1 = Mf32::translation(100.0, 200.0, 0.0);
         let m2 = m1.inverse().unwrap();
-        assert!(m1.pre_transform(&m2).approx_eq(&Mf32::identity()));
+        assert!(m1.then(&m2).approx_eq(&Mf32::identity()));
+        assert!(m2.then(&m1).approx_eq(&Mf32::identity()));
 
         let p1 = point2(1000.0, 2000.0);
         let p2 = m1.transform_point2d(p1);
@@ -1315,7 +1308,7 @@ mod tests {
 
     #[test]
     pub fn test_pre_post() {
-        let m1 = default::Transform3D::identity().post_scale(1.0, 2.0, 3.0).post_translate(vec3(1.0, 2.0, 3.0));
+        let m1 = default::Transform3D::identity().then_scale(1.0, 2.0, 3.0).then_translate(vec3(1.0, 2.0, 3.0));
         let m2 = default::Transform3D::identity().pre_translate(vec3(1.0, 2.0, 3.0)).pre_scale(1.0, 2.0, 3.0);
         assert!(m1.approx_eq(&m2));
 
@@ -1324,13 +1317,9 @@ mod tests {
 
         let a = point3(1.0, 1.0, 1.0);
 
-        assert!(r.post_transform(&t).transform_point3d(a).unwrap().approx_eq(&point3(1.0, 4.0, 1.0)));
-        assert!(t.post_transform(&r).transform_point3d(a).unwrap().approx_eq(&point3(-4.0, 3.0, 1.0)));
-        assert!(t.post_transform(&r).transform_point3d(a).unwrap().approx_eq(&r.transform_point3d(t.transform_point3d(a).unwrap()).unwrap()));
-
-        assert!(r.pre_transform(&t).transform_point3d(a).unwrap().approx_eq(&point3(-4.0, 3.0, 1.0)));
-        assert!(t.pre_transform(&r).transform_point3d(a).unwrap().approx_eq(&point3(1.0, 4.0, 1.0)));
-        assert!(t.pre_transform(&r).transform_point3d(a).unwrap().approx_eq(&t.transform_point3d(r.transform_point3d(a).unwrap()).unwrap()));
+        assert!(r.then(&t).transform_point3d(a).unwrap().approx_eq(&point3(1.0, 4.0, 1.0)));
+        assert!(t.then(&r).transform_point3d(a).unwrap().approx_eq(&point3(-4.0, 3.0, 1.0)));
+        assert!(t.then(&r).transform_point3d(a).unwrap().approx_eq(&r.transform_point3d(t.transform_point3d(a).unwrap()).unwrap()));
     }
 
     #[test]
@@ -1352,7 +1341,7 @@ mod tests {
                                  -2.5, 6.0, 1.0, 1.0);
 
         let p = point3(1.0, 3.0, 5.0);
-        let p1 = m2.pre_transform(&m1).transform_point3d(p).unwrap();
+        let p1 = m1.then(&m2).transform_point3d(p).unwrap();
         let p2 = m2.transform_point3d(m1.transform_point3d(p).unwrap()).unwrap();
         assert!(p1.approx_eq(&p2));
     }
@@ -1361,7 +1350,7 @@ mod tests {
     pub fn test_is_identity() {
         let m1 = default::Transform3D::identity();
         assert!(m1.is_identity());
-        let m2 = m1.post_translate(vec3(0.1, 0.0, 0.0));
+        let m2 = m1.then_translate(vec3(0.1, 0.0, 0.0));
         assert!(!m2.is_identity());
     }
 


### PR DESCRIPTION
 - Rename `post_transform` into `then`.
 - Remove `pre_transform` (`a.pre_transform(b)` can trivially be rewritten as `b.then(a)`).
 - Rename `Transform2D` and `Transform3D`'s `post_translate`, `post_rotate`, etc.  into `then_translate` etc.

Keep `pre_translate` and similar methods on Transform2D and Transform3D as they are still useful and IMO unambiguous.