### PR TITLE
Fix compile of `arbitrary` feature. 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,10 @@ jobs:
         include:
           - version: stable
             features: --features mint
+          - version: stable
+            features: --features bytemuck
+          - version: stable
+            features: --features arbitrary
           - version: nightly
             features: --features unstable
           - version: nightly
@@ -39,9 +43,6 @@ jobs:
         run: cargo test ${{ matrix.features }}
         env:
           RUST_BACKTRACE: 1
-
-      - name: bytemuck
-        run: cargo check --features bytemuck
 
   build_result:
     name: Result

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -23,7 +23,6 @@ use bytemuck::{Zeroable, Pod};
 /// An angle in radians
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Angle<T> {
     pub radians: T,
 }
@@ -33,6 +32,23 @@ unsafe impl<T: Zeroable> Zeroable for Angle<T> {}
 
 #[cfg(feature = "bytemuck")]
 unsafe impl<T: Pod> Pod for Angle<T> {}
+
+#[cfg(feature = "arbitrary")]
+impl<'a, T> arbitrary::Arbitrary<'a> for Angle<T>
+where
+    T: arbitrary::Arbitrary<'a>,
+{
+    // This implementation could be derived, but the derive would require an `extern crate std`.
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Angle {
+            radians: arbitrary::Arbitrary::arbitrary(u)?,
+        })
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        <T as arbitrary::Arbitrary>::size_hint(depth)
+    }
+}
 
 impl<T> Angle<T> {
     #[inline]


### PR DESCRIPTION
The `arbitrary` feature is currently broken, because the `Arbitrary` derive macro assumes `std` is present:

```
$ cargo build --features arbitrary
   Compiling euclid v0.22.9 (/Users/kpreid/Projects/rust/contributing/euclid)
error[E0433]: failed to resolve: use of undeclared crate or module `std`
  --> src/angle.rs:26:42
   |
26 | #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
   |                                          ^^^^^^^^^^^^^^^^^^^^ use of undeclared crate or module `std`
   |
   = note: this error originates in the derive macro `arbitrary::Arbitrary` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0425]: cannot find value `RECURSIVE_COUNT_Angle` in this scope
  --> src/angle.rs:26:42
   |
26 | #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
   |                                          ^^^^^^^^^^^^^^^^^^^^ not found in this scope
   |
   = note: this error originates in the derive macro `arbitrary::Arbitrary` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This PR replaces the sole use of that macro with a manual implementation, and adds CI testing for the feature so it won't break again.