### PR TITLE
Add getters providing strongly typed Length values

### DIFF
--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -12,6 +12,7 @@ use crate::approxord::{max, min};
 use crate::nonempty::NonEmpty;
 use crate::num::*;
 use crate::point::{point2, Point2D};
+use crate::length::Length;
 use crate::rect::Rect;
 use crate::scale::Scale;
 use crate::side_offsets::SideOffsets2D;
@@ -230,6 +231,18 @@ where
     #[inline]
     pub fn height(&self) -> T {
         self.max.y - self.min.y
+    }
+
+    /// Return this box's width as a strongly typed `Length`.
+    #[inline]
+    pub fn get_width(self) -> Length<T, U> {
+        Length::new(self.width())
+    }
+
+    /// Return this box's height as a strongly typed `Length`.
+    #[inline]
+    pub fn get_height(self) -> Length<T, U> {
+        Length::new(self.height())
     }
 
     #[inline]

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -12,6 +12,7 @@ use crate::approxord::{max, min};
 use crate::nonempty::NonEmpty;
 use crate::num::*;
 use crate::point::{point3, Point3D};
+use crate::length::Length;
 use crate::scale::Scale;
 use crate::size::Size3D;
 use crate::vector::Vector3D;
@@ -228,6 +229,24 @@ where
     #[inline]
     pub fn depth(&self) -> T {
         self.max.z - self.min.z
+    }
+
+    /// Return this box's width as a strongly typed `Length`.
+    #[inline]
+    pub fn get_width(self) -> Length<T, U> {
+        Length::new(self.width())
+    }
+
+    /// Return this box's height as a strongly typed `Length`.
+    #[inline]
+    pub fn get_height(self) -> Length<T, U> {
+        Length::new(self.height())
+    }
+
+    /// Return this box's depth as a strongly typed `Length`.
+    #[inline]
+    pub fn get_depth(self) -> Length<T, U> {
+        Length::new(self.depth())
     }
 }
 

--- a/src/point.rs
+++ b/src/point.rs
@@ -153,6 +153,18 @@ impl<T, U> Point2D<T, U> {
     pub fn from_untyped(p: Point2D<T, UnknownUnit>) -> Self {
         point2(p.x, p.y)
     }
+
+    /// Return this point's x component as a strongly typed `Length`.
+    #[inline]
+    pub fn get_x(self) -> Length<T, U> {
+        Length::new(self.x)
+    }
+
+    /// Return this point's y component as a strongly typed `Length`.
+    #[inline]
+    pub fn get_y(self) -> Length<T, U> {
+        Length::new(self.y)
+    }
 }
 
 impl<T: Copy, U> Point2D<T, U> {
@@ -823,6 +835,24 @@ impl<T, U> Point3D<T, U> {
     #[inline]
     pub fn from_untyped(p: Point3D<T, UnknownUnit>) -> Self {
         point3(p.x, p.y, p.z)
+    }
+
+    /// Return this point's x component as a strongly typed `Length`.
+    #[inline]
+    pub fn get_x(self) -> Length<T, U> {
+        Length::new(self.x)
+    }
+
+    /// Return this point's y component as a strongly typed `Length`.
+    #[inline]
+    pub fn get_y(self) -> Length<T, U> {
+        Length::new(self.y)
+    }
+
+    /// Return this point's z component as a strongly typed `Length`.
+    #[inline]
+    pub fn get_z(self) -> Length<T, U> {
+        Length::new(self.z)
     }
 }
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -149,6 +149,18 @@ impl<T, U> Size2D<T, U> {
     pub fn from_untyped(p: Size2D<T, UnknownUnit>) -> Self {
         Size2D::new(p.width, p.height)
     }
+
+    /// Return this size's width as a strongly typed `Length`.
+    #[inline]
+    pub fn get_width(self) -> Length<T, U> {
+        Length::new(self.width)
+    }
+
+    /// Return this size's height as a strongly typed `Length`.
+    #[inline]
+    pub fn get_height(self) -> Length<T, U> {
+        Length::new(self.height)
+    }
 }
 
 impl<T: Copy, U> Size2D<T, U> {
@@ -981,6 +993,23 @@ impl<T, U> Size3D<T, U> {
     #[inline]
     pub fn from_untyped(p: Size3D<T, UnknownUnit>) -> Self {
         Size3D::new(p.width, p.height, p.depth)
+    }
+
+    /// Return this size's width as a strongly typed `Length`.
+    #[inline]
+    pub fn get_width(self) -> Length<T, U> {
+        Length::new(self.width)
+    }
+
+    /// Return this size's height as a strongly typed `Length`.
+    #[inline]
+    pub fn get_height(self) -> Length<T, U> {
+        Length::new(self.height)
+    }
+    /// Return this size's depth as a strongly typed `Length`.
+    #[inline]
+    pub fn get_depth(self) -> Length<T, U> {
+        Length::new(self.depth)
     }
 }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -205,6 +205,18 @@ impl<T, U> Vector2D<T, U> {
     {
         self.x * other.y - self.y * other.x
     }
+
+    /// Return this vector's x component as a strongly typed `Length`.
+    #[inline]
+    pub fn get_x(self) -> Length<T, U> {
+        Length::new(self.x)
+    }
+
+    /// Return this vector's y component as a strongly typed `Length`.
+    #[inline]
+    pub fn get_y(self) -> Length<T, U> {
+        Length::new(self.y)
+    }
 }
 
 impl<T: Copy, U> Vector2D<T, U> {
@@ -387,6 +399,12 @@ impl<T: Float, U> Vector2D<T, U> {
     #[inline]
     pub fn length(self) -> T {
         self.square_length().sqrt()
+    }
+
+    /// Returns the vector length as a strongly typed `Length`.
+    #[inline]
+    pub fn get_length(self) -> Length<T, U> {
+        Length::new(self.length())
     }
 
     /// Returns the vector with length of one unit.
@@ -973,6 +991,24 @@ impl<T, U> Vector3D<T, U> {
     {
         self.x * other.x + self.y * other.y + self.z * other.z
     }
+
+    /// Return this vector's x component as a strongly typed `Length`.
+    #[inline]
+    pub fn get_x(self) -> Length<T, U> {
+        Length::new(self.x)
+    }
+
+    /// Return this vector's y component as a strongly typed `Length`.
+    #[inline]
+    pub fn get_y(self) -> Length<T, U> {
+        Length::new(self.y)
+    }
+
+    /// Return this vector's z component as a strongly typed `Length`.
+    #[inline]
+    pub fn get_z(self) -> Length<T, U> {
+        Length::new(self.z)
+    }
 }
 
 impl<T: Copy, U> Vector3D<T, U> {
@@ -1170,6 +1206,12 @@ impl<T: Float, U> Vector3D<T, U> {
     #[inline]
     pub fn length(self) -> T {
         self.square_length().sqrt()
+    }
+
+    /// Returns the vector length as a strongly typed `Length`.
+    #[inline]
+    pub fn get_length(self) -> Length<T, U> {
+        Length::new(self.length())
     }
 
     /// Returns the vector with length of one unit


### PR DESCRIPTION
Fixes #396 and #388.

This PR adds strongly typed `Length` getters with a simple naming scheme: anything prefixed with `get_` returns a `Length<T, U>`, while unprefixed methods returning a scalar and direct scalar member accesses yield `T` directly.

The main motivations behind this approach are:
 - Simple and nicer naming scheme than what we tried before. We used to have things like `v.x_typed()` and it was just too awkward to use so we removed it. I think that `get_` has less cognitive load and a long line of computation with lots of them is much easier to read than long lines with lots of `*_typed` suffixes.
 - It's easy to apply this naming scheme consistently even as we add new methods.
 - It doesn't get in the way of using euclid as a simple vector math crate without tagged units, which is pretty common.
 - Not a breaking change. Now is a good time to make breaking changes if they are worth the breakage, but not breaking downstream code unnecessarily is still a valuable thing.
