### PR TITLE
Make the no-default-features build not fail

### DIFF
--- a/src/angle.rs
+++ b/src/angle.rs
@@ -12,7 +12,9 @@ use crate::trig::Trig;
 use core::cmp::{Eq, PartialEq};
 use core::hash::Hash;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, Sub, SubAssign};
-use num_traits::{Float, FloatConst, NumCast, One, Zero};
+use num_traits::{FloatConst, NumCast, One, Zero};
+#[cfg(feature = "std")]
+use num_traits::Float;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -99,6 +101,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T> Angle<T>
 where
     T: Float,

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -13,7 +13,7 @@ use core::cmp::{Eq, PartialEq};
 use core::hash::Hash;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, Sub, SubAssign};
 use num_traits::{FloatConst, NumCast, One, Zero};
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 use num_traits::Float;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -101,7 +101,7 @@ where
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 impl<T> Angle<T>
 where
     T: Float,

--- a/src/approxeq.rs
+++ b/src/approxeq.rs
@@ -32,7 +32,7 @@ macro_rules! approx_eq {
             }
             #[inline]
             fn approx_eq_eps(&self, other: &$ty, approx_epsilon: &$ty) -> bool {
-                num_traits::Float::abs(*self - *other) < *approx_epsilon
+                num_traits::float::FloatCore::abs(*self - *other) < *approx_epsilon
             }
         }
     };

--- a/src/num.rs
+++ b/src/num.rs
@@ -104,13 +104,13 @@ macro_rules! num_float {
         impl Floor for $ty {
             #[inline]
             fn floor(self) -> $ty {
-                num_traits::Float::floor(self)
+                num_traits::float::FloatCore::floor(self)
             }
         }
         impl Ceil for $ty {
             #[inline]
             fn ceil(self) -> $ty {
-                num_traits::Float::ceil(self)
+                num_traits::float::FloatCore::ceil(self)
             }
         }
     };

--- a/src/point.rs
+++ b/src/point.rs
@@ -23,7 +23,7 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 #[cfg(feature = "mint")]
 use mint;
 use num_traits::NumCast;
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 use num_traits::Float;
 #[cfg(feature = "serde")]
 use serde;
@@ -466,7 +466,7 @@ impl<T: Copy + Add<T, Output = T>, U> Point2D<T, U> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 impl<T: Float + Sub<T, Output = T>, U> Point2D<T, U> {
     #[inline]
     pub fn distance_to(self, other: Self) -> T {
@@ -1169,7 +1169,7 @@ impl<T: Copy + Add<T, Output = T>, U> Point3D<T, U> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 impl<T: Float + Sub<T, Output = T>, U> Point3D<T, U> {
     #[inline]
     pub fn distance_to(self, other: Self) -> T {

--- a/src/point.rs
+++ b/src/point.rs
@@ -22,7 +22,9 @@ use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 #[cfg(feature = "mint")]
 use mint;
-use num_traits::{Float, NumCast};
+use num_traits::NumCast;
+#[cfg(feature = "std")]
+use num_traits::Float;
 #[cfg(feature = "serde")]
 use serde;
 
@@ -464,6 +466,7 @@ impl<T: Copy + Add<T, Output = T>, U> Point2D<T, U> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<T: Float + Sub<T, Output = T>, U> Point2D<T, U> {
     #[inline]
     pub fn distance_to(self, other: Self) -> T {
@@ -1166,6 +1169,7 @@ impl<T: Copy + Add<T, Output = T>, U> Point3D<T, U> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<T: Float + Sub<T, Output = T>, U> Point3D<T, U> {
     #[inline]
     pub fn distance_to(self, other: Self) -> T {

--- a/src/rigid.rs
+++ b/src/rigid.rs
@@ -5,6 +5,7 @@
 use crate::approxeq::ApproxEq;
 use crate::trig::Trig;
 use crate::{Rotation3D, Transform3D, UnknownUnit, Vector3D};
+#[cfg(feature = "std")]
 use num_traits::Float;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -45,6 +46,7 @@ impl<T: Copy, Src, Dst> RigidTransform3D<T, Src, Dst> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<T: Float + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
     /// Construct an identity transform
     #[inline]
@@ -183,6 +185,7 @@ impl<T: Float + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<T: Float + ApproxEq<T>, Src, Dst> From<Rotation3D<T, Src, Dst>>
     for RigidTransform3D<T, Src, Dst>
 {
@@ -191,6 +194,7 @@ impl<T: Float + ApproxEq<T>, Src, Dst> From<Rotation3D<T, Src, Dst>>
     }
 }
 
+#[cfg(feature = "std")]
 impl<T: Float + ApproxEq<T>, Src, Dst> From<Vector3D<T, Dst>> for RigidTransform3D<T, Src, Dst> {
     fn from(t: Vector3D<T, Dst>) -> Self {
         Self::from_translation(t)

--- a/src/rigid.rs
+++ b/src/rigid.rs
@@ -5,7 +5,7 @@
 use crate::approxeq::ApproxEq;
 use crate::trig::Trig;
 use crate::{Rotation3D, Transform3D, UnknownUnit, Vector3D};
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 use num_traits::Float;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -46,7 +46,7 @@ impl<T: Copy, Src, Dst> RigidTransform3D<T, Src, Dst> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 impl<T: Float + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
     /// Construct an identity transform
     #[inline]
@@ -185,7 +185,7 @@ impl<T: Float + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 impl<T: Float + ApproxEq<T>, Src, Dst> From<Rotation3D<T, Src, Dst>>
     for RigidTransform3D<T, Src, Dst>
 {
@@ -194,7 +194,7 @@ impl<T: Float + ApproxEq<T>, Src, Dst> From<Rotation3D<T, Src, Dst>>
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 impl<T: Float + ApproxEq<T>, Src, Dst> From<Vector3D<T, Dst>> for RigidTransform3D<T, Src, Dst> {
     fn from(t: Vector3D<T, Dst>) -> Self {
         Self::from_translation(t)

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -16,7 +16,9 @@ use core::fmt;
 use core::hash::Hash;
 use core::marker::PhantomData;
 use core::ops::{Add, Mul, Neg, Sub};
-use num_traits::{Float, NumCast, One, Zero};
+use num_traits::{NumCast, One, Zero};
+#[cfg(feature = "std")]
+use num_traits::Float;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -166,6 +168,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T: Float, Src, Dst> Rotation2D<T, Src, Dst> {
     /// Creates a 3d rotation (around the z axis) from this 2d rotation.
     #[inline]
@@ -206,6 +209,7 @@ impl<T: Float, Src, Dst> Rotation2D<T, Src, Dst> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<T, Src, Dst> Rotation2D<T, Src, Dst>
 where
     T: Copy + Add<Output = T> + Sub<Output = T> + Mul<Output = T> + Zero + Trig,
@@ -400,6 +404,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T, Src, Dst> Rotation3D<T, Src, Dst>
 where
     T: Float,

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -17,7 +17,7 @@ use core::hash::Hash;
 use core::marker::PhantomData;
 use core::ops::{Add, Mul, Neg, Sub};
 use num_traits::{NumCast, One, Zero};
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 use num_traits::Float;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -168,7 +168,7 @@ where
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 impl<T: Float, Src, Dst> Rotation2D<T, Src, Dst> {
     /// Creates a 3d rotation (around the z axis) from this 2d rotation.
     #[inline]
@@ -209,7 +209,7 @@ impl<T: Float, Src, Dst> Rotation2D<T, Src, Dst> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 impl<T, Src, Dst> Rotation2D<T, Src, Dst>
 where
     T: Copy + Add<Output = T> + Sub<Output = T> + Mul<Output = T> + Zero + Trig,
@@ -404,7 +404,7 @@ where
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 impl<T, Src, Dst> Rotation3D<T, Src, Dst>
 where
     T: Float,

--- a/src/transform2d.rs
+++ b/src/transform2d.rs
@@ -409,6 +409,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 /// Methods for creating and combining rotation transformations
 impl<T, Src, Dst> Transform2D<T, Src, Dst>
 where

--- a/src/transform2d.rs
+++ b/src/transform2d.rs
@@ -409,7 +409,7 @@ where
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 /// Methods for creating and combining rotation transformations
 impl<T, Src, Dst> Transform2D<T, Src, Dst>
 where

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -409,7 +409,7 @@ where
     /// Create a 2d skew transform.
     ///
     /// See <https://drafts.csswg.org/css-transforms/#funcdef-skew>
-    #[cfg(feature = "std")]
+    #[cfg(any(feature = "std", feature = "libm"))]
     pub fn skew(alpha: Angle<T>, beta: Angle<T>) -> Self
     where
         T: Trig,
@@ -534,7 +534,7 @@ where
 }
 
 /// Methods for creating and combining rotation transformations
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 impl<T, Src, Dst> Transform3D<T, Src, Dst>
 where
     T: Copy + Add<Output = T> + Sub<Output = T> + Mul<Output = T> + Div<Output = T> + Zero + One + Trig,

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -409,6 +409,7 @@ where
     /// Create a 2d skew transform.
     ///
     /// See <https://drafts.csswg.org/css-transforms/#funcdef-skew>
+    #[cfg(feature = "std")]
     pub fn skew(alpha: Angle<T>, beta: Angle<T>) -> Self
     where
         T: Trig,
@@ -533,6 +534,7 @@ where
 }
 
 /// Methods for creating and combining rotation transformations
+#[cfg(feature = "std")]
 impl<T, Src, Dst> Transform3D<T, Src, Dst>
 where
     T: Copy + Add<Output = T> + Sub<Output = T> + Mul<Output = T> + Div<Output = T> + Zero + One + Trig,

--- a/src/trig.rs
+++ b/src/trig.rs
@@ -9,13 +9,13 @@
 
 /// Trait for basic trigonometry functions, so they can be used on generic numeric types
 pub trait Trig {
-    #[cfg(feature = "std")]
+    #[cfg(any(feature = "std", feature = "libm"))]
     fn sin(self) -> Self;
-    #[cfg(feature = "std")]
+    #[cfg(any(feature = "std", feature = "libm"))]
     fn cos(self) -> Self;
-    #[cfg(feature = "std")]
+    #[cfg(any(feature = "std", feature = "libm"))]
     fn tan(self) -> Self;
-    #[cfg(feature = "std")]
+    #[cfg(any(feature = "std", feature = "libm"))]
     fn fast_atan2(y: Self, x: Self) -> Self;
     fn degrees_to_radians(deg: Self) -> Self;
     fn radians_to_degrees(rad: Self) -> Self;
@@ -24,17 +24,17 @@ pub trait Trig {
 macro_rules! trig {
     ($ty:ident) => {
         impl Trig for $ty {
-            #[cfg(feature = "std")]
+            #[cfg(any(feature = "std", feature = "libm"))]
             #[inline]
             fn sin(self) -> $ty {
                 num_traits::Float::sin(self)
             }
-            #[cfg(feature = "std")]
+            #[cfg(any(feature = "std", feature = "libm"))]
             #[inline]
             fn cos(self) -> $ty {
                 num_traits::Float::cos(self)
             }
-            #[cfg(feature = "std")]
+            #[cfg(any(feature = "std", feature = "libm"))]
             #[inline]
             fn tan(self) -> $ty {
                 num_traits::Float::tan(self)
@@ -43,7 +43,7 @@ macro_rules! trig {
             /// A slightly faster approximation of `atan2`.
             ///
             /// Note that it does not deal with the case where both x and y are 0.
-            #[cfg(feature = "std")]
+            #[cfg(any(feature = "std", feature = "libm"))]
             #[inline]
             fn fast_atan2(y: $ty, x: $ty) -> $ty {
                 // This macro is used with f32 and f64 and clippy warns about the extra

--- a/src/trig.rs
+++ b/src/trig.rs
@@ -9,9 +9,13 @@
 
 /// Trait for basic trigonometry functions, so they can be used on generic numeric types
 pub trait Trig {
+    #[cfg(feature = "std")]
     fn sin(self) -> Self;
+    #[cfg(feature = "std")]
     fn cos(self) -> Self;
+    #[cfg(feature = "std")]
     fn tan(self) -> Self;
+    #[cfg(feature = "std")]
     fn fast_atan2(y: Self, x: Self) -> Self;
     fn degrees_to_radians(deg: Self) -> Self;
     fn radians_to_degrees(rad: Self) -> Self;
@@ -20,14 +24,17 @@ pub trait Trig {
 macro_rules! trig {
     ($ty:ident) => {
         impl Trig for $ty {
+            #[cfg(feature = "std")]
             #[inline]
             fn sin(self) -> $ty {
                 num_traits::Float::sin(self)
             }
+            #[cfg(feature = "std")]
             #[inline]
             fn cos(self) -> $ty {
                 num_traits::Float::cos(self)
             }
+            #[cfg(feature = "std")]
             #[inline]
             fn tan(self) -> $ty {
                 num_traits::Float::tan(self)
@@ -36,6 +43,7 @@ macro_rules! trig {
             /// A slightly faster approximation of `atan2`.
             ///
             /// Note that it does not deal with the case where both x and y are 0.
+            #[cfg(feature = "std")]
             #[inline]
             fn fast_atan2(y: $ty, x: $ty) -> $ty {
                 // This macro is used with f32 and f64 and clippy warns about the extra

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -27,7 +27,7 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 #[cfg(feature = "mint")]
 use mint;
 use num_traits::{NumCast, Signed};
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 use num_traits::Float;
 #[cfg(feature = "serde")]
 use serde;
@@ -144,7 +144,7 @@ impl<T, U> Vector2D<T, U> {
     }
 
     /// Constructor taking angle and length
-    #[cfg(feature = "std")]
+    #[cfg(any(feature = "std", feature = "libm"))]
     pub fn from_angle_and_length(angle: Angle<T>, length: T) -> Self
     where
         T: Trig + Mul<Output = T> + Copy,
@@ -336,7 +336,7 @@ impl<T: Copy, U> Vector2D<T, U> {
     /// is `+y` axis.
     ///
     /// The returned angle is between -PI and PI.
-    #[cfg(feature = "std")]
+    #[cfg(any(feature = "std", feature = "libm"))]
     pub fn angle_from_x_axis(self) -> Angle<T>
     where
         T: Trig,
@@ -378,7 +378,7 @@ where
     /// Returns the signed angle between this vector and another vector.
     ///
     /// The returned angle is between -PI and PI.
-    #[cfg(feature = "std")]
+    #[cfg(any(feature = "std", feature = "libm"))]
     pub fn angle_to(self, other: Self) -> Angle<T>
     where
         T: Sub<Output = T> + Trig,
@@ -387,7 +387,7 @@ where
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 impl<T: Float, U> Vector2D<T, U> {
     /// Returns the vector length.
     #[inline]
@@ -1158,7 +1158,7 @@ where
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(any(feature = "std", feature = "libm"))]
 impl<T: Float, U> Vector3D<T, U> {
     /// Returns the positive angle between this vector and another vector.
     ///

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -26,7 +26,9 @@ use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 #[cfg(feature = "mint")]
 use mint;
-use num_traits::{Float, NumCast, Signed};
+use num_traits::{NumCast, Signed};
+#[cfg(feature = "std")]
+use num_traits::Float;
 #[cfg(feature = "serde")]
 use serde;
 
@@ -142,6 +144,7 @@ impl<T, U> Vector2D<T, U> {
     }
 
     /// Constructor taking angle and length
+    #[cfg(feature = "std")]
     pub fn from_angle_and_length(angle: Angle<T>, length: T) -> Self
     where
         T: Trig + Mul<Output = T> + Copy,
@@ -333,6 +336,7 @@ impl<T: Copy, U> Vector2D<T, U> {
     /// is `+y` axis.
     ///
     /// The returned angle is between -PI and PI.
+    #[cfg(feature = "std")]
     pub fn angle_from_x_axis(self) -> Angle<T>
     where
         T: Trig,
@@ -374,6 +378,7 @@ where
     /// Returns the signed angle between this vector and another vector.
     ///
     /// The returned angle is between -PI and PI.
+    #[cfg(feature = "std")]
     pub fn angle_to(self, other: Self) -> Angle<T>
     where
         T: Sub<Output = T> + Trig,
@@ -382,6 +387,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T: Float, U> Vector2D<T, U> {
     /// Returns the vector length.
     #[inline]
@@ -1152,6 +1158,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<T: Float, U> Vector3D<T, U> {
     /// Returns the positive angle between this vector and another vector.
     ///


### PR DESCRIPTION
This pull request resolves #467 . This feature-gates functions that use standard library functionality behind `#[cfg(feature = "std")]`. Note that the test suite for `--no-default-features` fails under this pull request; I still consider this an improvement over the entire build failing.