### PR TITLE
Add Intersection_or_zero

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.21.0"
+version = "0.21.1"
 authors = ["The Servo Project Developers"]
 edition = "2018"
 description = "Geometry primitives"

--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -190,6 +190,21 @@ where
         }
     }
 
+    /// Returns the intersection of this box and another one, or Box2D::zero()
+    /// if they don't intersect.
+    #[inline]
+    pub fn intersection_or_zero(&self, other: &Self) -> Self
+    where
+        T: Zero
+    {
+        let result = self.intersection_unchecked(other);
+        if result.is_empty() {
+            return Box2D::zero();
+        }
+
+        result
+    }
+
     #[inline]
     pub fn union(&self, other: &Self) -> Self {
         Box2D {

--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -193,13 +193,13 @@ where
     /// Returns the intersection of this box and another one, or Box2D::zero()
     /// if they don't intersect.
     #[inline]
-    pub fn intersection_or_zero(&self, other: &Self) -> Self
+    pub fn intersection_or_empty(&self, other: &Self) -> Self
     where
         T: Zero
     {
         let result = self.intersection_unchecked(other);
         if result.is_empty() {
-            return Box2D::zero();
+            return Box2D::empty();
         }
 
         result
@@ -380,6 +380,11 @@ where
     /// Constructor, setting all sides to zero.
     pub fn zero() -> Self {
         Box2D::new(Point2D::zero(), Point2D::zero())
+    }
+
+    /// Constructor, setting all sides to zero.
+    pub fn empty() -> Self {
+        Box2D::zero()
     }
 }
 

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -172,13 +172,13 @@ where
     /// Returns the intersection of this box and another one, or Box3D::zero()
     /// if they don't intersect.
     #[inline]
-    pub fn intersection_or_zero(&self, other: &Self) -> Self
+    pub fn intersection_or_empty(&self, other: &Self) -> Self
     where
         T: Zero
     {
         let result = self.intersection_unchecked(other);
         if result.is_empty() {
-            return Box3D::zero();
+            return Box3D::empty();
         }
 
         result
@@ -373,6 +373,11 @@ where
     /// Constructor, setting all sides to zero.
     pub fn zero() -> Self {
         Box3D::new(Point3D::zero(), Point3D::zero())
+    }
+
+    /// Constructor, setting all sides to zero.
+    pub fn empty() -> Self {
+        Box3D::zero()
     }
 }
 

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -169,6 +169,21 @@ where
         Box3D::new(intersection_min, intersection_max)
     }
 
+    /// Returns the intersection of this box and another one, or Box3D::zero()
+    /// if they don't intersect.
+    #[inline]
+    pub fn intersection_or_zero(&self, other: &Self) -> Self
+    where
+        T: Zero
+    {
+        let result = self.intersection_unchecked(other);
+        if result.is_empty() {
+            return Box3D::zero();
+        }
+
+        result
+    }
+
     /// Returns the smallest box containing both of the provided boxes.
     #[inline]
     pub fn union(&self, other: &Self) -> Self {

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -223,6 +223,18 @@ where
 
         Some(NonEmpty(box2d.to_rect()))
     }
+
+    /// Returns the intersection of this rectangle and another one, or Rect::zero()
+    /// if they don't intersect.
+    #[inline]
+    pub fn intersection_or_zero(&self, other: &Self) -> Self
+    where
+        T: Zero
+    {
+        self.to_box2d()
+            .intersection_or_zero(&other.to_box2d())
+            .to_rect()
+    }
 }
 
 impl<T, U> Rect<T, U>

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -112,6 +112,12 @@ where
         Rect::new(Point2D::origin(), Size2D::zero())
     }
 
+    /// Constructor, setting all sides to zero.
+    #[inline]
+    pub fn empty() -> Self {
+        Rect::zero()
+    }
+
     /// Creates a rect of the given size, at offset zero.
     #[inline]
     pub fn from_size(size: Size2D<T, U>) -> Self {
@@ -227,12 +233,12 @@ where
     /// Returns the intersection of this rectangle and another one, or Rect::zero()
     /// if they don't intersect.
     #[inline]
-    pub fn intersection_or_zero(&self, other: &Self) -> Self
+    pub fn intersection_or_empty(&self, other: &Self) -> Self
     where
         T: Zero
     {
         self.to_box2d()
-            .intersection_or_zero(&other.to_box2d())
+            .intersection_or_empty(&other.to_box2d())
             .to_rect()
     }
 }


### PR DESCRIPTION
Implemented for Rect, Box2D and Box3D, it returns the intersection of the two rects or boxes, or Rect/Box::zero() if they don't intersect.

This is useful in WebRender where we do a lot of `r1.intersection(r2).unwrap_or_else(Rect::zero)` which is inconvenient to write now that intersection returns `Option<NonEmpty<Self>>`.