### PR TITLE
Make Box::union behave like Rect::union

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.22.4"
+version = "0.22.5"
 authors = ["The Servo Project Developers"]
 edition = "2018"
 description = "Geometry primitives"

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -348,5 +348,4 @@ fn sum() {
     let angles = [A::radians(1.0), A::radians(2.0), A::radians(3.0)];
     let sum = A::radians(6.0);
     assert_eq!(angles.iter().sum::<A>(), sum);
-    assert_eq!(angles.into_iter().sum::<A>(), sum);
 }

--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -213,8 +213,18 @@ where
         }
     }
 
+    /// Computes the union of two boxes.
+    ///
+    /// If either of the boxes is empty, the other one is returned.
     #[inline]
     pub fn union(&self, other: &Self) -> Self {
+        if other.is_empty() {
+            return *self;
+        }
+        if self.is_empty() {
+            return *other;
+        }
+
         Box2D {
             min: point2(min(self.min.x, other.min.x), min(self.min.y, other.min.y)),
             max: point2(max(self.max.x, other.max.x), max(self.max.y, other.max.y)),

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -183,9 +183,18 @@ where
         Box3D::new(intersection_min, intersection_max)
     }
 
-    /// Returns the smallest box containing both of the provided boxes.
+    /// Computes the union of two boxes.
+    ///
+    /// If either of the boxes is empty, the other one is returned.
     #[inline]
     pub fn union(&self, other: &Self) -> Self {
+        if other.is_empty() {
+            return *self;
+        }
+        if self.is_empty() {
+            return *other;
+        }
+
         Box3D::new(
             Point3D::new(
                 min(self.min.x, other.min.x),

--- a/src/length.rs
+++ b/src/length.rs
@@ -406,7 +406,6 @@ mod tests {
         let lengths = [L::new(1.0), L::new(2.0), L::new(3.0)];
 
         assert_eq!(lengths.iter().sum::<L>(), L::new(6.0));
-        assert_eq!(lengths.into_iter().sum::<L>(), L::new(6.0));
     }
 
     #[test]

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -368,13 +368,6 @@ where
 {
     #[inline]
     pub fn union(&self, other: &Self) -> Self {
-        if self.size == Zero::zero() {
-            return *other;
-        }
-        if other.size == Zero::zero() {
-            return *self;
-        }
-
         self.to_box2d().union(&other.to_box2d()).to_rect()
     }
 }

--- a/src/size.rs
+++ b/src/size.rs
@@ -805,7 +805,6 @@ mod size2d {
             ];
             let sum = Size2D::new(3.0, 6.0);
             assert_eq!(sizes.iter().sum::<Size2D<_>>(), sum);
-            assert_eq!(sizes.into_iter().sum::<Size2D<_>>(), sum);
         }
 
         #[test]
@@ -1695,7 +1694,6 @@ mod size3d {
             ];
             let sum = Size3D::new(3.0, 6.0, 9.0);
             assert_eq!(sizes.iter().sum::<Size3D<_>>(), sum);
-            assert_eq!(sizes.into_iter().sum::<Size3D<_>>(), sum);
         }
 
         #[test]

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -2207,7 +2207,6 @@ mod vector2d {
         ];
         let sum = Vector2DMm::new(9.0, 12.0);
         assert_eq!(vecs.iter().sum::<Vector2DMm<_>>(), sum);
-        assert_eq!(vecs.into_iter().sum::<Vector2DMm<_>>(), sum);
     }
 
     #[test]
@@ -2273,7 +2272,6 @@ mod vector3d {
         ];
         let sum = Vec3::new(12.0, 15.0, 18.0);
         assert_eq!(vecs.iter().sum::<Vec3>(), sum);
-        assert_eq!(vecs.into_iter().sum::<Vec3>(), sum);
     }
 
     #[test]


### PR DESCRIPTION
There's also a commit that removes ambiguous use of array into_iter to address a warning and behave differently in the next rust eddition.