### PR TITLE
Optionally implement bytemuck Zeroable and Pod on all types.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,9 @@ jobs:
         env:
           RUST_BACKTRACE: 1
 
+      - name: bytemuck
+        run: cargo check --features bytemuck
+
   build_result:
     name: homu build finished
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         features: ["", "--features serde", "--no-default-features --features libm"]
-        version: ["1.31.0", "stable", "beta", "nightly"]
+        version: ["1.34.0", "stable", "beta", "nightly"]
         include:
           - version: stable
             features: --features mint

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ num-traits = { version = "0.2.10", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["serde_derive"], optional = true }
 mint = {version = "0.5.1", optional = true}
 arbitrary = { version = "1", optional = true, features = ["derive"] }
+bytemuck = { version = "1.9", optional = true }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -16,6 +16,8 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, Sub, S
 use num_traits::{Float, FloatConst, NumCast, One, Zero};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Zeroable, Pod};
 
 /// An angle in radians
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Hash)]
@@ -24,6 +26,12 @@ use serde::{Deserialize, Serialize};
 pub struct Angle<T> {
     pub radians: T,
 }
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Zeroable> Zeroable for Angle<T> {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Pod> Pod for Angle<T> {}
 
 impl<T> Angle<T> {
     #[inline]

--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -20,6 +20,8 @@ use crate::vector::{vec2, Vector2D};
 use num_traits::{NumCast, Float};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Zeroable, Pod};
 
 use core::borrow::Borrow;
 use core::cmp::PartialOrd;
@@ -98,6 +100,12 @@ impl<T: fmt::Debug, U> fmt::Debug for Box2D<T, U> {
             .finish()
     }
 }
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Zeroable, U> Zeroable for Box2D<T, U> {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Pod, U: 'static> Pod for Box2D<T, U> {}
 
 impl<T, U> Box2D<T, U> {
     /// Constructor.

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -18,6 +18,8 @@ use crate::vector::Vector3D;
 use num_traits::{NumCast, Float};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Zeroable, Pod};
 
 use core::borrow::Borrow;
 use core::cmp::PartialOrd;
@@ -68,6 +70,12 @@ impl<T: fmt::Debug, U> fmt::Debug for Box3D<T, U> {
             .finish()
     }
 }
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Zeroable, U> Zeroable for Box3D<T, U> {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Pod, U: 'static> Pod for Box3D<T, U> {}
 
 impl<T, U> Box3D<T, U> {
     /// Constructor.

--- a/src/homogen.rs
+++ b/src/homogen.rs
@@ -19,6 +19,8 @@ use core::marker::PhantomData;
 use core::ops::Div;
 #[cfg(feature = "serde")]
 use serde;
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Zeroable, Pod};
 
 /// Homogeneous vector in 3D space.
 #[repr(C)]
@@ -77,6 +79,12 @@ where
         (&self.x, &self.y, &self.z, &self.w).serialize(serializer)
     }
 }
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Zeroable, U> Zeroable for HomogeneousVector<T, U> {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Pod, U: 'static> Pod for HomogeneousVector<T, U> {}
 
 impl<T, U> Eq for HomogeneousVector<T, U> where T: Eq {}
 

--- a/src/length.rs
+++ b/src/length.rs
@@ -24,6 +24,8 @@ use core::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
 use num_traits::{NumCast, Saturating};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Zeroable, Pod};
 
 /// A one-dimensional distance, with value represented by `T` and unit of measurement `Unit`.
 ///
@@ -74,6 +76,12 @@ where
         self.0.serialize(serializer)
     }
 }
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Zeroable, U> Zeroable for Length<T, U> {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Pod, U: 'static> Pod for Length<T, U> {}
 
 impl<T, U> Length<T, U> {
     /// Associate a value with a unit of measure.

--- a/src/point.rs
+++ b/src/point.rs
@@ -26,6 +26,9 @@ use num_traits::{Float, NumCast};
 #[cfg(feature = "serde")]
 use serde;
 
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Zeroable, Pod};
+
 /// A 2d Point tagged with a unit.
 #[repr(C)]
 pub struct Point2D<T, U> {
@@ -93,6 +96,13 @@ where
         })
     }
 }
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Zeroable, U> Zeroable for Point2D<T, U> {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Pod, U: 'static> Pod for Point2D<T, U> {}
+
 impl<T, U> Eq for Point2D<T, U> where T: Eq {}
 
 impl<T, U> PartialEq for Point2D<T, U>
@@ -780,6 +790,12 @@ where
         (&self.x, &self.y, &self.z).serialize(serializer)
     }
 }
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Zeroable, U> Zeroable for Point3D<T, U> {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Pod, U: 'static> Pod for Point3D<T, U> {}
 
 impl<T, U> Eq for Point3D<T, U> where T: Eq {}
 

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -19,6 +19,8 @@ use crate::vector::Vector2D;
 use num_traits::{NumCast, Float};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Zeroable, Pod};
 
 use core::borrow::Borrow;
 use core::cmp::PartialOrd;
@@ -68,6 +70,12 @@ where
         })
     }
 }
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Zeroable, U> Zeroable for Rect<T, U> {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Pod, U: 'static> Pod for Rect<T, U> {}
 
 impl<T: Hash, U> Hash for Rect<T, U> {
     fn hash<H: Hasher>(&self, h: &mut H) {

--- a/src/rigid.rs
+++ b/src/rigid.rs
@@ -8,6 +8,8 @@ use crate::{Rotation3D, Transform3D, UnknownUnit, Vector3D};
 use num_traits::Float;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Zeroable, Pod};
 
 /// A rigid transformation. All lengths are preserved under such a transformation.
 ///
@@ -17,7 +19,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// This can be more efficient to use over full matrices, especially if you
 /// have to deal with the decomposed quantities often.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct RigidTransform3D<T, Src, Dst> {
@@ -182,6 +184,23 @@ impl<T: Float + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
         }
     }
 }
+
+impl<T: Copy, Src, Dst> Copy for RigidTransform3D<T, Src, Dst> {}
+
+impl<T: Clone, Src, Dst> Clone for RigidTransform3D<T, Src, Dst> {
+    fn clone(&self) -> Self {
+        RigidTransform3D {
+            rotation: self.rotation.clone(),
+            translation: self.translation.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Zeroable, Src, Dst> Zeroable for RigidTransform3D<T, Src, Dst> {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Pod, Src: 'static, Dst: 'static> Pod for RigidTransform3D<T, Src, Dst> {}
 
 impl<T: Float + ApproxEq<T>, Src, Dst> From<Rotation3D<T, Src, Dst>>
     for RigidTransform3D<T, Src, Dst>

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -19,6 +19,8 @@ use core::ops::{Add, Mul, Neg, Sub};
 use num_traits::{Float, NumCast, One, Zero};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Zeroable, Pod};
 
 /// A transform that can represent rotations in 2d, represented as an angle in radians.
 #[repr(C)]
@@ -67,6 +69,12 @@ where
         self.angle.hash(h);
     }
 }
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Zeroable, Src, Dst> Zeroable for Rotation2D<T, Src, Dst> {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Pod, Src: 'static, Dst: 'static> Pod for Rotation2D<T, Src, Dst> {}
 
 impl<T, Src, Dst> Rotation2D<T, Src, Dst> {
     /// Creates a rotation from an angle in radians.
@@ -284,6 +292,12 @@ where
         self.r.hash(h);
     }
 }
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Zeroable, Src, Dst> Zeroable for Rotation3D<T, Src, Dst> {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Pod, Src: 'static, Dst: 'static> Pod for Rotation3D<T, Src, Dst> {}
 
 impl<T, Src, Dst> Rotation3D<T, Src, Dst> {
     /// Creates a rotation around from a quaternion representation.

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -19,6 +19,8 @@ use core::ops::{Add, Div, Mul, Sub};
 use num_traits::NumCast;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Zeroable, Pod};
 
 /// A scaling factor between two different units of measurement.
 ///
@@ -294,6 +296,12 @@ impl<T: NumCast, Src, Dst> Scale<T, Src, Dst> {
         NumCast::from(self.0).map(Scale::new)
     }
 }
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Zeroable, Src, Dst> Zeroable for Scale<T, Src, Dst> {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Pod, Src: 'static, Dst: 'static> Pod for Scale<T, Src, Dst> {}
 
 // scale0 * scale1
 // (A,B) * (B,C) = (A,C)

--- a/src/side_offsets.rs
+++ b/src/side_offsets.rs
@@ -21,6 +21,8 @@ use core::marker::PhantomData;
 use core::ops::{Add, Div, DivAssign, Mul, MulAssign, Neg};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Zeroable, Pod};
 
 /// A group of 2D side offsets, which correspond to top/right/bottom/left for borders, padding,
 /// and margins in CSS, optionally tagged with a unit.
@@ -56,6 +58,12 @@ where
         })
     }
 }
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Zeroable, U> Zeroable for SideOffsets2D<T, U> {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Pod, U: 'static> Pod for SideOffsets2D<T, U> {}
 
 impl<T: Copy, U> Copy for SideOffsets2D<T, U> {}
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -26,6 +26,8 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 use num_traits::{NumCast, Signed, Float};
 #[cfg(feature = "serde")]
 use serde;
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Zeroable, Pod};
 
 /// A 2d size tagged with a unit.
 #[repr(C)]
@@ -98,6 +100,12 @@ where
         })
     }
 }
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Zeroable, U> Zeroable for Size2D<T, U> {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Pod, U: 'static> Pod for Size2D<T, U> {}
 
 impl<T, U> Eq for Size2D<T, U> where T: Eq {}
 
@@ -988,6 +996,12 @@ where
         (&self.width, &self.height, &self.depth).serialize(serializer)
     }
 }
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Zeroable, U> Zeroable for Size3D<T, U> {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Pod, U: 'static> Pod for Size3D<T, U> {}
 
 impl<T, U> Eq for Size3D<T, U> where T: Eq {}
 

--- a/src/transform2d.rs
+++ b/src/transform2d.rs
@@ -28,6 +28,8 @@ use core::fmt;
 use num_traits::NumCast;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Zeroable, Pod};
 
 /// A 2d transform represented by a column-major 3 by 3 matrix, compressed down to 3 by 2.
 ///
@@ -83,6 +85,12 @@ where
         })
     }
 }
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Zeroable, Src, Dst> Zeroable for Transform2D<T, Src, Dst> {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Pod, Src: 'static, Dst: 'static> Pod for Transform2D<T, Src, Dst> {}
 
 impl<T: Copy, Src, Dst> Copy for Transform2D<T, Src, Dst> {}
 

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -31,6 +31,8 @@ use core::hash::{Hash};
 use num_traits::NumCast;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Zeroable, Pod};
 
 /// A 3d transform stored as a column-major 4 by 4 matrix.
 ///
@@ -104,6 +106,12 @@ where
         })
     }
 }
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Zeroable, Src, Dst> Zeroable for Transform3D<T, Src, Dst> {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Pod, Src: 'static, Dst: 'static> Pod for Transform3D<T, Src, Dst> {}
 
 impl<T: Copy, Src, Dst> Copy for Transform3D<T, Src, Dst> {}
 

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -18,6 +18,8 @@ use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Neg, Sub, SubAssign};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Zeroable, Pod};
 
 /// A 2d transformation from a space to another that can only express translations.
 ///
@@ -251,6 +253,12 @@ impl<T: Copy, Src, Dst> Translation2D<T, Src, Dst> {
         Translation2D::new(-self.x, -self.y)
     }
 }
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Zeroable, Src, Dst> Zeroable for Translation2D<T, Src, Dst> {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Pod, Src: 'static, Dst: 'static> Pod for Translation2D<T, Src, Dst> {}
 
 impl<T: Add, Src, Dst1, Dst2> Add<Translation2D<T, Dst1, Dst2>> for Translation2D<T, Src, Dst1> {
     type Output = Translation2D<T::Output, Src, Dst2>;
@@ -571,6 +579,12 @@ impl<T: Copy, Src, Dst> Translation3D<T, Src, Dst> {
         Translation3D::new(-self.x, -self.y, -self.z)
     }
 }
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Zeroable, Src, Dst> Zeroable for Translation3D<T, Src, Dst> {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Pod, Src: 'static, Dst: 'static> Pod for Translation3D<T, Src, Dst> {}
 
 impl<T: Add, Src, Dst1, Dst2> Add<Translation3D<T, Dst1, Dst2>> for Translation3D<T, Src, Dst1> {
     type Output = Translation3D<T::Output, Src, Dst2>;

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -31,6 +31,9 @@ use num_traits::{Float, NumCast, Signed};
 #[cfg(feature = "serde")]
 use serde;
 
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Zeroable, Pod};
+
 /// A 2d Vector tagged with a unit.
 #[repr(C)]
 pub struct Vector2D<T, U> {
@@ -102,6 +105,12 @@ where
         })
     }
 }
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Zeroable, U> Zeroable for Vector2D<T, U> {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Pod, U: 'static> Pod for Vector2D<T, U> {}
 
 impl<T: Eq, U> Eq for Vector2D<T, U> {}
 
@@ -947,6 +956,12 @@ where
         (&self.x, &self.y, &self.z).serialize(serializer)
     }
 }
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Zeroable, U> Zeroable for Vector3D<T, U> {}
+
+#[cfg(feature = "bytemuck")]
+unsafe impl<T: Pod, U: 'static> Pod for Vector3D<T, U> {}
 
 impl<T: Eq, U> Eq for Vector3D<T, U> {}
 


### PR DESCRIPTION
Pod is very useful when interacting with GPU APIs like wgpu as it is the de-facto standard way to express that a piece of data is safe to put into GPU buffers.