### PR TITLE
(breaking change) Replace Scale::ONE with Scale::identity

### DIFF
--- a/src/scale.rs
+++ b/src/scale.rs
@@ -56,6 +56,15 @@ impl<T, Src, Dst> Scale<T, Src, Dst> {
         Scale(x, PhantomData)
     }
 
+    /// Creates an identity scale (1.0).
+    #[inline]
+    pub fn identity() -> Self
+    where
+        T: One
+    {
+        Scale::new(T::one())
+    }
+
     /// Returns the given point transformed by this scale.
     ///
     /// # Example
@@ -251,11 +260,6 @@ impl<T: NumCast, Src, Dst> Scale<T, Src, Dst> {
     pub fn try_cast<NewT: NumCast>(self) -> Option<Scale<NewT, Src, Dst>> {
         NumCast::from(self.0).map(Scale::new)
     }
-}
-
-impl<Src, Dst> Scale<f32, Src, Dst> {
-    /// Identity scaling, could be used to safely transit from one space to another.
-    pub const ONE: Self = Scale(1.0, PhantomData);
 }
 
 // scale0 * scale1


### PR DESCRIPTION
`ONE` was only implemented for `f32` (I think nothing else in euclid has a functionality implemented for a single type) whereas `identity` is implemented for all types implementing `num::One`. On the other hand `identity` can't be a `const fn` because these don't support trait bounds other than `Sized` currently.
Also `identity` is consistent with other transform types in euclid.