### PR TITLE
Implement `Add/Sub` of `Translation*` for `Point*`

### DIFF
--- a/src/point.rs
+++ b/src/point.rs
@@ -14,6 +14,7 @@ use crate::length::Length;
 use crate::num::*;
 use crate::scale::Scale;
 use crate::size::{Size2D, Size3D};
+use crate::translation::{Translation2D, Translation3D};
 use crate::vector::{vec2, vec3, Vector2D, Vector3D};
 use core::cmp::{Eq, PartialEq};
 use core::fmt;
@@ -560,6 +561,15 @@ impl<T: Copy + Add<T, Output = T>, U> AddAssign<Vector2D<T, U>> for Point2D<T, U
     }
 }
 
+impl<T: Copy + Add, Src, Dst> Add<Translation2D<T, Src, Dst>> for Point2D<T, Src> {
+    type Output = Point2D<T::Output, Dst>;
+
+    #[inline]
+    fn add(self, other: Translation2D<T, Src, Dst>) -> Self::Output {
+        other.transform_point(self)
+    }
+}
+
 impl<T: Sub, U> Sub for Point2D<T, U> {
     type Output = Vector2D<T::Output, U>;
 
@@ -599,6 +609,15 @@ impl<T: Copy + Sub<T, Output = T>, U> SubAssign<Vector2D<T, U>> for Point2D<T, U
     #[inline]
     fn sub_assign(&mut self, other: Vector2D<T, U>) {
         *self = *self - other
+    }
+}
+
+impl<T: Copy + Sub, Src, Dst> Sub<Translation2D<T, Src, Dst>> for Point2D<T, Dst> {
+    type Output = Point2D<T::Output, Src>;
+
+    #[inline]
+    fn sub(self, other: Translation2D<T, Src, Dst>) -> Self::Output {
+        other.transform_point_inv(self)
     }
 }
 
@@ -1337,6 +1356,15 @@ impl<T: Copy + Add<T, Output = T>, U> AddAssign<Vector3D<T, U>> for Point3D<T, U
     }
 }
 
+impl<T: Copy + Add, Src, Dst> Add<Translation3D<T, Src, Dst>> for Point3D<T, Src> {
+    type Output = Point3D<T::Output, Dst>;
+
+    #[inline]
+    fn add(self, other: Translation3D<T, Src, Dst>) -> Self::Output {
+        other.transform_point3d(&self)
+    }
+}
+
 impl<T: Sub, U> Sub for Point3D<T, U> {
     type Output = Vector3D<T::Output, U>;
 
@@ -1381,6 +1409,15 @@ impl<T: Copy + Sub<T, Output = T>, U> SubAssign<Vector3D<T, U>> for Point3D<T, U
     #[inline]
     fn sub_assign(&mut self, other: Vector3D<T, U>) {
         *self = *self - other
+    }
+}
+
+impl<T: Copy + Sub, Src, Dst> Sub<Translation3D<T, Src, Dst>> for Point3D<T, Dst> {
+    type Output = Point3D<T::Output, Src>;
+
+    #[inline]
+    fn sub(self, other: Translation3D<T, Src, Dst>) -> Self::Output {
+        other.transform_point3d_inv(&self)
     }
 }
 

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -220,6 +220,15 @@ impl<T: Copy, Src, Dst> Translation2D<T, Src, Dst> {
         point2(p.x + self.x, p.y + self.y)
     }
 
+    /// Translate a point by inverse and cast its unit.
+    #[inline]
+    pub(crate) fn transform_point_inv(&self, p: Point2D<T, Dst>) -> Point2D<T::Output, Src>
+    where
+        T: Sub,
+    {
+        point2(p.x - self.x, p.y - self.y)
+    }
+
     /// Translate a rectangle and cast its unit.
     #[inline]
     pub fn transform_rect(&self, r: &Rect<T, Src>) -> Rect<T::Output, Dst>
@@ -523,6 +532,15 @@ impl<T: Copy, Src, Dst> Translation3D<T, Src, Dst> {
         T: Add,
     {
         point3(p.x + self.x, p.y + self.y, p.z + self.z)
+    }
+
+    /// Translate a point by inverse and cast its unit.
+    #[inline]
+    pub(crate) fn transform_point3d_inv(&self, p: &Point3D<T, Dst>) -> Point3D<T::Output, Src>
+    where
+        T: Sub,
+    {
+        point3(p.x - self.x, p.y - self.y, p.z - self.z)
     }
 
     /// Translate a point and cast its unit.


### PR DESCRIPTION
Like https://github.com/servo/euclid/pull/506, these exist for the vector types. There doesn't seem to be any reason there shouldn't also work for translation types.

The existing `translate` methods could be used for subtraction with `inv`, but that requires a complicated bound involving `Inv` and `Add` instead of a `Sub` bound.