### PR TITLE
Add missing methods in Box2D/3D

### DIFF
--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -602,6 +602,15 @@ where
     }
 }
 
+impl<T: Default, U> Default for Box2D<T, U> {
+    fn default() -> Self {
+        Box2D {
+            min: Default::default(),
+            max: Default::default(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::default::Box2D;

--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -114,6 +114,15 @@ impl<T, U> Box2D<T, U> {
             max: point2(size.width, size.height),
         }
     }
+
+    /// Creates a Box2D of the given size, at offset zero.
+    #[inline]
+    pub fn from_size(size: Size2D<T, U>) -> Self where T: Zero {
+        Box2D {
+            min: Point2D::zero(),
+            max: point2(size.width, size.height),
+        }
+    }
 }
 
 impl<T, U> Box2D<T, U>
@@ -295,14 +304,6 @@ impl<T, U> Box2D<T, U>
 where
     T: Copy + Zero + PartialOrd,
 {
-    /// Creates a Box2D of the given size, at offset zero.
-    #[inline]
-    pub fn from_size(size: Size2D<T, U>) -> Self {
-        let zero = Point2D::zero();
-        let point = size.to_vector().to_point();
-        Box2D::from_points(&[zero, point])
-    }
-
     /// Returns the smallest box containing all of the provided points.
     pub fn from_points<I>(points: I) -> Self
     where

--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -105,6 +105,15 @@ impl<T, U> Box2D<T, U> {
     pub const fn new(min: Point2D<T, U>, max: Point2D<T, U>) -> Self {
         Box2D { min, max }
     }
+
+    /// Constructor.
+    #[inline]
+    pub fn from_origin_and_size(origin: Point2D<T, U>, size: Size2D<T, U>) -> Self {
+        Box2D {
+            min: origin,
+            max: point2(size.width, size.height),
+        }
+    }
 }
 
 impl<T, U> Box2D<T, U>

--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -25,7 +25,7 @@ use core::borrow::Borrow;
 use core::cmp::PartialOrd;
 use core::fmt;
 use core::hash::{Hash, Hasher};
-use core::ops::{Add, Div, DivAssign, Mul, MulAssign, Sub};
+use core::ops::{Add, Div, DivAssign, Mul, MulAssign, Sub, Range};
 
 /// A 2d axis aligned rectangle represented by its minimum and maximum coordinates.
 ///
@@ -453,6 +453,16 @@ impl<T, U> Box2D<T, U>
 where
     T: Copy,
 {
+    #[inline]
+    pub fn x_range(&self) -> Range<T> {
+        self.min.x..self.max.x
+    }
+
+    #[inline]
+    pub fn y_range(&self) -> Range<T> {
+        self.min.y..self.max.y
+    }
+
     /// Drop the units, preserving only the numeric value.
     #[inline]
     pub fn to_untyped(&self) -> Box2D<T, UnknownUnit> {

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -75,6 +75,15 @@ impl<T, U> Box3D<T, U> {
     pub const fn new(min: Point3D<T, U>, max: Point3D<T, U>) -> Self {
         Box3D { min, max }
     }
+
+    /// Creates a Box3D of the given size, at offset zero.
+    #[inline]
+    pub fn from_size(size: Size3D<T, U>) -> Self where T: Zero {
+        Box3D {
+            min: Point3D::zero(),
+            max: point3(size.width, size.height, size.depth),
+        }
+    }
 }
 
 impl<T, U> Box3D<T, U>
@@ -255,14 +264,6 @@ impl<T, U> Box3D<T, U>
 where
     T: Copy + Zero + PartialOrd,
 {
-    /// Creates a Box3D of the given size, at offset zero.
-    #[inline]
-    pub fn from_size(size: Size3D<T, U>) -> Self {
-        let zero = Point3D::zero();
-        let point = size.to_vector().to_point();
-        Box3D::from_points(&[zero, point])
-    }
-
     /// Returns the smallest box containing all of the provided points.
     pub fn from_points<I>(points: I) -> Self
     where

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -605,6 +605,15 @@ where
     }
 }
 
+impl<T: Default, U> Default for Box3D<T, U> {
+    fn default() -> Self {
+        Box3D {
+            min: Default::default(),
+            max: Default::default(),
+        }
+    }
+}
+
 /// Shorthand for `Box3D::new(Point3D::new(x1, y1, z1), Point3D::new(x2, y2, z2))`.
 pub fn box3d<T: Copy, U>(
     min_x: T,

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -23,7 +23,7 @@ use core::borrow::Borrow;
 use core::cmp::PartialOrd;
 use core::fmt;
 use core::hash::{Hash, Hasher};
-use core::ops::{Add, Div, DivAssign, Mul, MulAssign, Sub};
+use core::ops::{Add, Div, DivAssign, Mul, MulAssign, Sub, Range};
 
 /// An axis aligned 3D box represented by its minimum and maximum coordinates.
 #[repr(C)]
@@ -439,6 +439,21 @@ impl<T, U> Box3D<T, U>
 where
     T: Copy,
 {
+    #[inline]
+    pub fn x_range(&self) -> Range<T> {
+        self.min.x..self.max.x
+    }
+
+    #[inline]
+    pub fn y_range(&self) -> Range<T> {
+        self.min.y..self.max.y
+    }
+
+    #[inline]
+    pub fn z_range(&self) -> Range<T> {
+        self.min.z..self.max.z
+    }
+
     /// Drop the units, preserving only the numeric value.
     #[inline]
     pub fn to_untyped(&self) -> Box3D<T, UnknownUnit> {


### PR DESCRIPTION
I'd like to transition webrender's code from using Rect to using Box2D which is more appropriate for the kind of operations we do. This PR adds some missing methods present in Rect but not Box2D to ease the transition.