### PR TITLE
Sum traits for Angle, Size, Length, Vector

### DIFF
--- a/src/angle.rs
+++ b/src/angle.rs
@@ -340,6 +340,6 @@ fn sum() {
     type A = Angle<f32>;
     let angles = [A::radians(1.0), A::radians(2.0), A::radians(3.0)];
     let sum = A::radians(6.0);
-    assert_eq!(angles.iter().copied().sum::<A>(), sum);
     assert_eq!(angles.iter().sum::<A>(), sum);
+    assert_eq!(angles.into_iter().sum::<A>(), sum);
 }

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -11,6 +11,7 @@ use crate::approxeq::ApproxEq;
 use crate::trig::Trig;
 use core::cmp::{Eq, PartialEq};
 use core::hash::Hash;
+use core::iter::Sum;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, Sub, SubAssign};
 use num_traits::{Float, FloatConst, NumCast, One, Zero};
 #[cfg(feature = "serde")]
@@ -174,9 +175,28 @@ where
 }
 
 impl<T: Add<T, Output = T>> Add for Angle<T> {
-    type Output = Angle<T>;
-    fn add(self, other: Angle<T>) -> Angle<T> {
-        Angle::radians(self.radians + other.radians)
+    type Output = Self;
+    fn add(self, other: Self) -> Self {
+        Self::radians(self.radians + other.radians)
+    }
+}
+
+impl<T: Copy + Add<T, Output = T>> Add<&Self> for Angle<T> {
+    type Output = Self;
+    fn add(self, other: &Self) -> Self {
+        Self::radians(self.radians + other.radians)
+    }
+}
+
+impl<T: Add + Zero> Sum for Angle<T> {
+    fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), Add::add)
+    }
+}
+
+impl<'a, T: 'a + Add + Copy + Zero> Sum<&'a Self> for Angle<T> {
+    fn sum<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), Add::add)
     }
 }
 
@@ -313,4 +333,13 @@ fn lerp() {
     assert!(a
         .lerp(b + A::two_pi() * 5.0, 0.75)
         .approx_eq(&Angle::radians(1.75)));
+}
+
+#[test]
+fn sum() {
+    type A = Angle<f32>;
+    let angles = [A::radians(1.0), A::radians(2.0), A::radians(3.0)];
+    let sum = A::radians(6.0);
+    assert_eq!(angles.iter().copied().sum::<A>(), sum);
+    assert_eq!(angles.iter().sum::<A>(), sum);
 }

--- a/src/length.rs
+++ b/src/length.rs
@@ -17,6 +17,7 @@ use crate::num::One;
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{Hash, Hasher};
+use core::iter::Sum;
 use core::marker::PhantomData;
 use core::ops::{Add, Div, Mul, Neg, Sub};
 use core::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
@@ -172,6 +173,29 @@ impl<T: Add, U> Add for Length<T, U> {
 
     fn add(self, other: Self) -> Self::Output {
         Length::new(self.0 + other.0)
+    }
+}
+
+// length + &length
+impl<T: Add + Copy, U> Add<&Self> for Length<T, U> {
+    type Output = Length<T::Output, U>;
+
+    fn add(self, other: &Self) -> Self::Output {
+        Length::new(self.0 + other.0)
+    }
+}
+
+// length_iter.copied().sum()
+impl<T: Add<Output = T> + Zero, U> Sum for Length<T, U> {
+    fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), Add::add)
+    }
+}
+
+// length_iter.sum()
+impl<'a, T: 'a + Add<Output = T> + Copy + Zero, U: 'a> Sum<&'a Self> for Length<T, U> {
+    fn sum<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), Add::add)
     }
 }
 
@@ -372,9 +396,17 @@ mod tests {
         let length1: Length<u8, Mm> = Length::new(250);
         let length2: Length<u8, Mm> = Length::new(5);
 
-        let result = length1 + length2;
+        assert_eq!((length1 + length2).get(), 255);
+        assert_eq!((length1 + &length2).get(), 255);
+    }
 
-        assert_eq!(result.get(), 255);
+    #[test]
+    fn test_sum() {
+        type L = Length<f32, Mm>;
+        let lengths = [L::new(1.0), L::new(2.0), L::new(3.0)];
+
+        assert_eq!(lengths.iter().copied().sum::<L>(), L::new(6.0));
+        assert_eq!(lengths.iter().sum::<L>(), L::new(6.0));
     }
 
     #[test]

--- a/src/length.rs
+++ b/src/length.rs
@@ -405,8 +405,8 @@ mod tests {
         type L = Length<f32, Mm>;
         let lengths = [L::new(1.0), L::new(2.0), L::new(3.0)];
 
-        assert_eq!(lengths.iter().copied().sum::<L>(), L::new(6.0));
         assert_eq!(lengths.iter().sum::<L>(), L::new(6.0));
+        assert_eq!(lengths.into_iter().sum::<L>(), L::new(6.0));
     }
 
     #[test]

--- a/src/size.rs
+++ b/src/size.rs
@@ -762,7 +762,7 @@ mod size2d {
             ];
             let sum = Size2D::new(3.0, 6.0);
             assert_eq!(sizes.iter().sum::<Size2D<_>>(), sum);
-            assert_eq!(sizes.iter().copied().sum::<Size2D<_>>(), sum);
+            assert_eq!(sizes.into_iter().sum::<Size2D<_>>(), sum);
         }
 
         #[test]
@@ -1624,7 +1624,7 @@ mod size3d {
             ];
             let sum = Size3D::new(3.0, 6.0, 9.0);
             assert_eq!(sizes.iter().sum::<Size3D<_>>(), sum);
-            assert_eq!(sizes.iter().copied().sum::<Size3D<_>>(), sum);
+            assert_eq!(sizes.into_iter().sum::<Size3D<_>>(), sum);
         }
 
         #[test]

--- a/src/size.rs
+++ b/src/size.rs
@@ -20,6 +20,7 @@ use mint;
 use core::cmp::{Eq, PartialEq};
 use core::fmt;
 use core::hash::Hash;
+use core::iter::Sum;
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use num_traits::{NumCast, Signed};
@@ -498,6 +499,25 @@ impl<T: Add, U> Add for Size2D<T, U> {
     }
 }
 
+impl<T: Copy + Add<T, Output = T>, U> Add<&Self> for Size2D<T, U> {
+    type Output = Self;
+    fn add(self, other: &Self) -> Self {
+        Size2D::new(self.width + other.width, self.height + other.height)
+    }
+}
+
+impl<T: Add<Output = T> + Zero, U> Sum for Size2D<T, U> {
+    fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), Add::add)
+    }
+}
+
+impl<'a, T: 'a + Add<Output = T> + Copy + Zero, U: 'a> Sum<&'a Self> for Size2D<T, U> {
+    fn sum<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), Add::add)
+    }
+}
+
 impl<T: AddAssign, U> AddAssign for Size2D<T, U> {
     #[inline]
     fn add_assign(&mut self, other: Self) {
@@ -696,18 +716,22 @@ mod size2d {
             let s1 = Size2D::new(1.0, 2.0);
             let s2 = Size2D::new(3.0, 4.0);
             assert_eq!(s1 + s2, Size2D::new(4.0, 6.0));
+            assert_eq!(s1 + &s2, Size2D::new(4.0, 6.0));
 
             let s1 = Size2D::new(1.0, 2.0);
             let s2 = Size2D::new(0.0, 0.0);
             assert_eq!(s1 + s2, Size2D::new(1.0, 2.0));
+            assert_eq!(s1 + &s2, Size2D::new(1.0, 2.0));
 
             let s1 = Size2D::new(1.0, 2.0);
             let s2 = Size2D::new(-3.0, -4.0);
             assert_eq!(s1 + s2, Size2D::new(-2.0, -2.0));
+            assert_eq!(s1 + &s2, Size2D::new(-2.0, -2.0));
 
             let s1 = Size2D::new(0.0, 0.0);
             let s2 = Size2D::new(0.0, 0.0);
             assert_eq!(s1 + s2, Size2D::new(0.0, 0.0));
+            assert_eq!(s1 + &s2, Size2D::new(0.0, 0.0));
         }
 
         #[test]
@@ -727,6 +751,18 @@ mod size2d {
             let mut s = Size2D::new(0.0, 0.0);
             s += Size2D::new(0.0, 0.0);
             assert_eq!(s, Size2D::new(0.0, 0.0));
+        }
+
+        #[test]
+        pub fn test_sum() {
+            let sizes = [
+                Size2D::new(0.0, 1.0),
+                Size2D::new(1.0, 2.0),
+                Size2D::new(2.0, 3.0)
+            ];
+            let sum = Size2D::new(3.0, 6.0);
+            assert_eq!(sizes.iter().sum::<Size2D<_>>(), sum);
+            assert_eq!(sizes.iter().copied().sum::<Size2D<_>>(), sum);
         }
 
         #[test]
@@ -1339,6 +1375,29 @@ impl<T: Add, U> Add for Size3D<T, U> {
     }
 }
 
+impl<T: Copy + Add<T, Output = T>, U> Add<&Self> for Size3D<T, U> {
+    type Output = Self;
+    fn add(self, other: &Self) -> Self {
+        Size3D::new(
+            self.width + other.width,
+            self.height + other.height,
+            self.depth + other.depth,
+        )
+    }
+}
+
+impl<T: Add<Output = T> + Zero, U> Sum for Size3D<T, U> {
+    fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), Add::add)
+    }
+}
+
+impl<'a, T: 'a + Add<Output = T> + Copy + Zero, U: 'a> Sum<&'a Self> for Size3D<T, U> {
+    fn sum<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), Add::add)
+    }
+}
+
 impl<T: AddAssign, U> AddAssign for Size3D<T, U> {
     #[inline]
     fn add_assign(&mut self, other: Self) {
@@ -1538,18 +1597,34 @@ mod size3d {
             let s1 = Size3D::new(1.0, 2.0, 3.0);
             let s2 = Size3D::new(4.0, 5.0, 6.0);
             assert_eq!(s1 + s2, Size3D::new(5.0, 7.0, 9.0));
+            assert_eq!(s1 + &s2, Size3D::new(5.0, 7.0, 9.0));
 
             let s1 = Size3D::new(1.0, 2.0, 3.0);
             let s2 = Size3D::new(0.0, 0.0, 0.0);
             assert_eq!(s1 + s2, Size3D::new(1.0, 2.0, 3.0));
+            assert_eq!(s1 + &s2, Size3D::new(1.0, 2.0, 3.0));
 
             let s1 = Size3D::new(1.0, 2.0, 3.0);
             let s2 = Size3D::new(-4.0, -5.0, -6.0);
             assert_eq!(s1 + s2, Size3D::new(-3.0, -3.0, -3.0));
+            assert_eq!(s1 + &s2, Size3D::new(-3.0, -3.0, -3.0));
 
             let s1 = Size3D::new(0.0, 0.0, 0.0);
             let s2 = Size3D::new(0.0, 0.0, 0.0);
             assert_eq!(s1 + s2, Size3D::new(0.0, 0.0, 0.0));
+            assert_eq!(s1 + &s2, Size3D::new(0.0, 0.0, 0.0));
+        }
+
+        #[test]
+        pub fn test_sum() {
+            let sizes = [
+                Size3D::new(0.0, 1.0, 2.0),
+                Size3D::new(1.0, 2.0, 3.0),
+                Size3D::new(2.0, 3.0, 4.0)
+            ];
+            let sum = Size3D::new(3.0, 6.0, 9.0);
+            assert_eq!(sizes.iter().sum::<Size3D<_>>(), sum);
+            assert_eq!(sizes.iter().copied().sum::<Size3D<_>>(), sum);
         }
 
         #[test]

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -22,6 +22,7 @@ use crate::Angle;
 use core::cmp::{Eq, PartialEq};
 use core::fmt;
 use core::hash::Hash;
+use core::iter::Sum;
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 #[cfg(feature = "mint")]
@@ -646,6 +647,27 @@ impl<T: Add, U> Add for Vector2D<T, U> {
     #[inline]
     fn add(self, other: Self) -> Self::Output {
         Vector2D::new(self.x + other.x, self.y + other.y)
+    }
+}
+
+impl<T: Add + Copy, U> Add<&Self> for Vector2D<T, U> {
+    type Output = Vector2D<T::Output, U>;
+
+    #[inline]
+    fn add(self, other: &Self) -> Self::Output {
+        Vector2D::new(self.x + other.x, self.y + other.y)
+    }
+}
+
+impl<T: Add<Output = T> + Zero, U> Sum for Vector2D<T, U> {
+    fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), Add::add)
+    }
+}
+
+impl<'a, T: 'a + Add<Output = T> + Copy + Zero, U: 'a> Sum<&'a Self> for Vector2D<T, U> {
+    fn sum<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), Add::add)
     }
 }
 
@@ -1448,6 +1470,27 @@ impl<T: Add, U> Add for Vector3D<T, U> {
     }
 }
 
+impl<'a, T: 'a + Add + Copy, U: 'a> Add<&Self> for Vector3D<T, U> {
+    type Output = Vector3D<T::Output, U>;
+
+    #[inline]
+    fn add(self, other: &Self) -> Self::Output {
+        vec3(self.x + other.x, self.y + other.y, self.z + other.z)
+    }
+}
+
+impl<T: Add<Output = T> + Zero, U> Sum for Vector3D<T, U> {
+    fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), Add::add)
+    }
+}
+
+impl<'a, T: 'a + Add<Output = T> + Copy + Zero, U: 'a> Sum<&'a Self> for Vector3D<T, U> {
+    fn sum<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), Add::add)
+    }
+}
+
 impl<T: Copy + Add<T, Output = T>, U> AddAssign for Vector3D<T, U> {
     #[inline]
     fn add_assign(&mut self, other: Self) {
@@ -2043,9 +2086,20 @@ mod vector2d {
         let p1 = Vector2DMm::new(1.0, 2.0);
         let p2 = Vector2DMm::new(3.0, 4.0);
 
-        let result = p1 + p2;
+        assert_eq!(p1 + p2, vec2(4.0, 6.0));
+        assert_eq!(p1 + &p2, vec2(4.0, 6.0));
+    }
 
-        assert_eq!(result, vec2(4.0, 6.0));
+    #[test]
+    pub fn test_sum() {
+        let vecs = [
+            Vector2DMm::new(1.0, 2.0),
+            Vector2DMm::new(3.0, 4.0),
+            Vector2DMm::new(5.0, 6.0)
+        ];
+        let sum = Vector2DMm::new(9.0, 12.0);
+        assert_eq!(vecs.iter().copied().sum::<Vector2DMm<_>>(), sum);
+        assert_eq!(vecs.iter().sum::<Vector2DMm<_>>(), sum);
     }
 
     #[test]
@@ -2092,6 +2146,27 @@ mod vector3d {
     use mint;
 
     type Vec3 = default::Vector3D<f32>;
+
+    #[test]
+    pub fn test_add() {
+        let p1 = Vec3::new(1.0, 2.0, 3.0);
+        let p2 = Vec3::new(4.0, 5.0, 6.0);
+
+        assert_eq!(p1 + p2, vec3(5.0, 7.0, 9.0));
+        assert_eq!(p1 + &p2, vec3(5.0, 7.0, 9.0));
+    }
+
+    #[test]
+    pub fn test_sum() {
+        let vecs = [
+            Vec3::new(1.0, 2.0, 3.0),
+            Vec3::new(4.0, 5.0, 6.0),
+            Vec3::new(7.0, 8.0, 9.0)
+        ];
+        let sum = Vec3::new(12.0, 15.0, 18.0);
+        assert_eq!(vecs.iter().copied().sum::<Vec3>(), sum);
+        assert_eq!(vecs.iter().sum::<Vec3>(), sum);
+    }
 
     #[test]
     pub fn test_dot() {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -2098,8 +2098,8 @@ mod vector2d {
             Vector2DMm::new(5.0, 6.0)
         ];
         let sum = Vector2DMm::new(9.0, 12.0);
-        assert_eq!(vecs.iter().copied().sum::<Vector2DMm<_>>(), sum);
         assert_eq!(vecs.iter().sum::<Vector2DMm<_>>(), sum);
+        assert_eq!(vecs.into_iter().sum::<Vector2DMm<_>>(), sum);
     }
 
     #[test]
@@ -2164,8 +2164,8 @@ mod vector3d {
             Vec3::new(7.0, 8.0, 9.0)
         ];
         let sum = Vec3::new(12.0, 15.0, 18.0);
-        assert_eq!(vecs.iter().copied().sum::<Vec3>(), sum);
         assert_eq!(vecs.iter().sum::<Vec3>(), sum);
+        assert_eq!(vecs.into_iter().sum::<Vec3>(), sum);
     }
 
     #[test]


### PR DESCRIPTION
Addresses #469 with `Add<&Self>`, `Sum<Self>`, and `Sum<&Self>` traits, and filled in a handful of missing tests.

Note that there's a small inconsistency now with operations other than Add not supporting `other = &Self` for these types, but I think if there's concern about that it can be addressed in a follow-on PR.

My only other question on this (as a Rust noob) is just that the sum traits are expressed generically and thus pretty repetitive across all the supported types. I see some instances in the standard library where things like this are [handled across a dozen types at once using a macro](https://doc.rust-lang.org/1.49.0/src/core/iter/traits/accum.rs.html#41). That feels like it may not be worth it for a type or two at a time (eg, handling Vector2D and Vector3D with the same impl), but I was curious if such a thing could be usable for larger blocks of shared functionality, and whether or not that would even be desirable.