### PR TITLE
Switch to num_traits::real::Real instead of num_traits::Float where possible.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "euclid"
-version = "0.22.6"
+version = "0.22.7"
 authors = ["The Servo Project Developers"]
 edition = "2018"
 description = "Geometry primitives"

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -13,6 +13,7 @@ use core::cmp::{Eq, PartialEq};
 use core::hash::Hash;
 use core::iter::Sum;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, Sub, SubAssign};
+use num_traits::real::Real;
 use num_traits::{Float, FloatConst, NumCast, One, Zero};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -105,15 +106,20 @@ impl<T> Angle<T>
 where
     T: Float,
 {
-    /// Returns (sin(self), cos(self)).
-    pub fn sin_cos(self) -> (T, T) {
-        self.radians.sin_cos()
-    }
-
     /// Returns true if the angle is a finite number.
     #[inline]
     pub fn is_finite(self) -> bool {
         self.radians.is_finite()
+    }
+}
+
+impl<T> Angle<T>
+where
+    T: Real,
+{
+    /// Returns (sin(self), cos(self)).
+    pub fn sin_cos(self) -> (T, T) {
+        self.radians.sin_cos()
     }
 }
 

--- a/src/point.rs
+++ b/src/point.rs
@@ -22,6 +22,7 @@ use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 #[cfg(feature = "mint")]
 use mint;
+use num_traits::real::Real;
 use num_traits::{Float, NumCast};
 #[cfg(feature = "serde")]
 use serde;
@@ -500,7 +501,7 @@ impl<T: Copy + Add<T, Output = T>, U> Point2D<T, U> {
     }
 }
 
-impl<T: Float + Sub<T, Output = T>, U> Point2D<T, U> {
+impl<T: Real + Sub<T, Output = T>, U> Point2D<T, U> {
     #[inline]
     pub fn distance_to(self, other: Self) -> T {
         (self - other).length()
@@ -1224,7 +1225,7 @@ impl<T: Copy + Add<T, Output = T>, U> Point3D<T, U> {
     }
 }
 
-impl<T: Float + Sub<T, Output = T>, U> Point3D<T, U> {
+impl<T: Real + Sub<T, Output = T>, U> Point3D<T, U> {
     #[inline]
     pub fn distance_to(self, other: Self) -> T {
         (self - other).length()

--- a/src/rigid.rs
+++ b/src/rigid.rs
@@ -5,7 +5,7 @@
 use crate::approxeq::ApproxEq;
 use crate::trig::Trig;
 use crate::{Rotation3D, Transform3D, UnknownUnit, Vector3D};
-use num_traits::Float;
+use num_traits::real::Real;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -45,7 +45,7 @@ impl<T: Copy, Src, Dst> RigidTransform3D<T, Src, Dst> {
     }
 }
 
-impl<T: Float + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
+impl<T: Real + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
     /// Construct an identity transform
     #[inline]
     pub fn identity() -> Self {
@@ -183,7 +183,7 @@ impl<T: Float + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
     }
 }
 
-impl<T: Float + ApproxEq<T>, Src, Dst> From<Rotation3D<T, Src, Dst>>
+impl<T: Real + ApproxEq<T>, Src, Dst> From<Rotation3D<T, Src, Dst>>
     for RigidTransform3D<T, Src, Dst>
 {
     fn from(rot: Rotation3D<T, Src, Dst>) -> Self {
@@ -191,7 +191,7 @@ impl<T: Float + ApproxEq<T>, Src, Dst> From<Rotation3D<T, Src, Dst>>
     }
 }
 
-impl<T: Float + ApproxEq<T>, Src, Dst> From<Vector3D<T, Dst>> for RigidTransform3D<T, Src, Dst> {
+impl<T: Real + ApproxEq<T>, Src, Dst> From<Vector3D<T, Dst>> for RigidTransform3D<T, Src, Dst> {
     fn from(t: Vector3D<T, Dst>) -> Self {
         Self::from_translation(t)
     }

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -16,7 +16,8 @@ use core::fmt;
 use core::hash::Hash;
 use core::marker::PhantomData;
 use core::ops::{Add, Mul, Neg, Sub};
-use num_traits::{Float, NumCast, One, Zero};
+use num_traits::real::Real;
+use num_traits::{NumCast, One, Zero};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -166,7 +167,7 @@ where
     }
 }
 
-impl<T: Float, Src, Dst> Rotation2D<T, Src, Dst> {
+impl<T: Real, Src, Dst> Rotation2D<T, Src, Dst> {
     /// Creates a 3d rotation (around the z axis) from this 2d rotation.
     #[inline]
     pub fn to_3d(&self) -> Rotation3D<T, Src, Dst> {
@@ -193,7 +194,7 @@ impl<T: Float, Src, Dst> Rotation2D<T, Src, Dst> {
     /// The input point must be use the unit Src, and the returned point has the unit Dst.
     #[inline]
     pub fn transform_point(&self, point: Point2D<T, Src>) -> Point2D<T, Dst> {
-        let (sin, cos) = Float::sin_cos(self.angle);
+        let (sin, cos) = Real::sin_cos(self.angle);
         point2(point.x * cos - point.y * sin, point.y * cos + point.x * sin)
     }
 
@@ -402,7 +403,7 @@ where
 
 impl<T, Src, Dst> Rotation3D<T, Src, Dst>
 where
-    T: Float,
+    T: Real,
 {
     /// Creates a rotation around from a quaternion representation and normalizes it.
     ///
@@ -456,9 +457,9 @@ where
     pub fn euler(roll: Angle<T>, pitch: Angle<T>, yaw: Angle<T>) -> Self {
         let half = T::one() / (T::one() + T::one());
 
-        let (sy, cy) = Float::sin_cos(half * yaw.get());
-        let (sp, cp) = Float::sin_cos(half * pitch.get());
-        let (sr, cr) = Float::sin_cos(half * roll.get());
+        let (sy, cy) = Real::sin_cos(half * yaw.get());
+        let (sp, cp) = Real::sin_cos(half * pitch.get());
+        let (sr, cr) = Real::sin_cos(half * roll.get());
 
         Self::quaternion(
             cy * sr * cp - sy * cr * sp,
@@ -537,14 +538,14 @@ where
         }
 
         // For robustness, stay within the domain of acos.
-        dot = Float::min(dot, one);
+        dot = Real::min(dot, one);
 
         // Angle between r1 and the result.
-        let theta = Float::acos(dot) * t;
+        let theta = Real::acos(dot) * t;
 
         // r1 and r3 form an orthonormal basis.
         let r3 = r2.sub(r1.mul(dot)).normalize();
-        let (sin, cos) = Float::sin_cos(theta);
+        let (sin, cos) = Real::sin_cos(theta);
         r1.mul(cos).add(r3.mul(sin))
     }
 

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -27,6 +27,7 @@ use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 #[cfg(feature = "mint")]
 use mint;
+use num_traits::real::Real;
 use num_traits::{Float, NumCast, Signed};
 #[cfg(feature = "serde")]
 use serde;
@@ -440,6 +441,27 @@ where
 }
 
 impl<T: Float, U> Vector2D<T, U> {
+    /// Return the normalized vector even if the length is larger than the max value of Float.
+    #[inline]
+    #[must_use]
+    pub fn robust_normalize(self) -> Self {
+        let length = self.length();
+        if length.is_infinite() {
+            let scaled = self / T::max_value();
+            scaled / scaled.length()
+        } else {
+            self / length
+        }
+    }
+
+    /// Returns true if all members are finite.
+    #[inline]
+    pub fn is_finite(self) -> bool {
+        self.x.is_finite() && self.y.is_finite()
+    }
+}
+
+impl<T: Real, U> Vector2D<T, U> {
     /// Returns the vector length.
     #[inline]
     pub fn length(self) -> T {
@@ -465,19 +487,6 @@ impl<T: Float, U> Vector2D<T, U> {
             None
         } else {
             Some(self / len)
-        }
-    }
-
-    /// Return the normalized vector even if the length is larger than the max value of Float.
-    #[inline]
-    #[must_use]
-    pub fn robust_normalize(self) -> Self {
-        let length = self.length();
-        if length.is_infinite() {
-            let scaled = self / T::max_value();
-            scaled / scaled.length()
-        } else {
-            self / length
         }
     }
 
@@ -508,12 +517,6 @@ impl<T: Float, U> Vector2D<T, U> {
     pub fn clamp_length(self, min: T, max: T) -> Self {
         debug_assert!(min <= max);
         self.with_min_length(min).with_max_length(max)
-    }
-
-    /// Returns true if all members are finite.
-    #[inline]
-    pub fn is_finite(self) -> bool {
-        self.x.is_finite() && self.y.is_finite()
     }
 }
 
@@ -1277,6 +1280,27 @@ where
 }
 
 impl<T: Float, U> Vector3D<T, U> {
+    /// Return the normalized vector even if the length is larger than the max value of Float.
+    #[inline]
+    #[must_use]
+    pub fn robust_normalize(self) -> Self {
+        let length = self.length();
+        if length.is_infinite() {
+            let scaled = self / T::max_value();
+            scaled / scaled.length()
+        } else {
+            self / length
+        }
+    }
+
+    /// Returns true if all members are finite.
+    #[inline]
+    pub fn is_finite(self) -> bool {
+        self.x.is_finite() && self.y.is_finite() && self.z.is_finite()
+    }
+}
+
+impl<T: Real, U> Vector3D<T, U> {
     /// Returns the positive angle between this vector and another vector.
     ///
     /// The returned angle is between 0 and PI.
@@ -1318,19 +1342,6 @@ impl<T: Float, U> Vector3D<T, U> {
         }
     }
 
-    /// Return the normalized vector even if the length is larger than the max value of Float.
-    #[inline]
-    #[must_use]
-    pub fn robust_normalize(self) -> Self {
-        let length = self.length();
-        if length.is_infinite() {
-            let scaled = self / T::max_value();
-            scaled / scaled.length()
-        } else {
-            self / length
-        }
-    }
-
     /// Return this vector capped to a maximum length.
     #[inline]
     pub fn with_max_length(self, max_length: T) -> Self {
@@ -1358,12 +1369,6 @@ impl<T: Float, U> Vector3D<T, U> {
     pub fn clamp_length(self, min: T, max: T) -> Self {
         debug_assert!(min <= max);
         self.with_min_length(min).with_max_length(max)
-    }
-
-    /// Returns true if all members are finite.
-    #[inline]
-    pub fn is_finite(self) -> bool {
-        self.x.is_finite() && self.y.is_finite() && self.z.is_finite()
     }
 }
 


### PR DESCRIPTION
This allows `euclid` to be more useable with types that do not necessarily have floating-point-specific characteristics such as NaN and infinity. e.g. Fixed point types.

`num_traits` has `impl<T: Float> Real for T` so existing code should continue to work.