### PR TITLE
(breaking change) Some Rect and Box adjustments

### DIFF
--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -183,13 +183,7 @@ where
     /// Computes the intersection of two boxes, returning `None` if the boxes do not intersect.
     #[inline]
     pub fn try_intersection(&self, other: &Self) -> Option<NonEmpty<Self>> {
-        let intersection = self.intersection(other);
-
-        if intersection.is_negative() {
-            return None;
-        }
-
-        Some(NonEmpty(intersection))
+        self.intersection(other).to_non_empty()
     }
 
     #[inline]

--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -169,21 +169,25 @@ where
 
         Some(NonEmpty(*self))
     }
-    /// Computes the intersection of two boxes.
+
+    /// Computes the intersection of two boxes, returning `None` if the boxes do not intersect.
+    #[inline]
+    pub fn intersection(&self, other: &Self) -> Option<NonEmpty<Self>> {
+        self.intersection_unchecked(other).to_non_empty()
+    }
+
+    /// Computes the intersection of two boxes without check whether they do intersect.
     ///
     /// The result is a negative box if the boxes do not intersect.
+    /// This can be useful for computing the intersection of more than two boxes, as
+    /// it is possible to chain multiple intersection_unchecked calls and check for
+    /// empty/negative result at the end.
     #[inline]
-    pub fn intersection(&self, other: &Self) -> Self {
+    pub fn intersection_unchecked(&self, other: &Self) -> Self {
         Box2D {
             min: point2(max(self.min.x, other.min.x), max(self.min.y, other.min.y)),
             max: point2(min(self.max.x, other.max.x), min(self.max.y, other.max.y)),
         }
-    }
-
-    /// Computes the intersection of two boxes, returning `None` if the boxes do not intersect.
-    #[inline]
-    pub fn try_intersection(&self, other: &Self) -> Option<NonEmpty<Self>> {
-        self.intersection(other).to_non_empty()
     }
 
     #[inline]
@@ -723,10 +727,10 @@ mod tests {
     }
 
     #[test]
-    fn test_intersection() {
+    fn test_intersection_unchecked() {
         let b1 = Box2D::from_points(&[point2(-15.0, -20.0), point2(10.0, 20.0)]);
         let b2 = Box2D::from_points(&[point2(-10.0, 20.0), point2(15.0, -20.0)]);
-        let b = b1.intersection(&b2);
+        let b = b1.intersection_unchecked(&b2);
         assert_eq!(b.max.x, 10.0);
         assert_eq!(b.max.y, 20.0);
         assert_eq!(b.min.x, -10.0);
@@ -734,14 +738,14 @@ mod tests {
     }
 
     #[test]
-    fn test_try_intersection() {
+    fn test_intersection() {
         let b1 = Box2D::from_points(&[point2(-15.0, -20.0), point2(10.0, 20.0)]);
         let b2 = Box2D::from_points(&[point2(-10.0, 20.0), point2(15.0, -20.0)]);
-        assert!(b1.try_intersection(&b2).is_some());
+        assert!(b1.intersection(&b2).is_some());
 
         let b1 = Box2D::from_points(&[point2(-15.0, -20.0), point2(-10.0, 20.0)]);
         let b2 = Box2D::from_points(&[point2(10.0, 20.0), point2(15.0, -20.0)]);
-        assert!(b1.try_intersection(&b2).is_none());
+        assert!(b1.intersection(&b2).is_none());
     }
 
     #[test]

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -149,11 +149,11 @@ where
     }
 
     #[inline]
-    pub fn try_intersection(&self, other: &Self) -> Option<NonEmpty<Self>> {
-        self.intersection(other).to_non_empty()
+    pub fn intersection(&self, other: &Self) -> Option<NonEmpty<Self>> {
+        self.intersection_unchecked(other).to_non_empty()
     }
 
-    pub fn intersection(&self, other: &Self) -> Self {
+    pub fn intersection_unchecked(&self, other: &Self) -> Self {
         let intersection_min = Point3D::new(
             max(self.min.x, other.min.x),
             max(self.min.y, other.min.y),
@@ -770,10 +770,10 @@ mod tests {
     }
 
     #[test]
-    fn test_intersection() {
+    fn test_intersection_unchecked() {
         let b1 = Box3D::from_points(&[point3(-15.0, -20.0, -20.0), point3(10.0, 20.0, 20.0)]);
         let b2 = Box3D::from_points(&[point3(-10.0, 20.0, 20.0), point3(15.0, -20.0, -20.0)]);
-        let b = b1.intersection(&b2);
+        let b = b1.intersection_unchecked(&b2);
         assert!(b.max.x == 10.0);
         assert!(b.max.y == 20.0);
         assert!(b.max.z == 20.0);
@@ -784,14 +784,14 @@ mod tests {
     }
 
     #[test]
-    fn test_try_intersection() {
+    fn test_intersection() {
         let b1 = Box3D::from_points(&[point3(-15.0, -20.0, -20.0), point3(10.0, 20.0, 20.0)]);
         let b2 = Box3D::from_points(&[point3(-10.0, 20.0, 20.0), point3(15.0, -20.0, -20.0)]);
-        assert!(b1.try_intersection(&b2).is_some());
+        assert!(b1.intersection(&b2).is_some());
 
         let b1 = Box3D::from_points(&[point3(-15.0, -20.0, -20.0), point3(-10.0, 20.0, 20.0)]);
         let b2 = Box3D::from_points(&[point3(10.0, 20.0, 20.0), point3(15.0, -20.0, -20.0)]);
-        assert!(b1.try_intersection(&b2).is_none());
+        assert!(b1.intersection(&b2).is_none());
     }
 
     #[test]

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -150,11 +150,7 @@ where
 
     #[inline]
     pub fn try_intersection(&self, other: &Self) -> Option<NonEmpty<Self>> {
-        if !self.intersects(other) {
-            return None;
-        }
-
-        Some(NonEmpty(self.intersection(other)))
+        self.intersection(other).to_non_empty()
     }
 
     pub fn intersection(&self, other: &Self) -> Self {

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -215,13 +215,13 @@ where
     T: Copy + PartialOrd + Add<T, Output = T> + Sub<T, Output = T>,
 {
     #[inline]
-    pub fn intersection(&self, other: &Self) -> Option<Self> {
+    pub fn try_intersection(&self, other: &Self) -> Option<NonEmpty<Self>> {
         let box2d = self.to_box2d().intersection(&other.to_box2d());
         if box2d.is_empty() {
             return None;
         }
 
-        Some(box2d.to_rect())
+        Some(NonEmpty(box2d.to_rect()))
     }
 }
 
@@ -695,19 +695,19 @@ mod tests {
         let q = Rect::new(Point2D::new(5, 15), Size2D::new(10, 10));
         let r = Rect::new(Point2D::new(-5, -5), Size2D::new(8, 8));
 
-        let pq = p.intersection(&q);
+        let pq = p.try_intersection(&q);
         assert!(pq.is_some());
         let pq = pq.unwrap();
         assert!(pq.origin == Point2D::new(5, 15));
         assert!(pq.size == Size2D::new(5, 5));
 
-        let pr = p.intersection(&r);
+        let pr = p.try_intersection(&r);
         assert!(pr.is_some());
         let pr = pr.unwrap();
         assert!(pr.origin == Point2D::new(0, 0));
         assert!(pr.size == Size2D::new(3, 3));
 
-        let qr = q.intersection(&r);
+        let qr = q.try_intersection(&r);
         assert!(qr.is_none());
     }
 
@@ -723,10 +723,10 @@ mod tests {
         let r = Rect::new(Point2D::new(-2147483648, -2147483648), Size2D::new(1, 1));
 
         assert!(p.is_empty());
-        let pq = p.intersection(&q);
+        let pq = p.try_intersection(&q);
         assert!(pq.is_none());
 
-        let qr = q.intersection(&r);
+        let qr = q.try_intersection(&r);
         assert!(qr.is_none());
     }
 
@@ -902,6 +902,6 @@ mod tests {
         let r1: Rect<f32> = rect(-2.0, 5.0, 4.0, std::f32::NAN);
         let r2: Rect<f32> = rect(std::f32::NAN, -1.0, 3.0, 10.0);
 
-        assert_eq!(r1.intersection(&r2), None);
+        assert_eq!(r1.try_intersection(&r2), None);
     }
 }

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -215,8 +215,8 @@ where
     T: Copy + PartialOrd + Add<T, Output = T> + Sub<T, Output = T>,
 {
     #[inline]
-    pub fn try_intersection(&self, other: &Self) -> Option<NonEmpty<Self>> {
-        let box2d = self.to_box2d().intersection(&other.to_box2d());
+    pub fn intersection(&self, other: &Self) -> Option<NonEmpty<Self>> {
+        let box2d = self.to_box2d().intersection_unchecked(&other.to_box2d());
         if box2d.is_empty() {
             return None;
         }
@@ -695,19 +695,19 @@ mod tests {
         let q = Rect::new(Point2D::new(5, 15), Size2D::new(10, 10));
         let r = Rect::new(Point2D::new(-5, -5), Size2D::new(8, 8));
 
-        let pq = p.try_intersection(&q);
+        let pq = p.intersection(&q);
         assert!(pq.is_some());
         let pq = pq.unwrap();
         assert!(pq.origin == Point2D::new(5, 15));
         assert!(pq.size == Size2D::new(5, 5));
 
-        let pr = p.try_intersection(&r);
+        let pr = p.intersection(&r);
         assert!(pr.is_some());
         let pr = pr.unwrap();
         assert!(pr.origin == Point2D::new(0, 0));
         assert!(pr.size == Size2D::new(3, 3));
 
-        let qr = q.try_intersection(&r);
+        let qr = q.intersection(&r);
         assert!(qr.is_none());
     }
 
@@ -723,10 +723,10 @@ mod tests {
         let r = Rect::new(Point2D::new(-2147483648, -2147483648), Size2D::new(1, 1));
 
         assert!(p.is_empty());
-        let pq = p.try_intersection(&q);
+        let pq = p.intersection(&q);
         assert!(pq.is_none());
 
-        let qr = q.try_intersection(&r);
+        let qr = q.intersection(&r);
         assert!(qr.is_none());
     }
 
@@ -902,6 +902,6 @@ mod tests {
         let r1: Rect<f32> = rect(-2.0, 5.0, 4.0, std::f32::NAN);
         let r2: Rect<f32> = rect(std::f32::NAN, -1.0, 3.0, 10.0);
 
-        assert_eq!(r1.try_intersection(&r2), None);
+        assert_eq!(r1.intersection(&r2), None);
     }
 }


### PR DESCRIPTION
A few rect/box related adjustments:

 - Change `Rect::intersection -> Option<Self>` into `Rect::try_intersection -> Option<NonEmpty<Self>` to match Box2D's API and get the extra typeness of `NonEmpty`. That's main ly for consistency but I would understand if we feel like it's too annoying a change becase webrender (and perhaps servo layout?) code is riddled with intersection checks. Let me know.
 - Make `Box2D::try_intersection` check that the box is empty instead of just negative. That was an oversight, we'd previously get `Some(intersection)` with intersection being an empty rect (or a bad rect with NaNs) which I believe isn't what we want.
 - Express Box3D::try_intersection the same way as Box2D::try_intersection: That shouldn't affect the behavior but it removes a bit of redundant computation.