### PR TITLE
(breaking change) Simplify the code by requiring Copy instead of Clone

### DIFF
--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -370,68 +370,68 @@ where
     }
 }
 
-impl<T: Clone + Mul, U> Mul<T> for Box2D<T, U> {
+impl<T: Copy + Mul, U> Mul<T> for Box2D<T, U> {
     type Output = Box2D<T::Output, U>;
 
     #[inline]
     fn mul(self, scale: T) -> Self::Output {
-        Box2D::new(self.min * scale.clone(), self.max * scale)
+        Box2D::new(self.min * scale, self.max * scale)
     }
 }
 
-impl<T: Clone + MulAssign, U> MulAssign<T> for Box2D<T, U> {
+impl<T: Copy + MulAssign, U> MulAssign<T> for Box2D<T, U> {
     #[inline]
     fn mul_assign(&mut self, scale: T) {
         *self *= Scale::new(scale);
     }
 }
 
-impl<T: Clone + Div, U> Div<T> for Box2D<T, U> {
+impl<T: Copy + Div, U> Div<T> for Box2D<T, U> {
     type Output = Box2D<T::Output, U>;
 
     #[inline]
     fn div(self, scale: T) -> Self::Output {
-        Box2D::new(self.min / scale.clone(), self.max / scale)
+        Box2D::new(self.min / scale, self.max / scale)
     }
 }
 
-impl<T: Clone + DivAssign, U> DivAssign<T> for Box2D<T, U> {
+impl<T: Copy + DivAssign, U> DivAssign<T> for Box2D<T, U> {
     #[inline]
     fn div_assign(&mut self, scale: T) {
         *self /= Scale::new(scale);
     }
 }
 
-impl<T: Clone + Mul, U1, U2> Mul<Scale<T, U1, U2>> for Box2D<T, U1> {
+impl<T: Copy + Mul, U1, U2> Mul<Scale<T, U1, U2>> for Box2D<T, U1> {
     type Output = Box2D<T::Output, U2>;
 
     #[inline]
     fn mul(self, scale: Scale<T, U1, U2>) -> Self::Output {
-        Box2D::new(self.min * scale.clone(), self.max * scale)
+        Box2D::new(self.min * scale, self.max * scale)
     }
 }
 
-impl<T: Clone + MulAssign, U> MulAssign<Scale<T, U, U>> for Box2D<T, U> {
+impl<T: Copy + MulAssign, U> MulAssign<Scale<T, U, U>> for Box2D<T, U> {
     #[inline]
     fn mul_assign(&mut self, scale: Scale<T, U, U>) {
-        self.min *= scale.clone();
+        self.min *= scale;
         self.max *= scale;
     }
 }
 
-impl<T: Clone + Div, U1, U2> Div<Scale<T, U1, U2>> for Box2D<T, U2> {
+impl<T: Copy + Div, U1, U2> Div<Scale<T, U1, U2>> for Box2D<T, U2> {
     type Output = Box2D<T::Output, U1>;
 
     #[inline]
     fn div(self, scale: Scale<T, U1, U2>) -> Self::Output {
-        Box2D::new(self.min / scale.clone(), self.max / scale)
+        Box2D::new(self.min / scale, self.max / scale)
     }
 }
 
-impl<T: Clone + DivAssign, U> DivAssign<Scale<T, U, U>> for Box2D<T, U> {
+impl<T: Copy + DivAssign, U> DivAssign<Scale<T, U, U>> for Box2D<T, U> {
     #[inline]
     fn div_assign(&mut self, scale: Scale<T, U, U>) {
-        self.min /= scale.clone();
+        self.min /= scale;
         self.max /= scale;
     }
 }

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -365,24 +365,24 @@ where
     }
 }
 
-impl<T: Clone + Mul, U> Mul<T> for Box3D<T, U> {
+impl<T: Copy + Mul, U> Mul<T> for Box3D<T, U> {
     type Output = Box3D<T::Output, U>;
 
     #[inline]
     fn mul(self, scale: T) -> Self::Output {
-        Box3D::new(self.min * scale.clone(), self.max * scale)
+        Box3D::new(self.min * scale, self.max * scale)
     }
 }
 
-impl<T: Clone + MulAssign, U> MulAssign<T> for Box3D<T, U> {
+impl<T: Copy + MulAssign, U> MulAssign<T> for Box3D<T, U> {
     #[inline]
     fn mul_assign(&mut self, scale: T) {
-        self.min *= scale.clone();
+        self.min *= scale;
         self.max *= scale;
     }
 }
 
-impl<T: Clone + Div, U> Div<T> for Box3D<T, U> {
+impl<T: Copy + Div, U> Div<T> for Box3D<T, U> {
     type Output = Box3D<T::Output, U>;
 
     #[inline]
@@ -391,15 +391,15 @@ impl<T: Clone + Div, U> Div<T> for Box3D<T, U> {
     }
 }
 
-impl<T: Clone + DivAssign, U> DivAssign<T> for Box3D<T, U> {
+impl<T: Copy + DivAssign, U> DivAssign<T> for Box3D<T, U> {
     #[inline]
     fn div_assign(&mut self, scale: T) {
-        self.min /= scale.clone();
+        self.min /= scale;
         self.max /= scale;
     }
 }
 
-impl<T: Clone + Mul, U1, U2> Mul<Scale<T, U1, U2>> for Box3D<T, U1> {
+impl<T: Copy + Mul, U1, U2> Mul<Scale<T, U1, U2>> for Box3D<T, U1> {
     type Output = Box3D<T::Output, U2>;
 
     #[inline]
@@ -408,7 +408,7 @@ impl<T: Clone + Mul, U1, U2> Mul<Scale<T, U1, U2>> for Box3D<T, U1> {
     }
 }
 
-impl<T: Clone + MulAssign, U> MulAssign<Scale<T, U, U>> for Box3D<T, U> {
+impl<T: Copy + MulAssign, U> MulAssign<Scale<T, U, U>> for Box3D<T, U> {
     #[inline]
     fn mul_assign(&mut self, scale: Scale<T, U, U>) {
         self.min *= scale.clone();
@@ -416,7 +416,7 @@ impl<T: Clone + MulAssign, U> MulAssign<Scale<T, U, U>> for Box3D<T, U> {
     }
 }
 
-impl<T: Clone + Div, U1, U2> Div<Scale<T, U1, U2>> for Box3D<T, U2> {
+impl<T: Copy + Div, U1, U2> Div<Scale<T, U1, U2>> for Box3D<T, U2> {
     type Output = Box3D<T::Output, U1>;
 
     #[inline]
@@ -425,7 +425,7 @@ impl<T: Clone + Div, U1, U2> Div<Scale<T, U1, U2>> for Box3D<T, U2> {
     }
 }
 
-impl<T: Clone + DivAssign, U> DivAssign<Scale<T, U, U>> for Box3D<T, U> {
+impl<T: Copy + DivAssign, U> DivAssign<Scale<T, U, U>> for Box3D<T, U> {
     #[inline]
     fn div_assign(&mut self, scale: Scale<T, U, U>) {
         self.min /= scale.clone();

--- a/src/point.rs
+++ b/src/point.rs
@@ -555,12 +555,12 @@ impl<T: Copy + Sub<T, Output = T>, U> SubAssign<Vector2D<T, U>> for Point2D<T, U
     }
 }
 
-impl<T: Clone + Mul, U> Mul<T> for Point2D<T, U> {
+impl<T: Copy + Mul, U> Mul<T> for Point2D<T, U> {
     type Output = Point2D<T::Output, U>;
 
     #[inline]
     fn mul(self, scale: T) -> Self::Output {
-        point2(self.x * scale.clone(), self.y * scale)
+        point2(self.x * scale, self.y * scale)
     }
 }
 
@@ -571,29 +571,29 @@ impl<T: Copy + Mul<T, Output = T>, U> MulAssign<T> for Point2D<T, U> {
     }
 }
 
-impl<T: Clone + Mul, U1, U2> Mul<Scale<T, U1, U2>> for Point2D<T, U1> {
+impl<T: Copy + Mul, U1, U2> Mul<Scale<T, U1, U2>> for Point2D<T, U1> {
     type Output = Point2D<T::Output, U2>;
 
     #[inline]
     fn mul(self, scale: Scale<T, U1, U2>) -> Self::Output {
-        point2(self.x * scale.0.clone(), self.y * scale.0)
+        point2(self.x * scale.0, self.y * scale.0)
     }
 }
 
-impl<T: Clone + MulAssign, U> MulAssign<Scale<T, U, U>> for Point2D<T, U> {
+impl<T: Copy + MulAssign, U> MulAssign<Scale<T, U, U>> for Point2D<T, U> {
     #[inline]
     fn mul_assign(&mut self, scale: Scale<T, U, U>) {
-        self.x *= scale.0.clone();
+        self.x *= scale.0;
         self.y *= scale.0;
     }
 }
 
-impl<T: Clone + Div, U> Div<T> for Point2D<T, U> {
+impl<T: Copy + Div, U> Div<T> for Point2D<T, U> {
     type Output = Point2D<T::Output, U>;
 
     #[inline]
     fn div(self, scale: T) -> Self::Output {
-        point2(self.x / scale.clone(), self.y / scale)
+        point2(self.x / scale, self.y / scale)
     }
 }
 
@@ -604,19 +604,19 @@ impl<T: Copy + Div<T, Output = T>, U> DivAssign<T> for Point2D<T, U> {
     }
 }
 
-impl<T: Clone + Div, U1, U2> Div<Scale<T, U1, U2>> for Point2D<T, U2> {
+impl<T: Copy + Div, U1, U2> Div<Scale<T, U1, U2>> for Point2D<T, U2> {
     type Output = Point2D<T::Output, U1>;
 
     #[inline]
     fn div(self, scale: Scale<T, U1, U2>) -> Self::Output {
-        point2(self.x / scale.0.clone(), self.y / scale.0)
+        point2(self.x / scale.0, self.y / scale.0)
     }
 }
 
-impl<T: Clone + DivAssign, U> DivAssign<Scale<T, U, U>> for Point2D<T, U> {
+impl<T: Copy + DivAssign, U> DivAssign<Scale<T, U, U>> for Point2D<T, U> {
     #[inline]
     fn div_assign(&mut self, scale: Scale<T, U, U>) {
-        self.x /= scale.0.clone();
+        self.x /= scale.0;
         self.y /= scale.0;
     }
 }
@@ -1267,84 +1267,84 @@ impl<T: Copy + Sub<T, Output = T>, U> SubAssign<Vector3D<T, U>> for Point3D<T, U
     }
 }
 
-impl<T: Clone + Mul, U> Mul<T> for Point3D<T, U> {
+impl<T: Copy + Mul, U> Mul<T> for Point3D<T, U> {
     type Output = Point3D<T::Output, U>;
 
     #[inline]
     fn mul(self, scale: T) -> Self::Output {
         point3(
-            self.x * scale.clone(),
-            self.y * scale.clone(),
+            self.x * scale,
+            self.y * scale,
             self.z * scale,
         )
     }
 }
 
-impl<T: Clone + MulAssign, U> MulAssign<T> for Point3D<T, U> {
+impl<T: Copy + MulAssign, U> MulAssign<T> for Point3D<T, U> {
     #[inline]
     fn mul_assign(&mut self, scale: T) {
-        self.x *= scale.clone();
-        self.y *= scale.clone();
+        self.x *= scale;
+        self.y *= scale;
         self.z *= scale;
     }
 }
 
-impl<T: Clone + Mul, U1, U2> Mul<Scale<T, U1, U2>> for Point3D<T, U1> {
+impl<T: Copy + Mul, U1, U2> Mul<Scale<T, U1, U2>> for Point3D<T, U1> {
     type Output = Point3D<T::Output, U2>;
 
     #[inline]
     fn mul(self, scale: Scale<T, U1, U2>) -> Self::Output {
         point3(
-            self.x * scale.0.clone(),
-            self.y * scale.0.clone(),
+            self.x * scale.0,
+            self.y * scale.0,
             self.z * scale.0,
         )
     }
 }
 
-impl<T: Clone + MulAssign, U> MulAssign<Scale<T, U, U>> for Point3D<T, U> {
+impl<T: Copy + MulAssign, U> MulAssign<Scale<T, U, U>> for Point3D<T, U> {
     #[inline]
     fn mul_assign(&mut self, scale: Scale<T, U, U>) {
         *self *= scale.0;
     }
 }
 
-impl<T: Clone + Div, U> Div<T> for Point3D<T, U> {
+impl<T: Copy + Div, U> Div<T> for Point3D<T, U> {
     type Output = Point3D<T::Output, U>;
 
     #[inline]
     fn div(self, scale: T) -> Self::Output {
         point3(
-            self.x / scale.clone(),
-            self.y / scale.clone(),
+            self.x / scale,
+            self.y / scale,
             self.z / scale,
         )
     }
 }
 
-impl<T: Clone + DivAssign, U> DivAssign<T> for Point3D<T, U> {
+impl<T: Copy + DivAssign, U> DivAssign<T> for Point3D<T, U> {
     #[inline]
     fn div_assign(&mut self, scale: T) {
-        self.x /= scale.clone();
-        self.y /= scale.clone();
+        self.x /= scale;
+        self.y /= scale;
         self.z /= scale;
     }
 }
 
-impl<T: Clone + Div, U1, U2> Div<Scale<T, U1, U2>> for Point3D<T, U2> {
+impl<T: Copy + Div, U1, U2> Div<Scale<T, U1, U2>> for Point3D<T, U2> {
     type Output = Point3D<T::Output, U1>;
 
     #[inline]
     fn div(self, scale: Scale<T, U1, U2>) -> Self::Output {
         point3(
-            self.x / scale.0.clone(),
-            self.y / scale.0.clone(),
+            self.x / scale.0,
+            self.y / scale.0,
             self.z / scale.0,
         )
     }
 }
 
-impl<T: Clone + DivAssign, U> DivAssign<Scale<T, U, U>> for Point3D<T, U> {
+impl<T: Copy + DivAssign, U> DivAssign<Scale<T, U, U>> for Point3D<T, U> {
     #[inline]
     fn div_assign(&mut self, scale: Scale<T, U, U>) {
         *self /= scale.0;

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -402,23 +402,23 @@ impl<T: Copy + Zero + PartialOrd, U> Rect<T, U> {
     }
 }
 
-impl<T: Clone + Mul, U> Mul<T> for Rect<T, U> {
+impl<T: Copy + Mul, U> Mul<T> for Rect<T, U> {
     type Output = Rect<T::Output, U>;
 
     #[inline]
     fn mul(self, scale: T) -> Self::Output {
-        Rect::new(self.origin * scale.clone(), self.size * scale)
+        Rect::new(self.origin * scale, self.size * scale)
     }
 }
 
-impl<T: Clone + MulAssign, U> MulAssign<T> for Rect<T, U> {
+impl<T: Copy + MulAssign, U> MulAssign<T> for Rect<T, U> {
     #[inline]
     fn mul_assign(&mut self, scale: T) {
         *self *= Scale::new(scale);
     }
 }
 
-impl<T: Clone + Div, U> Div<T> for Rect<T, U> {
+impl<T: Copy + Div, U> Div<T> for Rect<T, U> {
     type Output = Rect<T::Output, U>;
 
     #[inline]
@@ -427,14 +427,14 @@ impl<T: Clone + Div, U> Div<T> for Rect<T, U> {
     }
 }
 
-impl<T: Clone + DivAssign, U> DivAssign<T> for Rect<T, U> {
+impl<T: Copy + DivAssign, U> DivAssign<T> for Rect<T, U> {
     #[inline]
     fn div_assign(&mut self, scale: T) {
         *self /= Scale::new(scale);
     }
 }
 
-impl<T: Clone + Mul, U1, U2> Mul<Scale<T, U1, U2>> for Rect<T, U1> {
+impl<T: Copy + Mul, U1, U2> Mul<Scale<T, U1, U2>> for Rect<T, U1> {
     type Output = Rect<T::Output, U2>;
 
     #[inline]
@@ -443,7 +443,7 @@ impl<T: Clone + Mul, U1, U2> Mul<Scale<T, U1, U2>> for Rect<T, U1> {
     }
 }
 
-impl<T: Clone + MulAssign, U> MulAssign<Scale<T, U, U>> for Rect<T, U> {
+impl<T: Copy + MulAssign, U> MulAssign<Scale<T, U, U>> for Rect<T, U> {
     #[inline]
     fn mul_assign(&mut self, scale: Scale<T, U, U>) {
         self.origin *= scale.clone();
@@ -451,7 +451,7 @@ impl<T: Clone + MulAssign, U> MulAssign<Scale<T, U, U>> for Rect<T, U> {
     }
 }
 
-impl<T: Clone + Div, U1, U2> Div<Scale<T, U1, U2>> for Rect<T, U2> {
+impl<T: Copy + Div, U1, U2> Div<Scale<T, U1, U2>> for Rect<T, U2> {
     type Output = Rect<T::Output, U1>;
 
     #[inline]
@@ -460,7 +460,7 @@ impl<T: Clone + Div, U1, U2> Div<Scale<T, U1, U2>> for Rect<T, U2> {
     }
 }
 
-impl<T: Clone + DivAssign, U> DivAssign<Scale<T, U, U>> for Rect<T, U> {
+impl<T: Copy + DivAssign, U> DivAssign<Scale<T, U, U>> for Rect<T, U> {
     #[inline]
     fn div_assign(&mut self, scale: Scale<T, U, U>) {
         self.origin /= scale.clone();

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -158,11 +158,11 @@ impl<T: Copy, Src, Dst> Rotation2D<T, Src, Dst> {
 
 impl<T, Src, Dst> Rotation2D<T, Src, Dst>
 where
-    T: Clone,
+    T: Copy,
 {
     /// Returns self.angle as a strongly typed `Angle<T>`.
     pub fn get_angle(&self) -> Angle<T> {
-        Angle::radians(self.angle.clone())
+        Angle::radians(self.angle)
     }
 }
 

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -72,9 +72,9 @@ impl<T, Src, Dst> Scale<T, Src, Dst> {
     #[inline]
     pub fn transform_point(self, point: Point2D<T, Src>) -> Point2D<T::Output, Dst>
     where
-        T: Clone + Mul,
+        T: Copy + Mul,
     {
-        Point2D::new(point.x * self.0.clone(), point.y * self.0)
+        Point2D::new(point.x * self.0, point.y * self.0)
     }
 
     /// Returns the given vector transformed by this scale.
@@ -93,9 +93,9 @@ impl<T, Src, Dst> Scale<T, Src, Dst> {
     #[inline]
     pub fn transform_vector(self, vec: Vector2D<T, Src>) -> Vector2D<T::Output, Dst>
     where
-        T: Clone + Mul,
+        T: Copy + Mul,
     {
-        Vector2D::new(vec.x * self.0.clone(), vec.y * self.0)
+        Vector2D::new(vec.x * self.0, vec.y * self.0)
     }
 
     /// Returns the given vector transformed by this scale.
@@ -114,9 +114,9 @@ impl<T, Src, Dst> Scale<T, Src, Dst> {
     #[inline]
     pub fn transform_size(self, size: Size2D<T, Src>) -> Size2D<T::Output, Dst>
     where
-        T: Clone + Mul,
+        T: Copy + Mul,
     {
-        Size2D::new(size.width * self.0.clone(), size.height * self.0)
+        Size2D::new(size.width * self.0, size.height * self.0)
     }
 
     /// Returns the given rect transformed by this scale.

--- a/src/side_offsets.rs
+++ b/src/side_offsets.rs
@@ -165,6 +165,13 @@ impl<T, U> SideOffsets2D<T, U> {
         }
     }
 
+    /// Constructor, setting all sides to zero.
+    pub fn zero() -> Self
+        where T: Zero,
+    {
+        SideOffsets2D::new(Zero::zero(), Zero::zero(), Zero::zero(), Zero::zero())
+    }
+
     /// Returns `true` if all side offsets are zero.
     pub fn is_zero(&self) -> bool
     where
@@ -173,29 +180,30 @@ impl<T, U> SideOffsets2D<T, U> {
         let zero = T::zero();
         self.top == zero && self.right == zero && self.bottom == zero && self.left == zero
     }
-}
 
-impl<T: Copy, U> SideOffsets2D<T, U> {
     /// Constructor setting the same value to all sides, taking a scalar value directly.
-    pub fn new_all_same(all: T) -> Self {
+    pub fn new_all_same(all: T) -> Self
+        where T : Copy
+    {
         SideOffsets2D::new(all, all, all, all)
     }
 
     /// Constructor setting the same value to all sides, taking a typed Length.
-    pub fn from_length_all_same(all: Length<T, U>) -> Self {
+    pub fn from_length_all_same(all: Length<T, U>) -> Self
+        where T : Copy
+    {
         SideOffsets2D::new_all_same(all.0)
     }
-}
 
-impl<T, U> SideOffsets2D<T, U>
-where
-    T: Add<T, Output = T> + Copy,
-{
-    pub fn horizontal(&self) -> T {
+    pub fn horizontal(&self) -> T
+        where T: Copy + Add<T, Output = T>
+    {
         self.left + self.right
     }
 
-    pub fn vertical(&self) -> T {
+    pub fn vertical(&self) -> T
+        where T: Copy + Add<T, Output = T>
+    {
         self.top + self.bottom
     }
 }
@@ -215,97 +223,90 @@ where
     }
 }
 
-impl<T: Zero, U> SideOffsets2D<T, U> {
-    /// Constructor, setting all sides to zero.
-    pub fn zero() -> Self {
-        SideOffsets2D::new(Zero::zero(), Zero::zero(), Zero::zero(), Zero::zero())
-    }
-}
-
-impl<T: Clone + Mul, U> Mul<T> for SideOffsets2D<T, U> {
+impl<T: Copy + Mul, U> Mul<T> for SideOffsets2D<T, U> {
     type Output = SideOffsets2D<T::Output, U>;
 
     #[inline]
     fn mul(self, scale: T) -> Self::Output {
         SideOffsets2D::new(
-            self.top * scale.clone(),
-            self.right * scale.clone(),
-            self.bottom * scale.clone(),
+            self.top * scale,
+            self.right * scale,
+            self.bottom * scale,
             self.left * scale,
         )
     }
 }
 
-impl<T: Clone + MulAssign, U> MulAssign<T> for SideOffsets2D<T, U> {
+impl<T: Copy + MulAssign, U> MulAssign<T> for SideOffsets2D<T, U> {
     #[inline]
     fn mul_assign(&mut self, other: T) {
-        self.top *= other.clone();
-        self.right *= other.clone();
-        self.bottom *= other.clone();
+        self.top *= other;
+        self.right *= other;
+        self.bottom *= other;
         self.left *= other;
     }
 }
 
-impl<T: Clone + Mul, U1, U2> Mul<Scale<T, U1, U2>> for SideOffsets2D<T, U1> {
+impl<T: Copy + Mul, U1, U2> Mul<Scale<T, U1, U2>> for SideOffsets2D<T, U1> {
     type Output = SideOffsets2D<T::Output, U2>;
 
     #[inline]
     fn mul(self, scale: Scale<T, U1, U2>) -> Self::Output {
         SideOffsets2D::new(
-            self.top * scale.0.clone(),
-            self.right * scale.0.clone(),
-            self.bottom * scale.0.clone(),
+            self.top * scale.0,
+            self.right * scale.0,
+            self.bottom * scale.0,
             self.left * scale.0,
         )
     }
 }
 
-impl<T: Clone + MulAssign, U> MulAssign<Scale<T, U, U>> for SideOffsets2D<T, U> {
+impl<T: Copy + MulAssign, U> MulAssign<Scale<T, U, U>> for SideOffsets2D<T, U> {
     #[inline]
     fn mul_assign(&mut self, other: Scale<T, U, U>) {
         *self *= other.0;
     }
 }
 
-impl<T: Clone + Div, U> Div<T> for SideOffsets2D<T, U> {
+impl<T: Copy + Div, U> Div<T> for SideOffsets2D<T, U> {
     type Output = SideOffsets2D<T::Output, U>;
 
     #[inline]
     fn div(self, scale: T) -> Self::Output {
         SideOffsets2D::new(
-            self.top / scale.clone(),
-            self.right / scale.clone(),
-            self.bottom / scale.clone(),
+            self.top / scale,
+            self.right / scale,
+            self.bottom / scale,
             self.left / scale,
         )
     }
 }
 
-impl<T: Clone + DivAssign, U> DivAssign<T> for SideOffsets2D<T, U> {
+impl<T: Copy + DivAssign, U> DivAssign<T> for SideOffsets2D<T, U> {
     #[inline]
     fn div_assign(&mut self, other: T) {
-        self.top /= other.clone();
-        self.right /= other.clone();
-        self.bottom /= other.clone();
+        self.top /= other;
+        self.right /= other;
+        self.bottom /= other;
         self.left /= other;
     }
 }
 
-impl<T: Clone + Div, U1, U2> Div<Scale<T, U1, U2>> for SideOffsets2D<T, U2> {
+impl<T: Copy + Div, U1, U2> Div<Scale<T, U1, U2>> for SideOffsets2D<T, U2> {
     type Output = SideOffsets2D<T::Output, U1>;
 
     #[inline]
     fn div(self, scale: Scale<T, U1, U2>) -> Self::Output {
         SideOffsets2D::new(
-            self.top / scale.0.clone(),
-            self.right / scale.0.clone(),
-            self.bottom / scale.0.clone(),
+            self.top / scale.0,
+            self.right / scale.0,
+            self.bottom / scale.0,
             self.left / scale.0,
         )
     }
 }
 
-impl<T: Clone + DivAssign, U> DivAssign<Scale<T, U, U>> for SideOffsets2D<T, U> {
+impl<T: Copy + DivAssign, U> DivAssign<Scale<T, U, U>> for SideOffsets2D<T, U> {
     fn div_assign(&mut self, other: Scale<T, U, U>) {
         *self /= other.0;
     }

--- a/src/size.rs
+++ b/src/size.rs
@@ -523,66 +523,66 @@ impl<T: SubAssign, U> SubAssign for Size2D<T, U> {
     }
 }
 
-impl<T: Clone + Mul, U> Mul<T> for Size2D<T, U> {
+impl<T: Copy + Mul, U> Mul<T> for Size2D<T, U> {
     type Output = Size2D<T::Output, U>;
 
     #[inline]
     fn mul(self, scale: T) -> Self::Output {
-        Size2D::new(self.width * scale.clone(), self.height * scale)
+        Size2D::new(self.width * scale, self.height * scale)
     }
 }
 
-impl<T: Clone + MulAssign, U> MulAssign<T> for Size2D<T, U> {
+impl<T: Copy + MulAssign, U> MulAssign<T> for Size2D<T, U> {
     #[inline]
     fn mul_assign(&mut self, other: T) {
-        self.width *= other.clone();
+        self.width *= other;
         self.height *= other;
     }
 }
 
-impl<T: Clone + Mul, U1, U2> Mul<Scale<T, U1, U2>> for Size2D<T, U1> {
+impl<T: Copy + Mul, U1, U2> Mul<Scale<T, U1, U2>> for Size2D<T, U1> {
     type Output = Size2D<T::Output, U2>;
 
     #[inline]
     fn mul(self, scale: Scale<T, U1, U2>) -> Self::Output {
-        Size2D::new(self.width * scale.0.clone(), self.height * scale.0)
+        Size2D::new(self.width * scale.0, self.height * scale.0)
     }
 }
 
-impl<T: Clone + MulAssign, U> MulAssign<Scale<T, U, U>> for Size2D<T, U> {
+impl<T: Copy + MulAssign, U> MulAssign<Scale<T, U, U>> for Size2D<T, U> {
     #[inline]
     fn mul_assign(&mut self, other: Scale<T, U, U>) {
         *self *= other.0;
     }
 }
 
-impl<T: Clone + Div, U> Div<T> for Size2D<T, U> {
+impl<T: Copy + Div, U> Div<T> for Size2D<T, U> {
     type Output = Size2D<T::Output, U>;
 
     #[inline]
     fn div(self, scale: T) -> Self::Output {
-        Size2D::new(self.width / scale.clone(), self.height / scale)
+        Size2D::new(self.width / scale, self.height / scale)
     }
 }
 
-impl<T: Clone + DivAssign, U> DivAssign<T> for Size2D<T, U> {
+impl<T: Copy + DivAssign, U> DivAssign<T> for Size2D<T, U> {
     #[inline]
     fn div_assign(&mut self, other: T) {
-        self.width /= other.clone();
+        self.width /= other;
         self.height /= other;
     }
 }
 
-impl<T: Clone + Div, U1, U2> Div<Scale<T, U1, U2>> for Size2D<T, U2> {
+impl<T: Copy + Div, U1, U2> Div<Scale<T, U1, U2>> for Size2D<T, U2> {
     type Output = Size2D<T::Output, U1>;
 
     #[inline]
     fn div(self, scale: Scale<T, U1, U2>) -> Self::Output {
-        Size2D::new(self.width / scale.0.clone(), self.height / scale.0)
+        Size2D::new(self.width / scale.0, self.height / scale.0)
     }
 }
 
-impl<T: Clone + DivAssign, U> DivAssign<Scale<T, U, U>> for Size2D<T, U> {
+impl<T: Copy + DivAssign, U> DivAssign<Scale<T, U, U>> for Size2D<T, U> {
     #[inline]
     fn div_assign(&mut self, other: Scale<T, U, U>) {
         *self /= other.0;
@@ -1370,84 +1370,84 @@ impl<T: SubAssign, U> SubAssign for Size3D<T, U> {
     }
 }
 
-impl<T: Clone + Mul, U> Mul<T> for Size3D<T, U> {
+impl<T: Copy + Mul, U> Mul<T> for Size3D<T, U> {
     type Output = Size3D<T::Output, U>;
 
     #[inline]
     fn mul(self, scale: T) -> Self::Output {
         Size3D::new(
-            self.width * scale.clone(),
-            self.height * scale.clone(),
+            self.width * scale,
+            self.height * scale,
             self.depth * scale,
         )
     }
 }
 
-impl<T: Clone + MulAssign, U> MulAssign<T> for Size3D<T, U> {
+impl<T: Copy + MulAssign, U> MulAssign<T> for Size3D<T, U> {
     #[inline]
     fn mul_assign(&mut self, other: T) {
-        self.width *= other.clone();
-        self.height *= other.clone();
+        self.width *= other;
+        self.height *= other;
         self.depth *= other;
     }
 }
 
-impl<T: Clone + Mul, U1, U2> Mul<Scale<T, U1, U2>> for Size3D<T, U1> {
+impl<T: Copy + Mul, U1, U2> Mul<Scale<T, U1, U2>> for Size3D<T, U1> {
     type Output = Size3D<T::Output, U2>;
 
     #[inline]
     fn mul(self, scale: Scale<T, U1, U2>) -> Self::Output {
         Size3D::new(
-            self.width * scale.0.clone(),
-            self.height * scale.0.clone(),
+            self.width * scale.0,
+            self.height * scale.0,
             self.depth * scale.0,
         )
     }
 }
 
-impl<T: Clone + MulAssign, U> MulAssign<Scale<T, U, U>> for Size3D<T, U> {
+impl<T: Copy + MulAssign, U> MulAssign<Scale<T, U, U>> for Size3D<T, U> {
     #[inline]
     fn mul_assign(&mut self, other: Scale<T, U, U>) {
         *self *= other.0;
     }
 }
 
-impl<T: Clone + Div, U> Div<T> for Size3D<T, U> {
+impl<T: Copy + Div, U> Div<T> for Size3D<T, U> {
     type Output = Size3D<T::Output, U>;
 
     #[inline]
     fn div(self, scale: T) -> Self::Output {
         Size3D::new(
-            self.width / scale.clone(),
-            self.height / scale.clone(),
+            self.width / scale,
+            self.height / scale,
             self.depth / scale,
         )
     }
 }
 
-impl<T: Clone + DivAssign, U> DivAssign<T> for Size3D<T, U> {
+impl<T: Copy + DivAssign, U> DivAssign<T> for Size3D<T, U> {
     #[inline]
     fn div_assign(&mut self, other: T) {
-        self.width /= other.clone();
-        self.height /= other.clone();
+        self.width /= other;
+        self.height /= other;
         self.depth /= other;
     }
 }
 
-impl<T: Clone + Div, U1, U2> Div<Scale<T, U1, U2>> for Size3D<T, U2> {
+impl<T: Copy + Div, U1, U2> Div<Scale<T, U1, U2>> for Size3D<T, U2> {
     type Output = Size3D<T::Output, U1>;
 
     #[inline]
     fn div(self, scale: Scale<T, U1, U2>) -> Self::Output {
         Size3D::new(
-            self.width / scale.0.clone(),
-            self.height / scale.0.clone(),
+            self.width / scale.0,
+            self.height / scale.0,
             self.depth / scale.0,
         )
     }
 }
 
-impl<T: Clone + DivAssign, U> DivAssign<Scale<T, U, U>> for Size3D<T, U> {
+impl<T: Copy + DivAssign, U> DivAssign<Scale<T, U, U>> for Size3D<T, U> {
     #[inline]
     fn div_assign(&mut self, other: Scale<T, U, U>) {
         *self /= other.0;

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -672,12 +672,12 @@ impl<T: Copy + Sub<T, Output = T>, U> SubAssign<Vector2D<T, U>> for Vector2D<T, 
     }
 }
 
-impl<T: Clone + Mul, U> Mul<T> for Vector2D<T, U> {
+impl<T: Copy + Mul, U> Mul<T> for Vector2D<T, U> {
     type Output = Vector2D<T::Output, U>;
 
     #[inline]
     fn mul(self, scale: T) -> Self::Output {
-        vec2(self.x * scale.clone(), self.y * scale)
+        vec2(self.x * scale, self.y * scale)
     }
 }
 
@@ -688,29 +688,29 @@ impl<T: Copy + Mul<T, Output = T>, U> MulAssign<T> for Vector2D<T, U> {
     }
 }
 
-impl<T: Clone + Mul, U1, U2> Mul<Scale<T, U1, U2>> for Vector2D<T, U1> {
+impl<T: Copy + Mul, U1, U2> Mul<Scale<T, U1, U2>> for Vector2D<T, U1> {
     type Output = Vector2D<T::Output, U2>;
 
     #[inline]
     fn mul(self, scale: Scale<T, U1, U2>) -> Self::Output {
-        vec2(self.x * scale.0.clone(), self.y * scale.0)
+        vec2(self.x * scale.0, self.y * scale.0)
     }
 }
 
-impl<T: Clone + MulAssign, U> MulAssign<Scale<T, U, U>> for Vector2D<T, U> {
+impl<T: Copy + MulAssign, U> MulAssign<Scale<T, U, U>> for Vector2D<T, U> {
     #[inline]
     fn mul_assign(&mut self, scale: Scale<T, U, U>) {
-        self.x *= scale.0.clone();
+        self.x *= scale.0;
         self.y *= scale.0;
     }
 }
 
-impl<T: Clone + Div, U> Div<T> for Vector2D<T, U> {
+impl<T: Copy + Div, U> Div<T> for Vector2D<T, U> {
     type Output = Vector2D<T::Output, U>;
 
     #[inline]
     fn div(self, scale: T) -> Self::Output {
-        vec2(self.x / scale.clone(), self.y / scale)
+        vec2(self.x / scale, self.y / scale)
     }
 }
 
@@ -721,19 +721,19 @@ impl<T: Copy + Div<T, Output = T>, U> DivAssign<T> for Vector2D<T, U> {
     }
 }
 
-impl<T: Clone + Div, U1, U2> Div<Scale<T, U1, U2>> for Vector2D<T, U2> {
+impl<T: Copy + Div, U1, U2> Div<Scale<T, U1, U2>> for Vector2D<T, U2> {
     type Output = Vector2D<T::Output, U1>;
 
     #[inline]
     fn div(self, scale: Scale<T, U1, U2>) -> Self::Output {
-        vec2(self.x / scale.0.clone(), self.y / scale.0)
+        vec2(self.x / scale.0, self.y / scale.0)
     }
 }
 
-impl<T: Clone + DivAssign, U> DivAssign<Scale<T, U, U>> for Vector2D<T, U> {
+impl<T: Copy + DivAssign, U> DivAssign<Scale<T, U, U>> for Vector2D<T, U> {
     #[inline]
     fn div_assign(&mut self, scale: Scale<T, U, U>) {
-        self.x /= scale.0.clone();
+        self.x /= scale.0;
         self.y /= scale.0;
     }
 }
@@ -1471,14 +1471,14 @@ impl<T: Copy + Sub<T, Output = T>, U> SubAssign<Vector3D<T, U>> for Vector3D<T, 
     }
 }
 
-impl<T: Clone + Mul, U> Mul<T> for Vector3D<T, U> {
+impl<T: Copy + Mul, U> Mul<T> for Vector3D<T, U> {
     type Output = Vector3D<T::Output, U>;
 
     #[inline]
     fn mul(self, scale: T) -> Self::Output {
         vec3(
-            self.x * scale.clone(),
-            self.y * scale.clone(),
+            self.x * scale,
+            self.y * scale,
             self.z * scale,
         )
     }
@@ -1491,36 +1491,36 @@ impl<T: Copy + Mul<T, Output = T>, U> MulAssign<T> for Vector3D<T, U> {
     }
 }
 
-impl<T: Clone + Mul, U1, U2> Mul<Scale<T, U1, U2>> for Vector3D<T, U1> {
+impl<T: Copy + Mul, U1, U2> Mul<Scale<T, U1, U2>> for Vector3D<T, U1> {
     type Output = Vector3D<T::Output, U2>;
 
     #[inline]
     fn mul(self, scale: Scale<T, U1, U2>) -> Self::Output {
         vec3(
-            self.x * scale.0.clone(),
-            self.y * scale.0.clone(),
+            self.x * scale.0,
+            self.y * scale.0,
             self.z * scale.0,
         )
     }
 }
 
-impl<T: Clone + MulAssign, U> MulAssign<Scale<T, U, U>> for Vector3D<T, U> {
+impl<T: Copy + MulAssign, U> MulAssign<Scale<T, U, U>> for Vector3D<T, U> {
     #[inline]
     fn mul_assign(&mut self, scale: Scale<T, U, U>) {
-        self.x *= scale.0.clone();
-        self.y *= scale.0.clone();
+        self.x *= scale.0;
+        self.y *= scale.0;
         self.z *= scale.0;
     }
 }
 
-impl<T: Clone + Div, U> Div<T> for Vector3D<T, U> {
+impl<T: Copy + Div, U> Div<T> for Vector3D<T, U> {
     type Output = Vector3D<T::Output, U>;
 
     #[inline]
     fn div(self, scale: T) -> Self::Output {
         vec3(
-            self.x / scale.clone(),
-            self.y / scale.clone(),
+            self.x / scale,
+            self.y / scale,
             self.z / scale,
         )
     }
@@ -1533,24 +1533,24 @@ impl<T: Copy + Div<T, Output = T>, U> DivAssign<T> for Vector3D<T, U> {
     }
 }
 
-impl<T: Clone + Div, U1, U2> Div<Scale<T, U1, U2>> for Vector3D<T, U2> {
+impl<T: Copy + Div, U1, U2> Div<Scale<T, U1, U2>> for Vector3D<T, U2> {
     type Output = Vector3D<T::Output, U1>;
 
     #[inline]
     fn div(self, scale: Scale<T, U1, U2>) -> Self::Output {
         vec3(
-            self.x / scale.0.clone(),
-            self.y / scale.0.clone(),
+            self.x / scale.0,
+            self.y / scale.0,
             self.z / scale.0,
         )
     }
 }
 
-impl<T: Clone + DivAssign, U> DivAssign<Scale<T, U, U>> for Vector3D<T, U> {
+impl<T: Copy + DivAssign, U> DivAssign<Scale<T, U, U>> for Vector3D<T, U> {
     #[inline]
     fn div_assign(&mut self, scale: Scale<T, U, U>) {
-        self.x /= scale.0.clone();
-        self.y /= scale.0.clone();
+        self.x /= scale.0;
+        self.y /= scale.0;
         self.z /= scale.0;
     }
 }


### PR DESCRIPTION
See #454 

Anything doing more than a couple of operations (all of the transforms code for example) already requires Copy. This change takes the position that we are better off not supporting non-Copy types with simpler code than complicate the code to half-support them. Since Clone implies Copy, we can change our minds later and relax the requirements without requiring a breaking change.

This is on top of #455 which will have to land before this can be rebased and landed.