### PR TITLE
(breaking change) Take self by value for small structs

### DIFF
--- a/src/homogen.rs
+++ b/src/homogen.rs
@@ -120,7 +120,7 @@ impl<T: Copy + Div<T, Output = T> + Zero + PartialOrd, U> HomogeneousVector<T, U
     ///
     /// Returns None if the point is on or behind the W=0 hemisphere.
     #[inline]
-    pub fn to_point2d(&self) -> Option<Point2D<T, U>> {
+    pub fn to_point2d(self) -> Option<Point2D<T, U>> {
         if self.w > T::zero() {
             Some(Point2D::new(self.x / self.w, self.y / self.w))
         } else {
@@ -132,7 +132,7 @@ impl<T: Copy + Div<T, Output = T> + Zero + PartialOrd, U> HomogeneousVector<T, U
     ///
     /// Returns None if the point is on or behind the W=0 hemisphere.
     #[inline]
-    pub fn to_point3d(&self) -> Option<Point3D<T, U>> {
+    pub fn to_point3d(self) -> Option<Point3D<T, U>> {
         if self.w > T::zero() {
             Some(Point3D::new(
                 self.x / self.w,

--- a/src/length.rs
+++ b/src/length.rs
@@ -83,15 +83,15 @@ impl<T, U> Length<T, U> {
 }
 
 impl<T: Clone, U> Length<T, U> {
-    /// Unpack the underlying value from the wrapper, cloning it.
-    pub fn get(&self) -> T {
-        self.0.clone()
+    /// Unpack the underlying value from the wrapper.
+    pub fn get(self) -> T {
+        self.0
     }
 
     /// Cast the unit
     #[inline]
-    pub fn cast_unit<V>(&self) -> Length<T, V> {
-        Length::new(self.0.clone())
+    pub fn cast_unit<V>(self) -> Length<T, V> {
+        Length::new(self.0)
     }
 
     /// Linearly interpolate between this length and another length.
@@ -111,7 +111,7 @@ impl<T: Clone, U> Length<T, U> {
     /// assert_eq!(from.lerp(to,  2.0), Length::new(16.0));
     /// ```
     #[inline]
-    pub fn lerp(&self, other: Self, t: T) -> Self
+    pub fn lerp(self, other: Self, t: T) -> Self
     where
         T: One + Sub<Output = T> + Mul<Output = T> + Add<Output = T>,
     {
@@ -137,13 +137,13 @@ impl<T: PartialOrd, U> Length<T, U> {
 impl<T: NumCast + Clone, U> Length<T, U> {
     /// Cast from one numeric representation to another, preserving the units.
     #[inline]
-    pub fn cast<NewT: NumCast>(&self) -> Length<NewT, U> {
+    pub fn cast<NewT: NumCast>(self) -> Length<NewT, U> {
         self.try_cast().unwrap()
     }
 
     /// Fallible cast from one numeric representation to another, preserving the units.
-    pub fn try_cast<NewT: NumCast>(&self) -> Option<Length<NewT, U>> {
-        NumCast::from(self.get()).map(Length::new)
+    pub fn try_cast<NewT: NumCast>(self) -> Option<Length<NewT, U>> {
+        NumCast::from(self.0).map(Length::new)
     }
 }
 
@@ -365,19 +365,6 @@ mod tests {
 
         assert_eq!(one_foot.get(), 12.0);
         assert_eq!(variable_length.get(), 24.0);
-    }
-
-    #[test]
-    fn test_get_clones_length_value() {
-        // Calling get returns a clone of the Length's value.
-        // To test this, we need something clone-able - hence a vector.
-        let mut length: Length<Vec<i32>, Inch> = Length::new(vec![1, 2, 3]);
-
-        let value = length.get();
-        length.0.push(4);
-
-        assert_eq!(value, vec![1, 2, 3]);
-        assert_eq!(length.get(), vec![1, 2, 3, 4]);
     }
 
     #[test]

--- a/src/point.rs
+++ b/src/point.rs
@@ -158,7 +158,7 @@ impl<T, U> Point2D<T, U> {
 impl<T: Copy, U> Point2D<T, U> {
     /// Create a 3d point from this one, using the specified z value.
     #[inline]
-    pub fn extend(&self, z: T) -> Point3D<T, U> {
+    pub fn extend(self, z: T) -> Point3D<T, U> {
         point3(self.x, self.y, z)
     }
 
@@ -166,7 +166,7 @@ impl<T: Copy, U> Point2D<T, U> {
     ///
     /// Equivalent to subtracting the origin from this point.
     #[inline]
-    pub fn to_vector(&self) -> Vector2D<T, U> {
+    pub fn to_vector(self) -> Vector2D<T, U> {
         Vector2D {
             x: self.x,
             y: self.y,
@@ -187,7 +187,7 @@ impl<T: Copy, U> Point2D<T, U> {
     /// assert_eq!(point.yx(), point2(-8, 1));
     /// ```
     #[inline]
-    pub fn yx(&self) -> Self {
+    pub fn yx(self) -> Self {
         point2(self.y, self.x)
     }
 
@@ -205,7 +205,7 @@ impl<T: Copy, U> Point2D<T, U> {
     /// assert_eq!(point.y, point.to_untyped().y);
     /// ```
     #[inline]
-    pub fn to_untyped(&self) -> Point2D<T, UnknownUnit> {
+    pub fn to_untyped(self) -> Point2D<T, UnknownUnit> {
         point2(self.x, self.y)
     }
 
@@ -224,7 +224,7 @@ impl<T: Copy, U> Point2D<T, U> {
     /// assert_eq!(point.y, point.cast_unit::<Cm>().y);
     /// ```
     #[inline]
-    pub fn cast_unit<V>(&self) -> Point2D<T, V> {
+    pub fn cast_unit<V>(self) -> Point2D<T, V> {
         point2(self.x, self.y)
     }
 
@@ -241,7 +241,7 @@ impl<T: Copy, U> Point2D<T, U> {
     /// assert_eq!(point.to_array(), [1, -8]);
     /// ```
     #[inline]
-    pub fn to_array(&self) -> [T; 2] {
+    pub fn to_array(self) -> [T; 2] {
         [self.x, self.y]
     }
 
@@ -258,13 +258,13 @@ impl<T: Copy, U> Point2D<T, U> {
     /// assert_eq!(point.to_tuple(), (1, -8));
     /// ```
     #[inline]
-    pub fn to_tuple(&self) -> (T, T) {
+    pub fn to_tuple(self) -> (T, T) {
         (self.x, self.y)
     }
 
     /// Convert into a 3d point with z-coordinate equals to zero.
     #[inline]
-    pub fn to_3d(&self) -> Point3D<T, U>
+    pub fn to_3d(self) -> Point3D<T, U>
     where
         T: Zero,
     {
@@ -283,7 +283,7 @@ impl<T: Copy, U> Point2D<T, U> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn round(&self) -> Self
+    pub fn round(self) -> Self
     where
         T: Round,
     {
@@ -302,7 +302,7 @@ impl<T: Copy, U> Point2D<T, U> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn ceil(&self) -> Self
+    pub fn ceil(self) -> Self
     where
         T: Ceil,
     {
@@ -321,7 +321,7 @@ impl<T: Copy, U> Point2D<T, U> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn floor(&self) -> Self
+    pub fn floor(self) -> Self
     where
         T: Floor,
     {
@@ -346,7 +346,7 @@ impl<T: Copy, U> Point2D<T, U> {
     /// assert_eq!(from.lerp(to,  2.0), point2(16.0, -18.0));
     /// ```
     #[inline]
-    pub fn lerp(&self, other: Self, t: T) -> Self
+    pub fn lerp(self, other: Self, t: T) -> Self
     where
         T: One + Sub<Output = T> + Mul<Output = T> + Add<Output = T>,
     {
@@ -371,7 +371,7 @@ impl<T: PartialOrd, U> Point2D<T, U> {
     ///
     /// Shortcut for `self.max(start).min(end)`.
     #[inline]
-    pub fn clamp(&self, start: Self, end: Self) -> Self
+    pub fn clamp(self, start: Self, end: Self) -> Self
     where
         T: Copy,
     {
@@ -386,7 +386,7 @@ impl<T: NumCast + Copy, U> Point2D<T, U> {
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
     #[inline]
-    pub fn cast<NewT: NumCast>(&self) -> Point2D<NewT, U> {
+    pub fn cast<NewT: NumCast>(self) -> Point2D<NewT, U> {
         self.try_cast().unwrap()
     }
 
@@ -395,7 +395,7 @@ impl<T: NumCast + Copy, U> Point2D<T, U> {
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
-    pub fn try_cast<NewT: NumCast>(&self) -> Option<Point2D<NewT, U>> {
+    pub fn try_cast<NewT: NumCast>(self) -> Option<Point2D<NewT, U>> {
         match (NumCast::from(self.x), NumCast::from(self.y)) {
             (Some(x), Some(y)) => Some(point2(x, y)),
             _ => None,
@@ -406,13 +406,13 @@ impl<T: NumCast + Copy, U> Point2D<T, U> {
 
     /// Cast into an `f32` point.
     #[inline]
-    pub fn to_f32(&self) -> Point2D<f32, U> {
+    pub fn to_f32(self) -> Point2D<f32, U> {
         self.cast()
     }
 
     /// Cast into an `f64` point.
     #[inline]
-    pub fn to_f64(&self) -> Point2D<f64, U> {
+    pub fn to_f64(self) -> Point2D<f64, U> {
         self.cast()
     }
 
@@ -422,7 +422,7 @@ impl<T: NumCast + Copy, U> Point2D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_usize(&self) -> Point2D<usize, U> {
+    pub fn to_usize(self) -> Point2D<usize, U> {
         self.cast()
     }
 
@@ -432,7 +432,7 @@ impl<T: NumCast + Copy, U> Point2D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_u32(&self) -> Point2D<u32, U> {
+    pub fn to_u32(self) -> Point2D<u32, U> {
         self.cast()
     }
 
@@ -442,7 +442,7 @@ impl<T: NumCast + Copy, U> Point2D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_i32(&self) -> Point2D<i32, U> {
+    pub fn to_i32(self) -> Point2D<i32, U> {
         self.cast()
     }
 
@@ -452,14 +452,14 @@ impl<T: NumCast + Copy, U> Point2D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_i64(&self) -> Point2D<i64, U> {
+    pub fn to_i64(self) -> Point2D<i64, U> {
         self.cast()
     }
 }
 
 impl<T: Copy + Add<T, Output = T>, U> Point2D<T, U> {
     #[inline]
-    pub fn add_size(&self, other: &Size2D<T, U>) -> Self {
+    pub fn add_size(self, other: &Size2D<T, U>) -> Self {
         point2(self.x + other.width, self.y + other.height)
     }
 }
@@ -632,7 +632,7 @@ impl<T: Round, U> Round for Point2D<T, U> {
     /// See [Point2D::round()](#method.round)
     #[inline]
     fn round(self) -> Self {
-        (&self).round()
+        self.round()
     }
 }
 
@@ -640,7 +640,7 @@ impl<T: Ceil, U> Ceil for Point2D<T, U> {
     /// See [Point2D::ceil()](#method.ceil)
     #[inline]
     fn ceil(self) -> Self {
-        (&self).ceil()
+        self.ceil()
     }
 }
 
@@ -648,7 +648,7 @@ impl<T: Floor, U> Floor for Point2D<T, U> {
     /// See [Point2D::floor()](#method.floor)
     #[inline]
     fn floor(self) -> Self {
-        (&self).floor()
+        self.floor()
     }
 }
 
@@ -831,7 +831,7 @@ impl<T: Copy, U> Point3D<T, U> {
     ///
     /// Equivalent to subtracting the origin to this point.
     #[inline]
-    pub fn to_vector(&self) -> Vector3D<T, U> {
+    pub fn to_vector(self) -> Vector3D<T, U> {
         Vector3D {
             x: self.x,
             y: self.y,
@@ -842,19 +842,19 @@ impl<T: Copy, U> Point3D<T, U> {
 
     /// Returns a 2d point using this point's x and y coordinates
     #[inline]
-    pub fn xy(&self) -> Point2D<T, U> {
+    pub fn xy(self) -> Point2D<T, U> {
         point2(self.x, self.y)
     }
 
     /// Returns a 2d point using this point's x and z coordinates
     #[inline]
-    pub fn xz(&self) -> Point2D<T, U> {
+    pub fn xz(self) -> Point2D<T, U> {
         point2(self.x, self.z)
     }
 
     /// Returns a 2d point using this point's x and z coordinates
     #[inline]
-    pub fn yz(&self) -> Point2D<T, U> {
+    pub fn yz(self) -> Point2D<T, U> {
         point2(self.y, self.z)
     }
 
@@ -871,12 +871,12 @@ impl<T: Copy, U> Point3D<T, U> {
     /// assert_eq!(point.to_array(), [1, -8, 0]);
     /// ```
     #[inline]
-    pub fn to_array(&self) -> [T; 3] {
+    pub fn to_array(self) -> [T; 3] {
         [self.x, self.y, self.z]
     }
 
     #[inline]
-    pub fn to_array_4d(&self) -> [T; 4]
+    pub fn to_array_4d(self) -> [T; 4]
     where
         T: One,
     {
@@ -896,12 +896,12 @@ impl<T: Copy, U> Point3D<T, U> {
     /// assert_eq!(point.to_tuple(), (1, -8, 0));
     /// ```
     #[inline]
-    pub fn to_tuple(&self) -> (T, T, T) {
+    pub fn to_tuple(self) -> (T, T, T) {
         (self.x, self.y, self.z)
     }
 
     #[inline]
-    pub fn to_tuple_4d(&self) -> (T, T, T, T)
+    pub fn to_tuple_4d(self) -> (T, T, T, T)
     where
         T: One,
     {
@@ -923,7 +923,7 @@ impl<T: Copy, U> Point3D<T, U> {
     /// assert_eq!(point.z, point.to_untyped().z);
     /// ```
     #[inline]
-    pub fn to_untyped(&self) -> Point3D<T, UnknownUnit> {
+    pub fn to_untyped(self) -> Point3D<T, UnknownUnit> {
         point3(self.x, self.y, self.z)
     }
 
@@ -943,13 +943,13 @@ impl<T: Copy, U> Point3D<T, U> {
     /// assert_eq!(point.z, point.cast_unit::<Cm>().z);
     /// ```
     #[inline]
-    pub fn cast_unit<V>(&self) -> Point3D<T, V> {
+    pub fn cast_unit<V>(self) -> Point3D<T, V> {
         point3(self.x, self.y, self.z)
     }
 
     /// Convert into a 2d point.
     #[inline]
-    pub fn to_2d(&self) -> Point2D<T, U> {
+    pub fn to_2d(self) -> Point2D<T, U> {
         self.xy()
     }
 
@@ -965,7 +965,7 @@ impl<T: Copy, U> Point3D<T, U> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn round(&self) -> Self
+    pub fn round(self) -> Self
     where
         T: Round,
     {
@@ -984,7 +984,7 @@ impl<T: Copy, U> Point3D<T, U> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn ceil(&self) -> Self
+    pub fn ceil(self) -> Self
     where
         T: Ceil,
     {
@@ -1003,7 +1003,7 @@ impl<T: Copy, U> Point3D<T, U> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn floor(&self) -> Self
+    pub fn floor(self) -> Self
     where
         T: Floor,
     {
@@ -1028,7 +1028,7 @@ impl<T: Copy, U> Point3D<T, U> {
     /// assert_eq!(from.lerp(to,  2.0), point3(16.0, -18.0,  1.0));
     /// ```
     #[inline]
-    pub fn lerp(&self, other: Self, t: T) -> Self
+    pub fn lerp(self, other: Self, t: T) -> Self
     where
         T: One + Sub<Output = T> + Mul<Output = T> + Add<Output = T>,
     {
@@ -1065,7 +1065,7 @@ impl<T: PartialOrd, U> Point3D<T, U> {
     ///
     /// Shortcut for `self.max(start).min(end)`.
     #[inline]
-    pub fn clamp(&self, start: Self, end: Self) -> Self
+    pub fn clamp(self, start: Self, end: Self) -> Self
     where
         T: Copy,
     {
@@ -1080,7 +1080,7 @@ impl<T: NumCast + Copy, U> Point3D<T, U> {
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
     #[inline]
-    pub fn cast<NewT: NumCast>(&self) -> Point3D<NewT, U> {
+    pub fn cast<NewT: NumCast>(self) -> Point3D<NewT, U> {
         self.try_cast().unwrap()
     }
 
@@ -1089,7 +1089,7 @@ impl<T: NumCast + Copy, U> Point3D<T, U> {
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
-    pub fn try_cast<NewT: NumCast>(&self) -> Option<Point3D<NewT, U>> {
+    pub fn try_cast<NewT: NumCast>(self) -> Option<Point3D<NewT, U>> {
         match (
             NumCast::from(self.x),
             NumCast::from(self.y),
@@ -1104,13 +1104,13 @@ impl<T: NumCast + Copy, U> Point3D<T, U> {
 
     /// Cast into an `f32` point.
     #[inline]
-    pub fn to_f32(&self) -> Point3D<f32, U> {
+    pub fn to_f32(self) -> Point3D<f32, U> {
         self.cast()
     }
 
     /// Cast into an `f64` point.
     #[inline]
-    pub fn to_f64(&self) -> Point3D<f64, U> {
+    pub fn to_f64(self) -> Point3D<f64, U> {
         self.cast()
     }
 
@@ -1120,7 +1120,7 @@ impl<T: NumCast + Copy, U> Point3D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_usize(&self) -> Point3D<usize, U> {
+    pub fn to_usize(self) -> Point3D<usize, U> {
         self.cast()
     }
 
@@ -1130,7 +1130,7 @@ impl<T: NumCast + Copy, U> Point3D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_u32(&self) -> Point3D<u32, U> {
+    pub fn to_u32(self) -> Point3D<u32, U> {
         self.cast()
     }
 
@@ -1140,7 +1140,7 @@ impl<T: NumCast + Copy, U> Point3D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_i32(&self) -> Point3D<i32, U> {
+    pub fn to_i32(self) -> Point3D<i32, U> {
         self.cast()
     }
 
@@ -1150,14 +1150,14 @@ impl<T: NumCast + Copy, U> Point3D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_i64(&self) -> Point3D<i64, U> {
+    pub fn to_i64(self) -> Point3D<i64, U> {
         self.cast()
     }
 }
 
 impl<T: Copy + Add<T, Output = T>, U> Point3D<T, U> {
     #[inline]
-    pub fn add_size(&self, other: &Size3D<T, U>) -> Self {
+    pub fn add_size(self, other: Size3D<T, U>) -> Self {
         point3(
             self.x + other.width,
             self.y + other.height,
@@ -1362,7 +1362,7 @@ impl<T: Round, U> Round for Point3D<T, U> {
     /// See [Point3D::round()](#method.round)
     #[inline]
     fn round(self) -> Self {
-        (&self).round()
+        self.round()
     }
 }
 
@@ -1370,7 +1370,7 @@ impl<T: Ceil, U> Ceil for Point3D<T, U> {
     /// See [Point3D::ceil()](#method.ceil)
     #[inline]
     fn ceil(self) -> Self {
-        (&self).ceil()
+        self.ceil()
     }
 }
 
@@ -1378,7 +1378,7 @@ impl<T: Floor, U> Floor for Point3D<T, U> {
     /// See [Point3D::floor()](#method.floor)
     #[inline]
     fn floor(self) -> Self {
-        (&self).floor()
+        self.floor()
     }
 }
 

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -384,7 +384,7 @@ impl<T: Copy + Mul<T, Output = T>, U> Rect<T, U> {
     }
 }
 
-impl<T: Zero + PartialOrd, U> Rect<T, U> {
+impl<T: Copy + Zero + PartialOrd, U> Rect<T, U> {
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.size.is_empty()

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -70,11 +70,11 @@ impl<T, Src, Dst> Scale<T, Src, Dst> {
     /// assert_eq!(to_mm.transform_point(point2(42, -42)), point2(420, -420));
     /// ```
     #[inline]
-    pub fn transform_point(&self, point: Point2D<T, Src>) -> Point2D<T::Output, Dst>
+    pub fn transform_point(self, point: Point2D<T, Src>) -> Point2D<T::Output, Dst>
     where
         T: Clone + Mul,
     {
-        Point2D::new(point.x * self.get(), point.y * self.get())
+        Point2D::new(point.x * self.0.clone(), point.y * self.0)
     }
 
     /// Returns the given vector transformed by this scale.
@@ -91,11 +91,11 @@ impl<T, Src, Dst> Scale<T, Src, Dst> {
     /// assert_eq!(to_mm.transform_vector(vec2(42, -42)), vec2(420, -420));
     /// ```
     #[inline]
-    pub fn transform_vector(&self, vec: Vector2D<T, Src>) -> Vector2D<T::Output, Dst>
+    pub fn transform_vector(self, vec: Vector2D<T, Src>) -> Vector2D<T::Output, Dst>
     where
         T: Clone + Mul,
     {
-        Vector2D::new(vec.x * self.get(), vec.y * self.get())
+        Vector2D::new(vec.x * self.0.clone(), vec.y * self.0)
     }
 
     /// Returns the given vector transformed by this scale.
@@ -112,11 +112,11 @@ impl<T, Src, Dst> Scale<T, Src, Dst> {
     /// assert_eq!(to_mm.transform_size(size2(42, -42)), size2(420, -420));
     /// ```
     #[inline]
-    pub fn transform_size(&self, size: Size2D<T, Src>) -> Size2D<T::Output, Dst>
+    pub fn transform_size(self, size: Size2D<T, Src>) -> Size2D<T::Output, Dst>
     where
         T: Clone + Mul,
     {
-        Size2D::new(size.width * self.get(), size.height * self.get())
+        Size2D::new(size.width * self.0.clone(), size.height * self.0)
     }
 
     /// Returns the given rect transformed by this scale.
@@ -133,7 +133,7 @@ impl<T, Src, Dst> Scale<T, Src, Dst> {
     /// assert_eq!(to_mm.transform_rect(&rect(1, 2, 42, -42)), rect(10, 20, 420, -420));
     /// ```
     #[inline]
-    pub fn transform_rect(&self, rect: &Rect<T, Src>) -> Rect<T::Output, Dst>
+    pub fn transform_rect(self, rect: &Rect<T, Src>) -> Rect<T::Output, Dst>
     where
         T: Copy + Mul,
     {
@@ -161,18 +161,17 @@ impl<T, Src, Dst> Scale<T, Src, Dst> {
     /// assert_eq!(mm_per_mm, Scale::one());
     /// ```
     #[inline]
-    pub fn is_identity(&self) -> bool
+    pub fn is_identity(self) -> bool
     where
         T: PartialEq + One,
     {
         self.0 == T::one()
     }
-}
 
-impl<T: Clone, Src, Dst> Scale<T, Src, Dst> {
+    /// Returns the underlying scalar scale factor.
     #[inline]
-    pub fn get(&self) -> T {
-        self.0.clone()
+    pub fn get(self) -> T {
+        self.0
     }
 
     /// The inverse Scale (1.0 / self).
@@ -188,16 +187,16 @@ impl<T: Clone, Src, Dst> Scale<T, Src, Dst> {
     ///
     /// assert_eq!(cm_per_mm.inverse(), Scale::new(10.0));
     /// ```
-    pub fn inverse(&self) -> Scale<T::Output, Dst, Src>
+    pub fn inverse(self) -> Scale<T::Output, Dst, Src>
     where
         T: One + Div,
     {
         let one: T = One::one();
-        Scale::new(one / self.0.clone())
+        Scale::new(one / self.0)
     }
 }
 
-impl<T: NumCast + Clone, Src, Dst> Scale<T, Src, Dst> {
+impl<T: NumCast, Src, Dst> Scale<T, Src, Dst> {
     /// Cast from one numeric representation to another, preserving the units.
     ///
     /// # Panics
@@ -226,7 +225,7 @@ impl<T: NumCast + Clone, Src, Dst> Scale<T, Src, Dst> {
     /// let to_em: Scale<i32, Mm, Em> = Scale::new(10e20).cast();
     /// ```
     #[inline]
-    pub fn cast<NewT: NumCast>(&self) -> Scale<NewT, Src, Dst> {
+    pub fn cast<NewT: NumCast>(self) -> Scale<NewT, Src, Dst> {
         self.try_cast().unwrap()
     }
 
@@ -249,8 +248,8 @@ impl<T: NumCast + Clone, Src, Dst> Scale<T, Src, Dst> {
     /// // Integer to small to store that number
     /// assert_eq!(to_em.try_cast::<i32>(), None);
     /// ```
-    pub fn try_cast<NewT: NumCast>(&self) -> Option<Scale<NewT, Src, Dst>> {
-        NumCast::from(self.get()).map(Scale::new)
+    pub fn try_cast<NewT: NumCast>(self) -> Option<Scale<NewT, Src, Dst>> {
+        NumCast::from(self.0).map(Scale::new)
     }
 }
 
@@ -315,7 +314,7 @@ impl<T: Ord, Src, Dst> Ord for Scale<T, Src, Dst> {
 
 impl<T: Clone, Src, Dst> Clone for Scale<T, Src, Dst> {
     fn clone(&self) -> Scale<T, Src, Dst> {
-        Scale::new(self.get())
+        Scale::new(self.0.clone())
     }
 }
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -154,31 +154,31 @@ impl<T, U> Size2D<T, U> {
 impl<T: Copy, U> Size2D<T, U> {
     /// Return this size as an array of two elements (width, then height).
     #[inline]
-    pub fn to_array(&self) -> [T; 2] {
+    pub fn to_array(self) -> [T; 2] {
         [self.width, self.height]
     }
 
     /// Return this size as a tuple of two elements (width, then height).
     #[inline]
-    pub fn to_tuple(&self) -> (T, T) {
+    pub fn to_tuple(self) -> (T, T) {
         (self.width, self.height)
     }
 
     /// Return this size as a vector with width and height.
     #[inline]
-    pub fn to_vector(&self) -> Vector2D<T, U> {
+    pub fn to_vector(self) -> Vector2D<T, U> {
         vec2(self.width, self.height)
     }
 
     /// Drop the units, preserving only the numeric value.
     #[inline]
-    pub fn to_untyped(&self) -> Size2D<T, UnknownUnit> {
+    pub fn to_untyped(self) -> Size2D<T, UnknownUnit> {
         self.cast_unit()
     }
 
     /// Cast the unit
     #[inline]
-    pub fn cast_unit<V>(&self) -> Size2D<T, V> {
+    pub fn cast_unit<V>(self) -> Size2D<T, V> {
         Size2D::new(self.width, self.height)
     }
 
@@ -194,7 +194,7 @@ impl<T: Copy, U> Size2D<T, U> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn round(&self) -> Self
+    pub fn round(self) -> Self
     where
         T: Round,
     {
@@ -213,7 +213,7 @@ impl<T: Copy, U> Size2D<T, U> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn ceil(&self) -> Self
+    pub fn ceil(self) -> Self
     where
         T: Ceil,
     {
@@ -232,7 +232,7 @@ impl<T: Copy, U> Size2D<T, U> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn floor(&self) -> Self
+    pub fn floor(self) -> Self
     where
         T: Floor,
     {
@@ -240,7 +240,7 @@ impl<T: Copy, U> Size2D<T, U> {
     }
 
     /// Returns result of multiplication of both components
-    pub fn area(&self) -> T::Output
+    pub fn area(self) -> T::Output
     where
         T: Mul,
     {
@@ -265,12 +265,12 @@ impl<T: Copy, U> Size2D<T, U> {
     /// assert_eq!(from.lerp(to,  2.0), size2(16.0, -18.0));
     /// ```
     #[inline]
-    pub fn lerp(&self, other: Self, t: T) -> Self
+    pub fn lerp(self, other: Self, t: T) -> Self
     where
         T: One + Sub<Output = T> + Mul<Output = T> + Add<Output = T>,
     {
         let one_t = T::one() - t;
-        (*self) * one_t + other * t
+        self * one_t + other * t
     }
 }
 
@@ -281,7 +281,7 @@ impl<T: NumCast + Copy, U> Size2D<T, U> {
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
     #[inline]
-    pub fn cast<NewT: NumCast>(&self) -> Size2D<NewT, U> {
+    pub fn cast<NewT: NumCast>(self) -> Size2D<NewT, U> {
         self.try_cast().unwrap()
     }
 
@@ -290,7 +290,7 @@ impl<T: NumCast + Copy, U> Size2D<T, U> {
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
-    pub fn try_cast<NewT: NumCast>(&self) -> Option<Size2D<NewT, U>> {
+    pub fn try_cast<NewT: NumCast>(self) -> Option<Size2D<NewT, U>> {
         match (NumCast::from(self.width), NumCast::from(self.height)) {
             (Some(w), Some(h)) => Some(Size2D::new(w, h)),
             _ => None,
@@ -301,13 +301,13 @@ impl<T: NumCast + Copy, U> Size2D<T, U> {
 
     /// Cast into an `f32` size.
     #[inline]
-    pub fn to_f32(&self) -> Size2D<f32, U> {
+    pub fn to_f32(self) -> Size2D<f32, U> {
         self.cast()
     }
 
     /// Cast into an `f64` size.
     #[inline]
-    pub fn to_f64(&self) -> Size2D<f64, U> {
+    pub fn to_f64(self) -> Size2D<f64, U> {
         self.cast()
     }
 
@@ -317,7 +317,7 @@ impl<T: NumCast + Copy, U> Size2D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_usize(&self) -> Size2D<usize, U> {
+    pub fn to_usize(self) -> Size2D<usize, U> {
         self.cast()
     }
 
@@ -327,7 +327,7 @@ impl<T: NumCast + Copy, U> Size2D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_u32(&self) -> Size2D<u32, U> {
+    pub fn to_u32(self) -> Size2D<u32, U> {
         self.cast()
     }
 
@@ -337,7 +337,7 @@ impl<T: NumCast + Copy, U> Size2D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_u64(&self) -> Size2D<u64, U> {
+    pub fn to_u64(self) -> Size2D<u64, U> {
         self.cast()
     }
 
@@ -347,7 +347,7 @@ impl<T: NumCast + Copy, U> Size2D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_i32(&self) -> Size2D<i32, U> {
+    pub fn to_i32(self) -> Size2D<i32, U> {
         self.cast()
     }
 
@@ -357,7 +357,7 @@ impl<T: NumCast + Copy, U> Size2D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_i64(&self) -> Size2D<i64, U> {
+    pub fn to_i64(self) -> Size2D<i64, U> {
         self.cast()
     }
 }
@@ -368,12 +368,12 @@ impl<T: Signed, U> Size2D<T, U> {
     /// For `f32` and `f64`, `NaN` will be returned for component if the component is `NaN`.
     ///
     /// For signed integers, `::MIN` will be returned for component if the component is `::MIN`.
-    pub fn abs(&self) -> Self {
+    pub fn abs(self) -> Self {
         size2(self.width.abs(), self.height.abs())
     }
 
     /// Returns `true` if both components is positive and `false` any component is zero or negative.
-    pub fn is_positive(&self) -> bool {
+    pub fn is_positive(self) -> bool {
         self.width.is_positive() && self.height.is_positive()
     }
 }
@@ -396,7 +396,7 @@ impl<T: PartialOrd, U> Size2D<T, U> {
     ///
     /// Shortcut for `self.max(start).min(end)`.
     #[inline]
-    pub fn clamp(&self, start: Self, end: Self) -> Self
+    pub fn clamp(self, start: Self, end: Self) -> Self
     where
         T: Copy,
     {
@@ -404,7 +404,7 @@ impl<T: PartialOrd, U> Size2D<T, U> {
     }
 
     /// Returns vector with results of "greater then" operation on each component.
-    pub fn greater_than(&self, other: Self) -> BoolVector2D {
+    pub fn greater_than(self, other: Self) -> BoolVector2D {
         BoolVector2D {
             x: self.width > other.width,
             y: self.height > other.height,
@@ -412,7 +412,7 @@ impl<T: PartialOrd, U> Size2D<T, U> {
     }
 
     /// Returns vector with results of "lower then" operation on each component.
-    pub fn lower_than(&self, other: Self) -> BoolVector2D {
+    pub fn lower_than(self, other: Self) -> BoolVector2D {
         BoolVector2D {
             x: self.width < other.width,
             y: self.height < other.height,
@@ -420,7 +420,7 @@ impl<T: PartialOrd, U> Size2D<T, U> {
     }
 
     /// Returns `true` if any component of size is zero, negative, or NaN.
-    pub fn is_empty(&self) -> bool
+    pub fn is_empty(self) -> bool
     where
         T: Zero,
     {
@@ -433,7 +433,7 @@ impl<T: PartialOrd, U> Size2D<T, U> {
 
 impl<T: PartialEq, U> Size2D<T, U> {
     /// Returns vector with results of "equal" operation on each component.
-    pub fn equal(&self, other: Self) -> BoolVector2D {
+    pub fn equal(self, other: Self) -> BoolVector2D {
         BoolVector2D {
             x: self.width == other.width,
             y: self.height == other.height,
@@ -441,7 +441,7 @@ impl<T: PartialEq, U> Size2D<T, U> {
     }
 
     /// Returns vector with results of "not equal" operation on each component.
-    pub fn not_equal(&self, other: Self) -> BoolVector2D {
+    pub fn not_equal(self, other: Self) -> BoolVector2D {
         BoolVector2D {
             x: self.width != other.width,
             y: self.height != other.height,
@@ -453,7 +453,7 @@ impl<T: Round, U> Round for Size2D<T, U> {
     /// See [`Size2D::round()`](#method.round).
     #[inline]
     fn round(self) -> Self {
-        (&self).round()
+        self.round()
     }
 }
 
@@ -461,7 +461,7 @@ impl<T: Ceil, U> Ceil for Size2D<T, U> {
     /// See [`Size2D::ceil()`](#method.ceil).
     #[inline]
     fn ceil(self) -> Self {
-        (&self).ceil()
+        self.ceil()
     }
 }
 
@@ -469,7 +469,7 @@ impl<T: Floor, U> Floor for Size2D<T, U> {
     /// See [`Size2D::floor()`](#method.floor).
     #[inline]
     fn floor(self) -> Self {
-        (&self).floor()
+        self.floor()
     }
 }
 
@@ -987,31 +987,31 @@ impl<T, U> Size3D<T, U> {
 impl<T: Copy, U> Size3D<T, U> {
     /// Return this size as an array of three elements (width, then height, then depth).
     #[inline]
-    pub fn to_array(&self) -> [T; 3] {
+    pub fn to_array(self) -> [T; 3] {
         [self.width, self.height, self.depth]
     }
 
     /// Return this size as an array of three elements (width, then height, then depth).
     #[inline]
-    pub fn to_tuple(&self) -> (T, T, T) {
+    pub fn to_tuple(self) -> (T, T, T) {
         (self.width, self.height, self.depth)
     }
 
     /// Return this size as a vector with width, height and depth.
     #[inline]
-    pub fn to_vector(&self) -> Vector3D<T, U> {
+    pub fn to_vector(self) -> Vector3D<T, U> {
         vec3(self.width, self.height, self.depth)
     }
 
     /// Drop the units, preserving only the numeric value.
     #[inline]
-    pub fn to_untyped(&self) -> Size3D<T, UnknownUnit> {
+    pub fn to_untyped(self) -> Size3D<T, UnknownUnit> {
         self.cast_unit()
     }
 
     /// Cast the unit
     #[inline]
-    pub fn cast_unit<V>(&self) -> Size3D<T, V> {
+    pub fn cast_unit<V>(self) -> Size3D<T, V> {
         Size3D::new(self.width, self.height, self.depth)
     }
 
@@ -1027,7 +1027,7 @@ impl<T: Copy, U> Size3D<T, U> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn round(&self) -> Self
+    pub fn round(self) -> Self
     where
         T: Round,
     {
@@ -1046,7 +1046,7 @@ impl<T: Copy, U> Size3D<T, U> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn ceil(&self) -> Self
+    pub fn ceil(self) -> Self
     where
         T: Ceil,
     {
@@ -1065,7 +1065,7 @@ impl<T: Copy, U> Size3D<T, U> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn floor(&self) -> Self
+    pub fn floor(self) -> Self
     where
         T: Floor,
     {
@@ -1073,7 +1073,7 @@ impl<T: Copy, U> Size3D<T, U> {
     }
 
     /// Returns result of multiplication of all components
-    pub fn volume(&self) -> T
+    pub fn volume(self) -> T
     where
         T: Mul<Output = T>,
     {
@@ -1098,12 +1098,12 @@ impl<T: Copy, U> Size3D<T, U> {
     /// assert_eq!(from.lerp(to,  2.0), size3(16.0, -18.0,  1.0));
     /// ```
     #[inline]
-    pub fn lerp(&self, other: Self, t: T) -> Self
+    pub fn lerp(self, other: Self, t: T) -> Self
     where
         T: One + Sub<Output = T> + Mul<Output = T> + Add<Output = T>,
     {
         let one_t = T::one() - t;
-        (*self) * one_t + other * t
+        self * one_t + other * t
     }
 }
 
@@ -1114,7 +1114,7 @@ impl<T: NumCast + Copy, U> Size3D<T, U> {
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
     #[inline]
-    pub fn cast<NewT: NumCast>(&self) -> Size3D<NewT, U> {
+    pub fn cast<NewT: NumCast>(self) -> Size3D<NewT, U> {
         self.try_cast().unwrap()
     }
 
@@ -1123,7 +1123,7 @@ impl<T: NumCast + Copy, U> Size3D<T, U> {
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
-    pub fn try_cast<NewT: NumCast>(&self) -> Option<Size3D<NewT, U>> {
+    pub fn try_cast<NewT: NumCast>(self) -> Option<Size3D<NewT, U>> {
         match (
             NumCast::from(self.width),
             NumCast::from(self.height),
@@ -1138,13 +1138,13 @@ impl<T: NumCast + Copy, U> Size3D<T, U> {
 
     /// Cast into an `f32` size.
     #[inline]
-    pub fn to_f32(&self) -> Size3D<f32, U> {
+    pub fn to_f32(self) -> Size3D<f32, U> {
         self.cast()
     }
 
     /// Cast into an `f64` size.
     #[inline]
-    pub fn to_f64(&self) -> Size3D<f64, U> {
+    pub fn to_f64(self) -> Size3D<f64, U> {
         self.cast()
     }
 
@@ -1154,7 +1154,7 @@ impl<T: NumCast + Copy, U> Size3D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_usize(&self) -> Size3D<usize, U> {
+    pub fn to_usize(self) -> Size3D<usize, U> {
         self.cast()
     }
 
@@ -1164,7 +1164,7 @@ impl<T: NumCast + Copy, U> Size3D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_u32(&self) -> Size3D<u32, U> {
+    pub fn to_u32(self) -> Size3D<u32, U> {
         self.cast()
     }
 
@@ -1174,7 +1174,7 @@ impl<T: NumCast + Copy, U> Size3D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_i32(&self) -> Size3D<i32, U> {
+    pub fn to_i32(self) -> Size3D<i32, U> {
         self.cast()
     }
 
@@ -1184,7 +1184,7 @@ impl<T: NumCast + Copy, U> Size3D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_i64(&self) -> Size3D<i64, U> {
+    pub fn to_i64(self) -> Size3D<i64, U> {
         self.cast()
     }
 }
@@ -1195,12 +1195,12 @@ impl<T: Signed, U> Size3D<T, U> {
     /// For `f32` and `f64`, `NaN` will be returned for component if the component is `NaN`.
     ///
     /// For signed integers, `::MIN` will be returned for component if the component is `::MIN`.
-    pub fn abs(&self) -> Self {
+    pub fn abs(self) -> Self {
         size3(self.width.abs(), self.height.abs(), self.depth.abs())
     }
 
     /// Returns `true` if all components is positive and `false` any component is zero or negative.
-    pub fn is_positive(&self) -> bool {
+    pub fn is_positive(self) -> bool {
         self.width.is_positive() && self.height.is_positive() && self.depth.is_positive()
     }
 }
@@ -1231,7 +1231,7 @@ impl<T: PartialOrd, U> Size3D<T, U> {
     ///
     /// Shortcut for `self.max(start).min(end)`.
     #[inline]
-    pub fn clamp(&self, start: Self, end: Self) -> Self
+    pub fn clamp(self, start: Self, end: Self) -> Self
     where
         T: Copy,
     {
@@ -1239,7 +1239,7 @@ impl<T: PartialOrd, U> Size3D<T, U> {
     }
 
     /// Returns vector with results of "greater than" operation on each component.
-    pub fn greater_than(&self, other: Self) -> BoolVector3D {
+    pub fn greater_than(self, other: Self) -> BoolVector3D {
         BoolVector3D {
             x: self.width > other.width,
             y: self.height > other.height,
@@ -1248,7 +1248,7 @@ impl<T: PartialOrd, U> Size3D<T, U> {
     }
 
     /// Returns vector with results of "lower than" operation on each component.
-    pub fn lower_than(&self, other: Self) -> BoolVector3D {
+    pub fn lower_than(self, other: Self) -> BoolVector3D {
         BoolVector3D {
             x: self.width < other.width,
             y: self.height < other.height,
@@ -1257,7 +1257,7 @@ impl<T: PartialOrd, U> Size3D<T, U> {
     }
 
     /// Returns `true` if any component of size is zero, negative or NaN.
-    pub fn is_empty(&self) -> bool
+    pub fn is_empty(self) -> bool
     where
         T: Zero,
     {
@@ -1268,7 +1268,7 @@ impl<T: PartialOrd, U> Size3D<T, U> {
 
 impl<T: PartialEq, U> Size3D<T, U> {
     /// Returns vector with results of "equal" operation on each component.
-    pub fn equal(&self, other: Self) -> BoolVector3D {
+    pub fn equal(self, other: Self) -> BoolVector3D {
         BoolVector3D {
             x: self.width == other.width,
             y: self.height == other.height,
@@ -1277,7 +1277,7 @@ impl<T: PartialEq, U> Size3D<T, U> {
     }
 
     /// Returns vector with results of "not equal" operation on each component.
-    pub fn not_equal(&self, other: Self) -> BoolVector3D {
+    pub fn not_equal(self, other: Self) -> BoolVector3D {
         BoolVector3D {
             x: self.width != other.width,
             y: self.height != other.height,
@@ -1290,7 +1290,7 @@ impl<T: Round, U> Round for Size3D<T, U> {
     /// See [`Size3D::round()`](#method.round).
     #[inline]
     fn round(self) -> Self {
-        (&self).round()
+        self.round()
     }
 }
 
@@ -1298,7 +1298,7 @@ impl<T: Ceil, U> Ceil for Size3D<T, U> {
     /// See [`Size3D::ceil()`](#method.ceil).
     #[inline]
     fn ceil(self) -> Self {
-        (&self).ceil()
+        self.ceil()
     }
 }
 
@@ -1306,7 +1306,7 @@ impl<T: Floor, U> Floor for Size3D<T, U> {
     /// See [`Size3D::floor()`](#method.floor).
     #[inline]
     fn floor(self) -> Self {
-        (&self).floor()
+        self.floor()
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -181,7 +181,7 @@ impl<T, U> Vector2D<T, U> {
     ///
     /// The behavior for each component follows the scalar type's implementation of
     /// `num_traits::Signed::abs`.
-    pub fn abs(&self) -> Self
+    pub fn abs(self) -> Self
     where
         T: Signed,
     {
@@ -210,7 +210,7 @@ impl<T, U> Vector2D<T, U> {
 impl<T: Copy, U> Vector2D<T, U> {
     /// Create a 3d vector from this one, using the specified z value.
     #[inline]
-    pub fn extend(&self, z: T) -> Vector3D<T, U> {
+    pub fn extend(self, z: T) -> Vector3D<T, U> {
         vec3(self.x, self.y, z)
     }
 
@@ -218,7 +218,7 @@ impl<T: Copy, U> Vector2D<T, U> {
     ///
     /// Equivalent to adding this vector to the origin.
     #[inline]
-    pub fn to_point(&self) -> Point2D<T, U> {
+    pub fn to_point(self) -> Point2D<T, U> {
         Point2D {
             x: self.x,
             y: self.y,
@@ -228,43 +228,43 @@ impl<T: Copy, U> Vector2D<T, U> {
 
     /// Swap x and y.
     #[inline]
-    pub fn yx(&self) -> Self {
+    pub fn yx(self) -> Self {
         vec2(self.y, self.x)
     }
 
     /// Cast this vector into a size.
     #[inline]
-    pub fn to_size(&self) -> Size2D<T, U> {
+    pub fn to_size(self) -> Size2D<T, U> {
         size2(self.x, self.y)
     }
 
     /// Drop the units, preserving only the numeric value.
     #[inline]
-    pub fn to_untyped(&self) -> Vector2D<T, UnknownUnit> {
+    pub fn to_untyped(self) -> Vector2D<T, UnknownUnit> {
         vec2(self.x, self.y)
     }
 
     /// Cast the unit.
     #[inline]
-    pub fn cast_unit<V>(&self) -> Vector2D<T, V> {
+    pub fn cast_unit<V>(self) -> Vector2D<T, V> {
         vec2(self.x, self.y)
     }
 
     /// Cast into an array with x and y.
     #[inline]
-    pub fn to_array(&self) -> [T; 2] {
+    pub fn to_array(self) -> [T; 2] {
         [self.x, self.y]
     }
 
     /// Cast into a tuple with x and y.
     #[inline]
-    pub fn to_tuple(&self) -> (T, T) {
+    pub fn to_tuple(self) -> (T, T) {
         (self.x, self.y)
     }
 
     /// Convert into a 3d vector with `z` coordinate equals to `T::zero()`.
     #[inline]
-    pub fn to_3d(&self) -> Vector3D<T, U>
+    pub fn to_3d(self) -> Vector3D<T, U>
     where
         T: Zero,
     {
@@ -283,7 +283,7 @@ impl<T: Copy, U> Vector2D<T, U> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn round(&self) -> Self
+    pub fn round(self) -> Self
     where
         T: Round,
     {
@@ -302,7 +302,7 @@ impl<T: Copy, U> Vector2D<T, U> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn ceil(&self) -> Self
+    pub fn ceil(self) -> Self
     where
         T: Ceil,
     {
@@ -321,7 +321,7 @@ impl<T: Copy, U> Vector2D<T, U> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn floor(&self) -> Self
+    pub fn floor(self) -> Self
     where
         T: Floor,
     {
@@ -333,7 +333,7 @@ impl<T: Copy, U> Vector2D<T, U> {
     /// is `+y` axis.
     ///
     /// The returned angle is between -PI and PI.
-    pub fn angle_from_x_axis(&self) -> Angle<T>
+    pub fn angle_from_x_axis(self) -> Angle<T>
     where
         T: Trig,
     {
@@ -342,7 +342,7 @@ impl<T: Copy, U> Vector2D<T, U> {
 
     /// Creates translation by this vector in vector units.
     #[inline]
-    pub fn to_transform(&self) -> Transform2D<T, U, U>
+    pub fn to_transform(self) -> Transform2D<T, U, U>
     where
         T: Zero + One,
     {
@@ -356,7 +356,7 @@ where
 {
     /// Returns the vector's length squared.
     #[inline]
-    pub fn square_length(&self) -> T {
+    pub fn square_length(self) -> T {
         self.x * self.x + self.y * self.y
     }
 
@@ -364,7 +364,7 @@ where
     ///
     /// Projecting onto a nil vector will cause a division by zero.
     #[inline]
-    pub fn project_onto_vector(&self, onto: Self) -> Self
+    pub fn project_onto_vector(self, onto: Self) -> Self
     where
         T: Sub<T, Output = T> + Div<T, Output = T>,
     {
@@ -374,7 +374,7 @@ where
     /// Returns the signed angle between this vector and another vector.
     ///
     /// The returned angle is between -PI and PI.
-    pub fn angle_to(&self, other: Self) -> Angle<T>
+    pub fn angle_to(self, other: Self) -> Angle<T>
     where
         T: Sub<Output = T> + Trig,
     {
@@ -385,7 +385,7 @@ where
 impl<T: Float, U> Vector2D<T, U> {
     /// Returns the vector length.
     #[inline]
-    pub fn length(&self) -> T {
+    pub fn length(self) -> T {
         self.square_length().sqrt()
     }
 
@@ -426,29 +426,29 @@ impl<T: Float, U> Vector2D<T, U> {
 
     /// Return this vector capped to a maximum length.
     #[inline]
-    pub fn with_max_length(&self, max_length: T) -> Self {
+    pub fn with_max_length(self, max_length: T) -> Self {
         let square_length = self.square_length();
         if square_length > max_length * max_length {
-            return (*self) * (max_length / square_length.sqrt());
+            return self * (max_length / square_length.sqrt());
         }
 
-        *self
+        self
     }
 
     /// Return this vector with a minimum length applied.
     #[inline]
-    pub fn with_min_length(&self, min_length: T) -> Self {
+    pub fn with_min_length(self, min_length: T) -> Self {
         let square_length = self.square_length();
         if square_length < min_length * min_length {
-            return (*self) * (min_length / square_length.sqrt());
+            return self * (min_length / square_length.sqrt());
         }
 
-        *self
+        self
     }
 
     /// Return this vector with minimum and maximum lengths applied.
     #[inline]
-    pub fn clamp_length(&self, min: T, max: T) -> Self {
+    pub fn clamp_length(self, min: T, max: T) -> Self {
         debug_assert!(min <= max);
         self.with_min_length(min).with_max_length(max)
     }
@@ -476,16 +476,16 @@ where
     /// assert_eq!(from.lerp(to,  2.0), vec2(16.0, -18.0));
     /// ```
     #[inline]
-    pub fn lerp(&self, other: Self, t: T) -> Self {
+    pub fn lerp(self, other: Self, t: T) -> Self {
         let one_t = T::one() - t;
-        (*self) * one_t + other * t
+        self * one_t + other * t
     }
 
     /// Returns a reflection vector using an incident ray and a surface normal.
     #[inline]
-    pub fn reflect(&self, normal: Self) -> Self {
+    pub fn reflect(self, normal: Self) -> Self {
         let two = T::one() + T::one();
-        *self - normal * two * self.dot(normal)
+        self - normal * two * self.dot(normal)
     }
 }
 
@@ -507,7 +507,7 @@ impl<T: PartialOrd, U> Vector2D<T, U> {
     ///
     /// Shortcut for `self.max(start).min(end)`.
     #[inline]
-    pub fn clamp(&self, start: Self, end: Self) -> Self
+    pub fn clamp(self, start: Self, end: Self) -> Self
     where
         T: Copy,
     {
@@ -516,7 +516,7 @@ impl<T: PartialOrd, U> Vector2D<T, U> {
 
     /// Returns vector with results of "greater than" operation on each component.
     #[inline]
-    pub fn greater_than(&self, other: Self) -> BoolVector2D {
+    pub fn greater_than(self, other: Self) -> BoolVector2D {
         BoolVector2D {
             x: self.x > other.x,
             y: self.y > other.y,
@@ -525,7 +525,7 @@ impl<T: PartialOrd, U> Vector2D<T, U> {
 
     /// Returns vector with results of "lower than" operation on each component.
     #[inline]
-    pub fn lower_than(&self, other: Self) -> BoolVector2D {
+    pub fn lower_than(self, other: Self) -> BoolVector2D {
         BoolVector2D {
             x: self.x < other.x,
             y: self.y < other.y,
@@ -536,7 +536,7 @@ impl<T: PartialOrd, U> Vector2D<T, U> {
 impl<T: PartialEq, U> Vector2D<T, U> {
     /// Returns vector with results of "equal" operation on each component.
     #[inline]
-    pub fn equal(&self, other: Self) -> BoolVector2D {
+    pub fn equal(self, other: Self) -> BoolVector2D {
         BoolVector2D {
             x: self.x == other.x,
             y: self.y == other.y,
@@ -545,7 +545,7 @@ impl<T: PartialEq, U> Vector2D<T, U> {
 
     /// Returns vector with results of "not equal" operation on each component.
     #[inline]
-    pub fn not_equal(&self, other: Self) -> BoolVector2D {
+    pub fn not_equal(self, other: Self) -> BoolVector2D {
         BoolVector2D {
             x: self.x != other.x,
             y: self.y != other.y,
@@ -560,7 +560,7 @@ impl<T: NumCast + Copy, U> Vector2D<T, U> {
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
     #[inline]
-    pub fn cast<NewT: NumCast>(&self) -> Vector2D<NewT, U> {
+    pub fn cast<NewT: NumCast>(self) -> Vector2D<NewT, U> {
         self.try_cast().unwrap()
     }
 
@@ -569,7 +569,7 @@ impl<T: NumCast + Copy, U> Vector2D<T, U> {
     /// When casting from floating vector to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
-    pub fn try_cast<NewT: NumCast>(&self) -> Option<Vector2D<NewT, U>> {
+    pub fn try_cast<NewT: NumCast>(self) -> Option<Vector2D<NewT, U>> {
         match (NumCast::from(self.x), NumCast::from(self.y)) {
             (Some(x), Some(y)) => Some(Vector2D::new(x, y)),
             _ => None,
@@ -580,13 +580,13 @@ impl<T: NumCast + Copy, U> Vector2D<T, U> {
 
     /// Cast into an `f32` vector.
     #[inline]
-    pub fn to_f32(&self) -> Vector2D<f32, U> {
+    pub fn to_f32(self) -> Vector2D<f32, U> {
         self.cast()
     }
 
     /// Cast into an `f64` vector.
     #[inline]
-    pub fn to_f64(&self) -> Vector2D<f64, U> {
+    pub fn to_f64(self) -> Vector2D<f64, U> {
         self.cast()
     }
 
@@ -596,7 +596,7 @@ impl<T: NumCast + Copy, U> Vector2D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_usize(&self) -> Vector2D<usize, U> {
+    pub fn to_usize(self) -> Vector2D<usize, U> {
         self.cast()
     }
 
@@ -606,7 +606,7 @@ impl<T: NumCast + Copy, U> Vector2D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_u32(&self) -> Vector2D<u32, U> {
+    pub fn to_u32(self) -> Vector2D<u32, U> {
         self.cast()
     }
 
@@ -616,7 +616,7 @@ impl<T: NumCast + Copy, U> Vector2D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_i32(&self) -> Vector2D<i32, U> {
+    pub fn to_i32(self) -> Vector2D<i32, U> {
         self.cast()
     }
 
@@ -626,7 +626,7 @@ impl<T: NumCast + Copy, U> Vector2D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_i64(&self) -> Vector2D<i64, U> {
+    pub fn to_i64(self) -> Vector2D<i64, U> {
         self.cast()
     }
 }
@@ -742,7 +742,7 @@ impl<T: Round, U> Round for Vector2D<T, U> {
     /// See [`Vector2D::round()`](#method.round)
     #[inline]
     fn round(self) -> Self {
-        (&self).round()
+        self.round()
     }
 }
 
@@ -750,7 +750,7 @@ impl<T: Ceil, U> Ceil for Vector2D<T, U> {
     /// See [`Vector2D::ceil()`](#method.ceil)
     #[inline]
     fn ceil(self) -> Self {
-        (&self).ceil()
+        self.ceil()
     }
 }
 
@@ -758,7 +758,7 @@ impl<T: Floor, U> Floor for Vector2D<T, U> {
     /// See [`Vector2D::floor()`](#method.floor)
     #[inline]
     fn floor(self) -> Self {
-        (&self).floor()
+        self.floor()
     }
 }
 
@@ -958,7 +958,7 @@ impl<T, U> Vector3D<T, U> {
     ///
     /// The behavior for each component follows the scalar type's implementation of
     /// `num_traits::Signed::abs`.
-    pub fn abs(&self) -> Self
+    pub fn abs(self) -> Self
     where
         T: Signed,
     {
@@ -993,37 +993,37 @@ impl<T: Copy, U> Vector3D<T, U> {
     ///
     /// Equivalent to adding this vector to the origin.
     #[inline]
-    pub fn to_point(&self) -> Point3D<T, U> {
+    pub fn to_point(self) -> Point3D<T, U> {
         point3(self.x, self.y, self.z)
     }
 
     /// Returns a 2d vector using this vector's x and y coordinates
     #[inline]
-    pub fn xy(&self) -> Vector2D<T, U> {
+    pub fn xy(self) -> Vector2D<T, U> {
         vec2(self.x, self.y)
     }
 
     /// Returns a 2d vector using this vector's x and z coordinates
     #[inline]
-    pub fn xz(&self) -> Vector2D<T, U> {
+    pub fn xz(self) -> Vector2D<T, U> {
         vec2(self.x, self.z)
     }
 
     /// Returns a 2d vector using this vector's x and z coordinates
     #[inline]
-    pub fn yz(&self) -> Vector2D<T, U> {
+    pub fn yz(self) -> Vector2D<T, U> {
         vec2(self.y, self.z)
     }
 
     /// Cast into an array with x, y and z.
     #[inline]
-    pub fn to_array(&self) -> [T; 3] {
+    pub fn to_array(self) -> [T; 3] {
         [self.x, self.y, self.z]
     }
 
     /// Cast into an array with x, y, z and 0.
     #[inline]
-    pub fn to_array_4d(&self) -> [T; 4]
+    pub fn to_array_4d(self) -> [T; 4]
     where
         T: Zero,
     {
@@ -1032,13 +1032,13 @@ impl<T: Copy, U> Vector3D<T, U> {
 
     /// Cast into a tuple with x, y and z.
     #[inline]
-    pub fn to_tuple(&self) -> (T, T, T) {
+    pub fn to_tuple(self) -> (T, T, T) {
         (self.x, self.y, self.z)
     }
 
     /// Cast into a tuple with x, y, z and 0.
     #[inline]
-    pub fn to_tuple_4d(&self) -> (T, T, T, T)
+    pub fn to_tuple_4d(self) -> (T, T, T, T)
     where
         T: Zero,
     {
@@ -1047,19 +1047,19 @@ impl<T: Copy, U> Vector3D<T, U> {
 
     /// Drop the units, preserving only the numeric value.
     #[inline]
-    pub fn to_untyped(&self) -> Vector3D<T, UnknownUnit> {
+    pub fn to_untyped(self) -> Vector3D<T, UnknownUnit> {
         vec3(self.x, self.y, self.z)
     }
 
     /// Cast the unit.
     #[inline]
-    pub fn cast_unit<V>(&self) -> Vector3D<T, V> {
+    pub fn cast_unit<V>(self) -> Vector3D<T, V> {
         vec3(self.x, self.y, self.z)
     }
 
     /// Convert into a 2d vector.
     #[inline]
-    pub fn to_2d(&self) -> Vector2D<T, U> {
+    pub fn to_2d(self) -> Vector2D<T, U> {
         self.xy()
     }
 
@@ -1075,7 +1075,7 @@ impl<T: Copy, U> Vector3D<T, U> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn round(&self) -> Self
+    pub fn round(self) -> Self
     where
         T: Round,
     {
@@ -1094,7 +1094,7 @@ impl<T: Copy, U> Vector3D<T, U> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn ceil(&self) -> Self
+    pub fn ceil(self) -> Self
     where
         T: Ceil,
     {
@@ -1113,7 +1113,7 @@ impl<T: Copy, U> Vector3D<T, U> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn floor(&self) -> Self
+    pub fn floor(self) -> Self
     where
         T: Floor,
     {
@@ -1122,7 +1122,7 @@ impl<T: Copy, U> Vector3D<T, U> {
 
     /// Creates translation by this vector in vector units
     #[inline]
-    pub fn to_transform(&self) -> Transform3D<T, U, U>
+    pub fn to_transform(self) -> Transform3D<T, U, U>
     where
         T: Zero + One,
     {
@@ -1136,7 +1136,7 @@ where
 {
     /// Returns the vector's length squared.
     #[inline]
-    pub fn square_length(&self) -> T {
+    pub fn square_length(self) -> T {
         self.x * self.x + self.y * self.y + self.z * self.z
     }
 
@@ -1144,7 +1144,7 @@ where
     ///
     /// Projecting onto a nil vector will cause a division by zero.
     #[inline]
-    pub fn project_onto_vector(&self, onto: Self) -> Self
+    pub fn project_onto_vector(self, onto: Self) -> Self
     where
         T: Sub<T, Output = T> + Div<T, Output = T>,
     {
@@ -1156,7 +1156,7 @@ impl<T: Float, U> Vector3D<T, U> {
     /// Returns the positive angle between this vector and another vector.
     ///
     /// The returned angle is between 0 and PI.
-    pub fn angle_to(&self, other: Self) -> Angle<T>
+    pub fn angle_to(self, other: Self) -> Angle<T>
     where
         T: Trig,
     {
@@ -1168,7 +1168,7 @@ impl<T: Float, U> Vector3D<T, U> {
 
     /// Returns the vector length.
     #[inline]
-    pub fn length(&self) -> T {
+    pub fn length(self) -> T {
         self.square_length().sqrt()
     }
 
@@ -1209,29 +1209,29 @@ impl<T: Float, U> Vector3D<T, U> {
 
     /// Return this vector capped to a maximum length.
     #[inline]
-    pub fn with_max_length(&self, max_length: T) -> Self {
+    pub fn with_max_length(self, max_length: T) -> Self {
         let square_length = self.square_length();
         if square_length > max_length * max_length {
-            return (*self) * (max_length / square_length.sqrt());
+            return self * (max_length / square_length.sqrt());
         }
 
-        *self
+        self
     }
 
     /// Return this vector with a minimum length applied.
     #[inline]
-    pub fn with_min_length(&self, min_length: T) -> Self {
+    pub fn with_min_length(self, min_length: T) -> Self {
         let square_length = self.square_length();
         if square_length < min_length * min_length {
-            return (*self) * (min_length / square_length.sqrt());
+            return self * (min_length / square_length.sqrt());
         }
 
-        *self
+        self
     }
 
     /// Return this vector with minimum and maximum lengths applied.
     #[inline]
-    pub fn clamp_length(&self, min: T, max: T) -> Self {
+    pub fn clamp_length(self, min: T, max: T) -> Self {
         debug_assert!(min <= max);
         self.with_min_length(min).with_max_length(max)
     }
@@ -1259,16 +1259,16 @@ where
     /// assert_eq!(from.lerp(to,  2.0), vec3(16.0, -18.0,  1.0));
     /// ```
     #[inline]
-    pub fn lerp(&self, other: Self, t: T) -> Self {
+    pub fn lerp(self, other: Self, t: T) -> Self {
         let one_t = T::one() - t;
-        (*self) * one_t + other * t
+        self * one_t + other * t
     }
 
     /// Returns a reflection vector using an incident ray and a surface normal.
     #[inline]
-    pub fn reflect(&self, normal: Self) -> Self {
+    pub fn reflect(self, normal: Self) -> Self {
         let two = T::one() + T::one();
-        *self - normal * two * self.dot(normal)
+        self - normal * two * self.dot(normal)
     }
 }
 
@@ -1298,7 +1298,7 @@ impl<T: PartialOrd, U> Vector3D<T, U> {
     ///
     /// Shortcut for `self.max(start).min(end)`.
     #[inline]
-    pub fn clamp(&self, start: Self, end: Self) -> Self
+    pub fn clamp(self, start: Self, end: Self) -> Self
     where
         T: Copy,
     {
@@ -1307,7 +1307,7 @@ impl<T: PartialOrd, U> Vector3D<T, U> {
 
     /// Returns vector with results of "greater than" operation on each component.
     #[inline]
-    pub fn greater_than(&self, other: Self) -> BoolVector3D {
+    pub fn greater_than(self, other: Self) -> BoolVector3D {
         BoolVector3D {
             x: self.x > other.x,
             y: self.y > other.y,
@@ -1317,7 +1317,7 @@ impl<T: PartialOrd, U> Vector3D<T, U> {
 
     /// Returns vector with results of "lower than" operation on each component.
     #[inline]
-    pub fn lower_than(&self, other: Self) -> BoolVector3D {
+    pub fn lower_than(self, other: Self) -> BoolVector3D {
         BoolVector3D {
             x: self.x < other.x,
             y: self.y < other.y,
@@ -1329,7 +1329,7 @@ impl<T: PartialOrd, U> Vector3D<T, U> {
 impl<T: PartialEq, U> Vector3D<T, U> {
     /// Returns vector with results of "equal" operation on each component.
     #[inline]
-    pub fn equal(&self, other: Self) -> BoolVector3D {
+    pub fn equal(self, other: Self) -> BoolVector3D {
         BoolVector3D {
             x: self.x == other.x,
             y: self.y == other.y,
@@ -1339,7 +1339,7 @@ impl<T: PartialEq, U> Vector3D<T, U> {
 
     /// Returns vector with results of "not equal" operation on each component.
     #[inline]
-    pub fn not_equal(&self, other: Self) -> BoolVector3D {
+    pub fn not_equal(self, other: Self) -> BoolVector3D {
         BoolVector3D {
             x: self.x != other.x,
             y: self.y != other.y,
@@ -1355,7 +1355,7 @@ impl<T: NumCast + Copy, U> Vector3D<T, U> {
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
     #[inline]
-    pub fn cast<NewT: NumCast>(&self) -> Vector3D<NewT, U> {
+    pub fn cast<NewT: NumCast>(self) -> Vector3D<NewT, U> {
         self.try_cast().unwrap()
     }
 
@@ -1364,7 +1364,7 @@ impl<T: NumCast + Copy, U> Vector3D<T, U> {
     /// When casting from floating vector to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
-    pub fn try_cast<NewT: NumCast>(&self) -> Option<Vector3D<NewT, U>> {
+    pub fn try_cast<NewT: NumCast>(self) -> Option<Vector3D<NewT, U>> {
         match (
             NumCast::from(self.x),
             NumCast::from(self.y),
@@ -1379,13 +1379,13 @@ impl<T: NumCast + Copy, U> Vector3D<T, U> {
 
     /// Cast into an `f32` vector.
     #[inline]
-    pub fn to_f32(&self) -> Vector3D<f32, U> {
+    pub fn to_f32(self) -> Vector3D<f32, U> {
         self.cast()
     }
 
     /// Cast into an `f64` vector.
     #[inline]
-    pub fn to_f64(&self) -> Vector3D<f64, U> {
+    pub fn to_f64(self) -> Vector3D<f64, U> {
         self.cast()
     }
 
@@ -1395,7 +1395,7 @@ impl<T: NumCast + Copy, U> Vector3D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_usize(&self) -> Vector3D<usize, U> {
+    pub fn to_usize(self) -> Vector3D<usize, U> {
         self.cast()
     }
 
@@ -1405,7 +1405,7 @@ impl<T: NumCast + Copy, U> Vector3D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_u32(&self) -> Vector3D<u32, U> {
+    pub fn to_u32(self) -> Vector3D<u32, U> {
         self.cast()
     }
 
@@ -1415,7 +1415,7 @@ impl<T: NumCast + Copy, U> Vector3D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_i32(&self) -> Vector3D<i32, U> {
+    pub fn to_i32(self) -> Vector3D<i32, U> {
         self.cast()
     }
 
@@ -1425,7 +1425,7 @@ impl<T: NumCast + Copy, U> Vector3D<T, U> {
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
     /// the desired conversion behavior.
     #[inline]
-    pub fn to_i64(&self) -> Vector3D<i64, U> {
+    pub fn to_i64(self) -> Vector3D<i64, U> {
         self.cast()
     }
 }
@@ -1559,7 +1559,7 @@ impl<T: Round, U> Round for Vector3D<T, U> {
     /// See [`Vector3D::round()`](#method.round)
     #[inline]
     fn round(self) -> Self {
-        (&self).round()
+        self.round()
     }
 }
 
@@ -1567,7 +1567,7 @@ impl<T: Ceil, U> Ceil for Vector3D<T, U> {
     /// See [`Vector3D::ceil()`](#method.ceil)
     #[inline]
     fn ceil(self) -> Self {
-        (&self).ceil()
+        self.ceil()
     }
 }
 
@@ -1575,7 +1575,7 @@ impl<T: Floor, U> Floor for Vector3D<T, U> {
     /// See [`Vector3D::floor()`](#method.floor)
     #[inline]
     fn floor(self) -> Self {
-        (&self).floor()
+        self.floor()
     }
 }
 
@@ -1639,25 +1639,25 @@ pub struct BoolVector3D {
 impl BoolVector2D {
     /// Returns `true` if all components are `true` and `false` otherwise.
     #[inline]
-    pub fn all(&self) -> bool {
+    pub fn all(self) -> bool {
         self.x && self.y
     }
 
     /// Returns `true` if any component are `true` and `false` otherwise.
     #[inline]
-    pub fn any(&self) -> bool {
+    pub fn any(self) -> bool {
         self.x || self.y
     }
 
     /// Returns `true` if all components are `false` and `false` otherwise. Negation of `any()`.
     #[inline]
-    pub fn none(&self) -> bool {
+    pub fn none(self) -> bool {
         !self.any()
     }
 
     /// Returns new vector with by-component AND operation applied.
     #[inline]
-    pub fn and(&self, other: Self) -> Self {
+    pub fn and(self, other: Self) -> Self {
         BoolVector2D {
             x: self.x && other.x,
             y: self.y && other.y,
@@ -1666,7 +1666,7 @@ impl BoolVector2D {
 
     /// Returns new vector with by-component OR operation applied.
     #[inline]
-    pub fn or(&self, other: Self) -> Self {
+    pub fn or(self, other: Self) -> Self {
         BoolVector2D {
             x: self.x || other.x,
             y: self.y || other.y,
@@ -1675,7 +1675,7 @@ impl BoolVector2D {
 
     /// Returns new vector with results of negation operation on each component.
     #[inline]
-    pub fn not(&self) -> Self {
+    pub fn not(self) -> Self {
         BoolVector2D {
             x: !self.x,
             y: !self.y,
@@ -1685,7 +1685,7 @@ impl BoolVector2D {
     /// Returns point, each component of which or from `a`, or from `b` depending on truly value
     /// of corresponding vector component. `true` selects value from `a` and `false` from `b`.
     #[inline]
-    pub fn select_point<T, U>(&self, a: Point2D<T, U>, b: Point2D<T, U>) -> Point2D<T, U> {
+    pub fn select_point<T, U>(self, a: Point2D<T, U>, b: Point2D<T, U>) -> Point2D<T, U> {
         point2(
             if self.x { a.x } else { b.x },
             if self.y { a.y } else { b.y },
@@ -1695,7 +1695,7 @@ impl BoolVector2D {
     /// Returns vector, each component of which or from `a`, or from `b` depending on truly value
     /// of corresponding vector component. `true` selects value from `a` and `false` from `b`.
     #[inline]
-    pub fn select_vector<T, U>(&self, a: Vector2D<T, U>, b: Vector2D<T, U>) -> Vector2D<T, U> {
+    pub fn select_vector<T, U>(self, a: Vector2D<T, U>, b: Vector2D<T, U>) -> Vector2D<T, U> {
         vec2(
             if self.x { a.x } else { b.x },
             if self.y { a.y } else { b.y },
@@ -1705,7 +1705,7 @@ impl BoolVector2D {
     /// Returns size, each component of which or from `a`, or from `b` depending on truly value
     /// of corresponding vector component. `true` selects value from `a` and `false` from `b`.
     #[inline]
-    pub fn select_size<T, U>(&self, a: Size2D<T, U>, b: Size2D<T, U>) -> Size2D<T, U> {
+    pub fn select_size<T, U>(self, a: Size2D<T, U>, b: Size2D<T, U>) -> Size2D<T, U> {
         size2(
             if self.x { a.width } else { b.width },
             if self.y { a.height } else { b.height },
@@ -1716,25 +1716,25 @@ impl BoolVector2D {
 impl BoolVector3D {
     /// Returns `true` if all components are `true` and `false` otherwise.
     #[inline]
-    pub fn all(&self) -> bool {
+    pub fn all(self) -> bool {
         self.x && self.y && self.z
     }
 
     /// Returns `true` if any component are `true` and `false` otherwise.
     #[inline]
-    pub fn any(&self) -> bool {
+    pub fn any(self) -> bool {
         self.x || self.y || self.z
     }
 
     /// Returns `true` if all components are `false` and `false` otherwise. Negation of `any()`.
     #[inline]
-    pub fn none(&self) -> bool {
+    pub fn none(self) -> bool {
         !self.any()
     }
 
     /// Returns new vector with by-component AND operation applied.
     #[inline]
-    pub fn and(&self, other: Self) -> Self {
+    pub fn and(self, other: Self) -> Self {
         BoolVector3D {
             x: self.x && other.x,
             y: self.y && other.y,
@@ -1744,7 +1744,7 @@ impl BoolVector3D {
 
     /// Returns new vector with by-component OR operation applied.
     #[inline]
-    pub fn or(&self, other: Self) -> Self {
+    pub fn or(self, other: Self) -> Self {
         BoolVector3D {
             x: self.x || other.x,
             y: self.y || other.y,
@@ -1754,7 +1754,7 @@ impl BoolVector3D {
 
     /// Returns new vector with results of negation operation on each component.
     #[inline]
-    pub fn not(&self) -> Self {
+    pub fn not(self) -> Self {
         BoolVector3D {
             x: !self.x,
             y: !self.y,
@@ -1765,7 +1765,7 @@ impl BoolVector3D {
     /// Returns point, each component of which or from `a`, or from `b` depending on truly value
     /// of corresponding vector component. `true` selects value from `a` and `false` from `b`.
     #[inline]
-    pub fn select_point<T, U>(&self, a: Point3D<T, U>, b: Point3D<T, U>) -> Point3D<T, U> {
+    pub fn select_point<T, U>(self, a: Point3D<T, U>, b: Point3D<T, U>) -> Point3D<T, U> {
         point3(
             if self.x { a.x } else { b.x },
             if self.y { a.y } else { b.y },
@@ -1776,7 +1776,7 @@ impl BoolVector3D {
     /// Returns vector, each component of which or from `a`, or from `b` depending on truly value
     /// of corresponding vector component. `true` selects value from `a` and `false` from `b`.
     #[inline]
-    pub fn select_vector<T, U>(&self, a: Vector3D<T, U>, b: Vector3D<T, U>) -> Vector3D<T, U> {
+    pub fn select_vector<T, U>(self, a: Vector3D<T, U>, b: Vector3D<T, U>) -> Vector3D<T, U> {
         vec3(
             if self.x { a.x } else { b.x },
             if self.y { a.y } else { b.y },
@@ -1788,7 +1788,7 @@ impl BoolVector3D {
     /// of corresponding vector component. `true` selects value from `a` and `false` from `b`.
     #[inline]
     #[must_use]
-    pub fn select_size<T, U>(&self, a: Size3D<T, U>, b: Size3D<T, U>) -> Size3D<T, U> {
+    pub fn select_size<T, U>(self, a: Size3D<T, U>, b: Size3D<T, U>) -> Size3D<T, U> {
         size3(
             if self.x { a.width } else { b.width },
             if self.y { a.height } else { b.height },
@@ -1798,7 +1798,7 @@ impl BoolVector3D {
 
     /// Returns a 2d vector using this vector's x and y coordinates.
     #[inline]
-    pub fn xy(&self) -> BoolVector2D {
+    pub fn xy(self) -> BoolVector2D {
         BoolVector2D {
             x: self.x,
             y: self.y,
@@ -1807,7 +1807,7 @@ impl BoolVector3D {
 
     /// Returns a 2d vector using this vector's x and z coordinates.
     #[inline]
-    pub fn xz(&self) -> BoolVector2D {
+    pub fn xz(self) -> BoolVector2D {
         BoolVector2D {
             x: self.x,
             y: self.z,
@@ -1816,7 +1816,7 @@ impl BoolVector3D {
 
     /// Returns a 2d vector using this vector's y and z coordinates.
     #[inline]
-    pub fn yz(&self) -> BoolVector2D {
+    pub fn yz(self) -> BoolVector2D {
         BoolVector2D {
             x: self.y,
             y: self.z,


### PR DESCRIPTION
See #454 

Points, vectors, sizes, length and scale which are passed by value are now consistently taking self by value as well.