### PR TITLE
Add back Floor, Ceil, and Round on integer types

### DIFF
--- a/src/num.rs
+++ b/src/num.rs
@@ -70,6 +70,29 @@ pub trait Ceil: Copy {
     fn ceil(self) -> Self;
 }
 
+macro_rules! num_int {
+    ($ty:ty) => {
+        impl Round for $ty {
+            #[inline]
+            fn round(self) -> $ty {
+                self
+            }
+        }
+        impl Floor for $ty {
+            #[inline]
+            fn floor(self) -> $ty {
+                self
+            }
+        }
+        impl Ceil for $ty {
+            #[inline]
+            fn ceil(self) -> $ty {
+                self
+            }
+        }
+    };
+}
+
 macro_rules! num_float {
     ($ty:ty) => {
         impl Round for $ty {
@@ -92,5 +115,14 @@ macro_rules! num_float {
         }
     };
 }
+
+num_int!(i16);
+num_int!(u16);
+num_int!(i32);
+num_int!(u32);
+num_int!(i64);
+num_int!(u64);
+num_int!(isize);
+num_int!(usize);
 num_float!(f32);
 num_float!(f64);


### PR DESCRIPTION
It can be helpful to treat floating point and integer types the same in a
generic context when you need to find an integral bounding box or the closest
integer coordinate.