### PR TITLE
Reformat and configure for auto-formatting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,14 @@ jobs:
         env:
           RUST_BACKTRACE: 1
 
+  fmt:
+    name: Check code formatting
+    runs-on: ubuntu-latest
+    steps:
+      # GitHub runners already have a usable version of cargo & rustfmt, so an install is not needed
+      - uses: actions/checkout@v3
+      - run: cargo fmt --check
+
   build_result:
     name: Result
     runs-on: ubuntu-latest

--- a/src/angle.rs
+++ b/src/angle.rs
@@ -9,16 +9,18 @@
 
 use crate::approxeq::ApproxEq;
 use crate::trig::Trig;
+
 use core::cmp::{Eq, PartialEq};
 use core::hash::Hash;
 use core::iter::Sum;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, Sub, SubAssign};
+
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Pod, Zeroable};
 use num_traits::real::Real;
 use num_traits::{Float, FloatConst, NumCast, One, Zero};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "bytemuck")]
-use bytemuck::{Zeroable, Pod};
 
 /// An angle in radians
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, PartialOrd, Hash)]
@@ -226,13 +228,13 @@ impl<T: Copy + Add<T, Output = T>> Add<&Self> for Angle<T> {
 }
 
 impl<T: Add + Zero> Sum for Angle<T> {
-    fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::zero(), Add::add)
     }
 }
 
 impl<'a, T: 'a + Add + Copy + Zero> Sum<&'a Self> for Angle<T> {
-    fn sum<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
+    fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
         iter.fold(Self::zero(), Add::add)
     }
 }

--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -874,6 +874,7 @@ mod tests {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_nan_empty() {
         use std::f32::NAN;
         assert!(Box2D { min: point2(NAN, 2.0), max: point2(1.0, 3.0) }.is_empty());

--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -17,17 +17,17 @@ use crate::side_offsets::SideOffsets2D;
 use crate::size::Size2D;
 use crate::vector::{vec2, Vector2D};
 
-use num_traits::{NumCast, Float};
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Pod, Zeroable};
+use num_traits::{Float, NumCast};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "bytemuck")]
-use bytemuck::{Zeroable, Pod};
 
 use core::borrow::Borrow;
 use core::cmp::PartialOrd;
 use core::fmt;
 use core::hash::{Hash, Hasher};
-use core::ops::{Add, Div, DivAssign, Mul, MulAssign, Sub, Range};
+use core::ops::{Add, Div, DivAssign, Mul, MulAssign, Range, Sub};
 
 /// A 2d axis aligned rectangle represented by its minimum and maximum coordinates.
 ///
@@ -116,9 +116,9 @@ impl<T, U> Box2D<T, U> {
 
     /// Constructor.
     #[inline]
-    pub fn from_origin_and_size(origin: Point2D<T, U>, size: Size2D<T, U>) -> Self 
+    pub fn from_origin_and_size(origin: Point2D<T, U>, size: Size2D<T, U>) -> Self
     where
-        T: Copy + Add<T, Output = T>
+        T: Copy + Add<T, Output = T>,
     {
         Box2D {
             min: origin,
@@ -128,7 +128,10 @@ impl<T, U> Box2D<T, U> {
 
     /// Creates a Box2D of the given size, at offset zero.
     #[inline]
-    pub fn from_size(size: Size2D<T, U>) -> Self where T: Zero {
+    pub fn from_size(size: Size2D<T, U>) -> Self
+    where
+        T: Zero,
+    {
         Box2D {
             min: Point2D::zero(),
             max: point2(size.width, size.height),

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -919,6 +919,7 @@ mod tests {
     }
 
     #[test]
+    #[rustfmt::skip]
     fn test_nan_empty_or_negative() {
         use std::f32::NAN;
         assert!(Box3D { min: point3(NAN, 2.0, 1.0), max: point3(1.0, 3.0, 5.0) }.is_empty());

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -15,17 +15,17 @@ use crate::scale::Scale;
 use crate::size::Size3D;
 use crate::vector::Vector3D;
 
-use num_traits::{NumCast, Float};
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Pod, Zeroable};
+use num_traits::{Float, NumCast};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "bytemuck")]
-use bytemuck::{Zeroable, Pod};
 
 use core::borrow::Borrow;
 use core::cmp::PartialOrd;
 use core::fmt;
 use core::hash::{Hash, Hasher};
-use core::ops::{Add, Div, DivAssign, Mul, MulAssign, Sub, Range};
+use core::ops::{Add, Div, DivAssign, Mul, MulAssign, Range, Sub};
 
 /// An axis aligned 3D box represented by its minimum and maximum coordinates.
 #[repr(C)]
@@ -86,7 +86,10 @@ impl<T, U> Box3D<T, U> {
 
     /// Creates a Box3D of the given size, at offset zero.
     #[inline]
-    pub fn from_size(size: Size3D<T, U>) -> Self where T: Zero {
+    pub fn from_size(size: Size3D<T, U>) -> Self
+    where
+        T: Zero,
+    {
         Box3D {
             min: Point3D::zero(),
             max: point3(size.width, size.height, size.depth),

--- a/src/homogen.rs
+++ b/src/homogen.rs
@@ -12,6 +12,8 @@ use crate::vector::{Vector2D, Vector3D};
 
 use crate::num::{One, Zero};
 
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Pod, Zeroable};
 use core::cmp::{Eq, PartialEq};
 use core::fmt;
 use core::hash::Hash;
@@ -19,8 +21,6 @@ use core::marker::PhantomData;
 use core::ops::Div;
 #[cfg(feature = "serde")]
 use serde;
-#[cfg(feature = "bytemuck")]
-use bytemuck::{Zeroable, Pod};
 
 /// Homogeneous vector in 3D space.
 #[repr(C)]

--- a/src/length.rs
+++ b/src/length.rs
@@ -9,11 +9,13 @@
 //! A one-dimensional length, tagged with its units.
 
 use crate::approxeq::ApproxEq;
+use crate::approxord::{max, min};
 use crate::num::Zero;
 use crate::scale::Scale;
-use crate::approxord::{max, min};
 
 use crate::num::One;
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Pod, Zeroable};
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{Hash, Hasher};
@@ -24,8 +26,6 @@ use core::ops::{AddAssign, DivAssign, MulAssign, SubAssign};
 use num_traits::{NumCast, Saturating};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-#[cfg(feature = "bytemuck")]
-use bytemuck::{Zeroable, Pod};
 
 /// A one-dimensional distance, with value represented by `T` and unit of measurement `Unit`.
 ///
@@ -195,14 +195,14 @@ impl<T: Add + Copy, U> Add<&Self> for Length<T, U> {
 
 // length_iter.copied().sum()
 impl<T: Add<Output = T> + Zero, U> Sum for Length<T, U> {
-    fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::zero(), Add::add)
     }
 }
 
 // length_iter.sum()
 impl<'a, T: 'a + Add<Output = T> + Copy + Zero, U: 'a> Sum<&'a Self> for Length<T, U> {
-    fn sum<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
+    fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
         iter.fold(Self::zero(), Add::add)
     }
 }

--- a/src/point.rs
+++ b/src/point.rs
@@ -23,12 +23,12 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 #[cfg(feature = "mint")]
 use mint;
 use num_traits::real::Real;
-use num_traits::{Float, NumCast, Euclid};
+use num_traits::{Euclid, Float, NumCast};
 #[cfg(feature = "serde")]
 use serde;
 
 #[cfg(feature = "bytemuck")]
-use bytemuck::{Zeroable, Pod};
+use bytemuck::{Pod, Zeroable};
 
 /// A 2d Point tagged with a unit.
 #[repr(C)]
@@ -87,8 +87,7 @@ impl<'a, T, U> arbitrary::Arbitrary<'a> for Point2D<T, U>
 where
     T: arbitrary::Arbitrary<'a>,
 {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self>
-    {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let (x, y) = arbitrary::Arbitrary::arbitrary(u)?;
         Ok(Point2D {
             x,
@@ -748,9 +747,9 @@ impl<T: ApproxEq<T>, U> ApproxEq<Point2D<T, U>> for Point2D<T, U> {
 
 impl<T: Euclid, U> Point2D<T, U> {
     /// Calculates the least nonnegative remainder of `self (mod other)`.
-    /// 
+    ///
     /// # Example
-    /// 
+    ///
     /// ```rust
     /// use euclid::point2;
     /// use euclid::default::{Point2D, Size2D};
@@ -764,13 +763,16 @@ impl<T: Euclid, U> Point2D<T, U> {
     /// ```
     #[inline]
     pub fn rem_euclid(&self, other: &Size2D<T, U>) -> Self {
-        point2(self.x.rem_euclid(&other.width), self.y.rem_euclid(&other.height))
+        point2(
+            self.x.rem_euclid(&other.width),
+            self.y.rem_euclid(&other.height),
+        )
     }
 
     /// Calculates Euclidean division, the matching method for `rem_euclid`.
-    /// 
+    ///
     /// # Example
-    /// 
+    ///
     /// ```rust
     /// use euclid::point2;
     /// use euclid::default::{Point2D, Size2D};
@@ -784,7 +786,10 @@ impl<T: Euclid, U> Point2D<T, U> {
     /// ```
     #[inline]
     pub fn div_euclid(&self, other: &Size2D<T, U>) -> Self {
-        point2(self.x.div_euclid(&other.width), self.y.div_euclid(&other.height))
+        point2(
+            self.x.div_euclid(&other.width),
+            self.y.div_euclid(&other.height),
+        )
     }
 }
 
@@ -1459,11 +1464,7 @@ impl<T: Copy + Mul, U> Mul<T> for Point3D<T, U> {
 
     #[inline]
     fn mul(self, scale: T) -> Self::Output {
-        point3(
-            self.x * scale,
-            self.y * scale,
-            self.z * scale,
-        )
+        point3(self.x * scale, self.y * scale, self.z * scale)
     }
 }
 
@@ -1481,11 +1482,7 @@ impl<T: Copy + Mul, U1, U2> Mul<Scale<T, U1, U2>> for Point3D<T, U1> {
 
     #[inline]
     fn mul(self, scale: Scale<T, U1, U2>) -> Self::Output {
-        point3(
-            self.x * scale.0,
-            self.y * scale.0,
-            self.z * scale.0,
-        )
+        point3(self.x * scale.0, self.y * scale.0, self.z * scale.0)
     }
 }
 
@@ -1501,11 +1498,7 @@ impl<T: Copy + Div, U> Div<T> for Point3D<T, U> {
 
     #[inline]
     fn div(self, scale: T) -> Self::Output {
-        point3(
-            self.x / scale,
-            self.y / scale,
-            self.z / scale,
-        )
+        point3(self.x / scale, self.y / scale, self.z / scale)
     }
 }
 
@@ -1523,11 +1516,7 @@ impl<T: Copy + Div, U1, U2> Div<Scale<T, U1, U2>> for Point3D<T, U2> {
 
     #[inline]
     fn div(self, scale: Scale<T, U1, U2>) -> Self::Output {
-        point3(
-            self.x / scale.0,
-            self.y / scale.0,
-            self.z / scale.0,
-        )
+        point3(self.x / scale.0, self.y / scale.0, self.z / scale.0)
     }
 }
 
@@ -1589,9 +1578,9 @@ impl<T: ApproxEq<T>, U> ApproxEq<Point3D<T, U>> for Point3D<T, U> {
 
 impl<T: Euclid, U> Point3D<T, U> {
     /// Calculates the least nonnegative remainder of `self (mod other)`.
-    /// 
+    ///
     /// # Example
-    /// 
+    ///
     /// ```rust
     /// use euclid::point3;
     /// use euclid::default::{Point3D, Size3D};
@@ -1613,9 +1602,9 @@ impl<T: Euclid, U> Point3D<T, U> {
     }
 
     /// Calculates Euclidean division, the matching method for `rem_euclid`.
-    /// 
+    ///
     /// # Example
-    /// 
+    ///
     /// ```rust
     /// use euclid::point3;
     /// use euclid::default::{Point3D, Size3D};
@@ -1943,8 +1932,8 @@ mod point2d {
     }
 
     mod euclid {
-        use crate::point2;
         use crate::default::{Point2D, Size2D};
+        use crate::point2;
 
         #[test]
         pub fn test_rem_euclid() {
@@ -2227,8 +2216,8 @@ mod point3d {
     }
 
     mod euclid {
-        use crate::point3;
         use crate::default::{Point3D, Size3D};
+        use crate::point3;
 
         #[test]
         pub fn test_rem_euclid() {

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -16,11 +16,11 @@ use crate::side_offsets::SideOffsets2D;
 use crate::size::Size2D;
 use crate::vector::Vector2D;
 
-use num_traits::{NumCast, Float};
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Pod, Zeroable};
+use num_traits::{Float, NumCast};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "bytemuck")]
-use bytemuck::{Zeroable, Pod};
 
 use core::borrow::Borrow;
 use core::cmp::PartialOrd;
@@ -61,13 +61,9 @@ impl<'a, T, U> arbitrary::Arbitrary<'a> for Rect<T, U>
 where
     T: arbitrary::Arbitrary<'a>,
 {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self>
-    {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let (origin, size) = arbitrary::Arbitrary::arbitrary(u)?;
-        Ok(Rect {
-            origin,
-            size,
-        })
+        Ok(Rect { origin, size })
     }
 }
 

--- a/src/rigid.rs
+++ b/src/rigid.rs
@@ -8,11 +8,11 @@ use crate::{Rotation3D, Transform3D, UnknownUnit, Vector3D};
 
 use core::{fmt, hash};
 
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Pod, Zeroable};
 use num_traits::real::Real;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "bytemuck")]
-use bytemuck::{Zeroable, Pod};
 
 /// A rigid transformation. All lengths are preserved under such a transformation.
 ///
@@ -165,7 +165,9 @@ impl<T: Real + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
     where
         T: Trig,
     {
-        self.rotation.to_transform().then(&self.translation.to_transform())
+        self.rotation
+            .to_transform()
+            .then(&self.translation.to_transform())
     }
 
     /// Drop the units, preserving only the numeric value.
@@ -252,14 +254,14 @@ mod test {
         let rotation = Rotation3D::unit_quaternion(0.5, -7.8, 2.2, 4.3);
 
         let rigid = RigidTransform3D::new(rotation, translation);
-        assert!(rigid.to_transform().approx_eq(
-            &rotation.to_transform().then(&translation.to_transform())
-        ));
+        assert!(rigid
+            .to_transform()
+            .approx_eq(&rotation.to_transform().then(&translation.to_transform())));
 
         let rigid = RigidTransform3D::new_from_reversed(translation, rotation);
-        assert!(rigid.to_transform().approx_eq(
-            &translation.to_transform().then(&rotation.to_transform())
-        ));
+        assert!(rigid
+            .to_transform()
+            .approx_eq(&translation.to_transform().then(&rotation.to_transform())));
     }
 
     #[test]

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -11,17 +11,19 @@ use crate::approxeq::ApproxEq;
 use crate::trig::Trig;
 use crate::{point2, point3, vec3, Angle, Point2D, Point3D, Vector2D, Vector3D};
 use crate::{Transform2D, Transform3D, UnknownUnit};
+
 use core::cmp::{Eq, PartialEq};
 use core::fmt;
 use core::hash::Hash;
 use core::marker::PhantomData;
 use core::ops::{Add, Mul, Neg, Sub};
+
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Pod, Zeroable};
 use num_traits::real::Real;
 use num_traits::{NumCast, One, Zero};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "bytemuck")]
-use bytemuck::{Zeroable, Pod};
 
 /// A transform that can represent rotations in 2d, represented as an angle in radians.
 #[repr(C)]
@@ -190,10 +192,7 @@ impl<T: Real, Src, Dst> Rotation2D<T, Src, Dst> {
 
     /// Returns a rotation representing the other rotation followed by this rotation.
     #[inline]
-    pub fn then<NewSrc>(
-        &self,
-        other: &Rotation2D<T, NewSrc, Src>,
-    ) -> Rotation2D<T, NewSrc, Dst> {
+    pub fn then<NewSrc>(&self, other: &Rotation2D<T, NewSrc, Src>) -> Rotation2D<T, NewSrc, Dst> {
         Rotation2D::radians(self.angle + other.angle)
     }
 
@@ -669,10 +668,7 @@ where
 
     /// Returns a rotation representing this rotation followed by the other rotation.
     #[inline]
-    pub fn then<NewDst>(
-        &self,
-        other: &Rotation3D<T, Dst, NewDst>,
-    ) -> Rotation3D<T, Src, NewDst>
+    pub fn then<NewDst>(&self, other: &Rotation3D<T, Dst, NewDst>) -> Rotation3D<T, Src, NewDst>
     where
         T: ApproxEq<T>,
     {

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -624,6 +624,7 @@ where
 
     /// Returns the matrix representation of this rotation.
     #[inline]
+    #[rustfmt::skip]
     pub fn to_transform(&self) -> Transform3D<T, Src, Dst>
     where
         T: ApproxEq<T>,
@@ -826,18 +827,12 @@ fn pre_post() {
     // Check that the order of transformations is correct (corresponds to what
     // we do in Transform3D).
     let p1 = r1.then(&r2).then(&r3).transform_point3d(p);
-    let p2 = t1
-        .then(&t2)
-        .then(&t3)
-        .transform_point3d(p);
+    let p2 = t1.then(&t2).then(&t3).transform_point3d(p);
 
     assert!(p1.approx_eq(&p2.unwrap()));
 
     // Check that changing the order indeed matters.
-    let p3 = t3
-        .then(&t1)
-        .then(&t2)
-        .transform_point3d(p);
+    let p3 = t3.then(&t1).then(&t2).transform_point3d(p);
     assert!(!p1.approx_eq(&p3.unwrap()));
 }
 

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -11,17 +11,19 @@
 use crate::num::One;
 
 use crate::approxord::{max, min};
-use crate::{Point2D, Point3D, Rect, Size2D, Vector2D, Box2D, Box3D};
+use crate::{Box2D, Box3D, Point2D, Point3D, Rect, Size2D, Vector2D};
+
 use core::cmp::Ordering;
 use core::fmt;
 use core::hash::{Hash, Hasher};
 use core::marker::PhantomData;
 use core::ops::{Add, Div, Mul, Sub};
+
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Pod, Zeroable};
 use num_traits::NumCast;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "bytemuck")]
-use bytemuck::{Zeroable, Pod};
 
 /// A scaling factor between two different units of measurement.
 ///
@@ -63,7 +65,7 @@ impl<T, Src, Dst> Scale<T, Src, Dst> {
     #[inline]
     pub fn identity() -> Self
     where
-        T: One
+        T: One,
     {
         Scale::new(T::one())
     }
@@ -264,7 +266,6 @@ impl<T: PartialOrd, Src, Dst> Scale<T, Src, Dst> {
         self.max(start).min(end)
     }
 }
-
 
 impl<T: NumCast, Src, Dst> Scale<T, Src, Dst> {
     /// Cast from one numeric representation to another, preserving the units.

--- a/src/side_offsets.rs
+++ b/src/side_offsets.rs
@@ -14,15 +14,17 @@ use crate::length::Length;
 use crate::num::Zero;
 use crate::scale::Scale;
 use crate::Vector2D;
+
 use core::cmp::{Eq, PartialEq};
 use core::fmt;
 use core::hash::Hash;
 use core::marker::PhantomData;
-use core::ops::{Add, AddAssign, Sub, SubAssign, Div, DivAssign, Mul, MulAssign, Neg};
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Pod, Zeroable};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "bytemuck")]
-use bytemuck::{Zeroable, Pod};
 
 /// A group of 2D side offsets, which correspond to top/right/bottom/left for borders, padding,
 /// and margins in CSS, optionally tagged with a unit.
@@ -46,8 +48,7 @@ impl<'a, T, U> arbitrary::Arbitrary<'a> for SideOffsets2D<T, U>
 where
     T: arbitrary::Arbitrary<'a>,
 {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self>
-    {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let (top, right, bottom, left) = arbitrary::Arbitrary::arbitrary(u)?;
         Ok(SideOffsets2D {
             top,
@@ -193,7 +194,8 @@ impl<T, U> SideOffsets2D<T, U> {
 
     /// Constructor, setting all sides to zero.
     pub fn zero() -> Self
-        where T: Zero,
+    where
+        T: Zero,
     {
         SideOffsets2D::new(Zero::zero(), Zero::zero(), Zero::zero(), Zero::zero())
     }
@@ -209,26 +211,30 @@ impl<T, U> SideOffsets2D<T, U> {
 
     /// Constructor setting the same value to all sides, taking a scalar value directly.
     pub fn new_all_same(all: T) -> Self
-        where T : Copy
+    where
+        T: Copy,
     {
         SideOffsets2D::new(all, all, all, all)
     }
 
     /// Constructor setting the same value to all sides, taking a typed Length.
     pub fn from_length_all_same(all: Length<T, U>) -> Self
-        where T : Copy
+    where
+        T: Copy,
     {
         SideOffsets2D::new_all_same(all.0)
     }
 
     pub fn horizontal(&self) -> T
-        where T: Copy + Add<T, Output = T>
+    where
+        T: Copy + Add<T, Output = T>,
     {
         self.left + self.right
     }
 
     pub fn vertical(&self) -> T
-        where T: Copy + Add<T, Output = T>
+    where
+        T: Copy + Add<T, Output = T>,
     {
         self.top + self.bottom
     }
@@ -290,7 +296,7 @@ where
 
 impl<T, U> Neg for SideOffsets2D<T, U>
 where
-    T: Neg<Output = T>
+    T: Neg<Output = T>,
 {
     type Output = Self;
     fn neg(self) -> Self {

--- a/src/size.rs
+++ b/src/size.rs
@@ -1517,6 +1517,7 @@ impl<T: Copy + Mul, U> Mul<T> for Size3D<T, U> {
     type Output = Size3D<T::Output, U>;
 
     #[inline]
+    #[rustfmt::skip]
     fn mul(self, scale: T) -> Self::Output {
         Size3D::new(
             self.width * scale,
@@ -1559,6 +1560,7 @@ impl<T: Copy + Div, U> Div<T> for Size3D<T, U> {
     type Output = Size3D<T::Output, U>;
 
     #[inline]
+    #[rustfmt::skip]
     fn div(self, scale: T) -> Self::Output {
         Size3D::new(
             self.width / scale,

--- a/src/size.rs
+++ b/src/size.rs
@@ -14,8 +14,6 @@ use crate::num::*;
 use crate::scale::Scale;
 use crate::vector::{vec2, BoolVector2D, Vector2D};
 use crate::vector::{vec3, BoolVector3D, Vector3D};
-#[cfg(feature = "mint")]
-use mint;
 
 use core::cmp::{Eq, PartialEq};
 use core::fmt;
@@ -23,11 +21,14 @@ use core::hash::Hash;
 use core::iter::Sum;
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
-use num_traits::{NumCast, Signed, Float};
+
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Pod, Zeroable};
+#[cfg(feature = "mint")]
+use mint;
+use num_traits::{Float, NumCast, Signed};
 #[cfg(feature = "serde")]
 use serde;
-#[cfg(feature = "bytemuck")]
-use bytemuck::{Zeroable, Pod};
 
 /// A 2d size tagged with a unit.
 #[repr(C)]
@@ -90,8 +91,7 @@ impl<'a, T, U> arbitrary::Arbitrary<'a> for Size2D<T, U>
 where
     T: arbitrary::Arbitrary<'a>,
 {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self>
-    {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let (width, height) = arbitrary::Arbitrary::arbitrary(u)?;
         Ok(Size2D {
             width,
@@ -478,7 +478,7 @@ impl<T: PartialOrd, U> Size2D<T, U> {
     {
         let zero = T::zero();
         // The condition is experessed this way so that we return true in
-        // the presence of NaN. 
+        // the presence of NaN.
         !(self.width > zero && self.height > zero)
     }
 }
@@ -558,13 +558,13 @@ impl<T: Copy + Add<T, Output = T>, U> Add<&Self> for Size2D<T, U> {
 }
 
 impl<T: Add<Output = T> + Zero, U> Sum for Size2D<T, U> {
-    fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::zero(), Add::add)
     }
 }
 
 impl<'a, T: 'a + Add<Output = T> + Copy + Zero, U: 'a> Sum<&'a Self> for Size2D<T, U> {
-    fn sum<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
+    fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
         iter.fold(Self::zero(), Add::add)
     }
 }
@@ -809,7 +809,7 @@ mod size2d {
             let sizes = [
                 Size2D::new(0.0, 1.0),
                 Size2D::new(1.0, 2.0),
-                Size2D::new(2.0, 3.0)
+                Size2D::new(2.0, 3.0),
             ];
             let sum = Size2D::new(3.0, 6.0);
             assert_eq!(sizes.iter().sum::<Size2D<_>>(), sum);
@@ -1357,7 +1357,6 @@ impl<T: PartialOrd, U> Size3D<T, U> {
         self.width >= other.width && self.height >= other.height && self.depth >= other.depth
     }
 
-
     /// Returns vector with results of "greater than" operation on each component.
     pub fn greater_than(self, other: Self) -> BoolVector3D {
         BoolVector3D {
@@ -1471,13 +1470,13 @@ impl<T: Copy + Add<T, Output = T>, U> Add<&Self> for Size3D<T, U> {
 }
 
 impl<T: Add<Output = T> + Zero, U> Sum for Size3D<T, U> {
-    fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::zero(), Add::add)
     }
 }
 
 impl<'a, T: 'a + Add<Output = T> + Copy + Zero, U: 'a> Sum<&'a Self> for Size3D<T, U> {
-    fn sum<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
+    fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
         iter.fold(Self::zero(), Add::add)
     }
 }
@@ -1706,7 +1705,7 @@ mod size3d {
             let sizes = [
                 Size3D::new(0.0, 1.0, 2.0),
                 Size3D::new(1.0, 2.0, 3.0),
-                Size3D::new(2.0, 3.0, 4.0)
+                Size3D::new(2.0, 3.0, 4.0),
             ];
             let sum = Size3D::new(3.0, 6.0, 9.0);
             assert_eq!(sizes.iter().sum::<Size3D<_>>(), sum);

--- a/src/transform2d.rs
+++ b/src/transform2d.rs
@@ -9,27 +9,28 @@
 
 #![cfg_attr(feature = "cargo-clippy", allow(just_underscores_and_digits))]
 
-use super::{UnknownUnit, Angle};
+use super::{Angle, UnknownUnit};
+use crate::approxeq::ApproxEq;
+use crate::box2d::Box2D;
+use crate::num::{One, Zero};
+use crate::point::{point2, Point2D};
+use crate::rect::Rect;
+use crate::transform3d::Transform3D;
+use crate::trig::Trig;
+use crate::vector::{vec2, Vector2D};
+use core::cmp::{Eq, PartialEq};
+use core::fmt;
+use core::hash::Hash;
+use core::marker::PhantomData;
+use core::ops::{Add, Div, Mul, Sub};
+
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Pod, Zeroable};
 #[cfg(feature = "mint")]
 use mint;
-use crate::num::{One, Zero};
-use crate::point::{Point2D, point2};
-use crate::vector::{Vector2D, vec2};
-use crate::rect::Rect;
-use crate::box2d::Box2D;
-use crate::transform3d::Transform3D;
-use core::ops::{Add, Mul, Div, Sub};
-use core::marker::PhantomData;
-use core::cmp::{Eq, PartialEq};
-use core::hash::{Hash};
-use crate::approxeq::ApproxEq;
-use crate::trig::Trig;
-use core::fmt;
 use num_traits::NumCast;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "bytemuck")]
-use bytemuck::{Zeroable, Pod};
 
 /// A 2d transform represented by a column-major 3 by 3 matrix, compressed down to 3 by 2.
 ///
@@ -63,6 +64,7 @@ use bytemuck::{Zeroable, Pod};
     feature = "serde",
     serde(bound(serialize = "T: Serialize", deserialize = "T: Deserialize<'de>"))
 )]
+#[rustfmt::skip]
 pub struct Transform2D<T, Src, Dst> {
     pub m11: T, pub m12: T,
     pub m21: T, pub m22: T,
@@ -76,11 +78,15 @@ impl<'a, T, Src, Dst> arbitrary::Arbitrary<'a> for Transform2D<T, Src, Dst>
 where
     T: arbitrary::Arbitrary<'a>,
 {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self>
-    {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let (m11, m12, m21, m22, m31, m32) = arbitrary::Arbitrary::arbitrary(u)?;
         Ok(Transform2D {
-            m11, m12, m21, m22, m31, m32,
+            m11,
+            m12,
+            m21,
+            m22,
+            m31,
+            m32,
             _unit: PhantomData,
         })
     }
@@ -153,6 +159,7 @@ impl<T, Src, Dst> Transform2D<T, Src, Dst> {
     ///   tx,  ty,
     /// );
     /// ```
+    #[rustfmt::skip]
     pub const fn new(m11: T, m12: T, m21: T, m22: T, m31: T, m32: T) -> Self {
         Transform2D {
             m11, m12,
@@ -170,7 +177,9 @@ impl<T, Src, Dst> Transform2D<T, Src, Dst> {
     /// [`ApproxEq::approx_eq()`]: ./approxeq/trait.ApproxEq.html#method.approx_eq
     #[inline]
     pub fn approx_eq(&self, other: &Self) -> bool
-    where T : ApproxEq<T> {
+    where
+        T: ApproxEq<T>,
+    {
         <Self as ApproxEq<T>>::approx_eq(&self, &other)
     }
 
@@ -197,6 +206,7 @@ impl<T: Copy, Src, Dst> Transform2D<T, Src, Dst> {
     /// For example the translation terms are found in the
     /// last two slots of the array.
     #[inline]
+    #[rustfmt::skip]
     pub fn to_array(&self) -> [T; 6] {
         [
             self.m11, self.m12,
@@ -214,6 +224,7 @@ impl<T: Copy, Src, Dst> Transform2D<T, Src, Dst> {
     /// For example the translation terms are found at indices 2 and 5
     /// in the array.
     #[inline]
+    #[rustfmt::skip]
     pub fn to_array_transposed(&self) -> [T; 6] {
         [
             self.m11, self.m21, self.m31,
@@ -239,6 +250,7 @@ impl<T: Copy, Src, Dst> Transform2D<T, Src, Dst> {
     /// column-major-column-vector matrix notation (the same order
     /// as `Transform2D::new`).
     #[inline]
+    #[rustfmt::skip]
     pub fn from_array(array: [T; 6]) -> Self {
         Self::new(
             array[0], array[1],
@@ -254,6 +266,7 @@ impl<T: Copy, Src, Dst> Transform2D<T, Src, Dst> {
     /// column-major-column-vector matrix notation (the same order
     /// as `Transform3D::new`).
     #[inline]
+    #[rustfmt::skip]
     pub fn from_arrays(array: [[T; 2]; 3]) -> Self {
         Self::new(
             array[0][0], array[0][1],
@@ -264,6 +277,7 @@ impl<T: Copy, Src, Dst> Transform2D<T, Src, Dst> {
 
     /// Drop the units, preserving only the numeric value.
     #[inline]
+    #[rustfmt::skip]
     pub fn to_untyped(&self) -> Transform2D<T, UnknownUnit, UnknownUnit> {
         Transform2D::new(
             self.m11, self.m12,
@@ -274,6 +288,7 @@ impl<T: Copy, Src, Dst> Transform2D<T, Src, Dst> {
 
     /// Tag a unitless value with units.
     #[inline]
+    #[rustfmt::skip]
     pub fn from_untyped(p: &Transform2D<T, UnknownUnit, UnknownUnit>) -> Self {
         Transform2D::new(
             p.m11, p.m12,
@@ -284,6 +299,7 @@ impl<T: Copy, Src, Dst> Transform2D<T, Src, Dst> {
 
     /// Returns the same transform with a different source unit.
     #[inline]
+    #[rustfmt::skip]
     pub fn with_source<NewSrc>(&self) -> Transform2D<T, NewSrc, Dst> {
         Transform2D::new(
             self.m11, self.m12,
@@ -294,6 +310,7 @@ impl<T: Copy, Src, Dst> Transform2D<T, Src, Dst> {
 
     /// Returns the same transform with a different destination unit.
     #[inline]
+    #[rustfmt::skip]
     pub fn with_destination<NewDst>(&self) -> Transform2D<T, Src, NewDst> {
         Transform2D::new(
             self.m11, self.m12,
@@ -319,6 +336,7 @@ impl<T: NumCast + Copy, Src, Dst> Transform2D<T, Src, Dst> {
     }
 
     /// Fallible cast from one numeric representation to another, preserving the units.
+    #[rustfmt::skip]
     pub fn try_cast<NewT: NumCast>(&self) -> Option<Transform2D<NewT, Src, Dst>> {
         match (NumCast::from(self.m11), NumCast::from(self.m12),
                NumCast::from(self.m21), NumCast::from(self.m22),
@@ -364,7 +382,6 @@ where
     }
 }
 
-
 /// Methods for combining generic transformations
 impl<T, Src, Dst> Transform2D<T, Src, Dst>
 where
@@ -373,6 +390,7 @@ where
     /// Returns the multiplication of the two matrices such that mat's transformation
     /// applies after self's transformation.
     #[must_use]
+    #[rustfmt::skip]
     pub fn then<NewDst>(&self, mat: &Transform2D<T, Dst, NewDst>) -> Transform2D<T, Src, NewDst> {
         Transform2D::new(
             self.m11 * mat.m11 + self.m12 * mat.m21,
@@ -400,6 +418,7 @@ where
     /// x y
     /// ```
     #[inline]
+    #[rustfmt::skip]
     pub fn translation(x: T, y: T) -> Self {
         let _0 = || T::zero();
         let _1 = || T::one();
@@ -439,6 +458,7 @@ where
 {
     /// Returns a rotation transform.
     #[inline]
+    #[rustfmt::skip]
     pub fn rotation(theta: Angle<T>) -> Self {
         let _0 = Zero::zero();
         let cos = theta.get().cos();
@@ -475,6 +495,7 @@ impl<T, Src, Dst> Transform2D<T, Src, Dst> {
     /// 0 0
     /// ```
     #[inline]
+    #[rustfmt::skip]
     pub fn scale(x: T, y: T) -> Self
     where
         T: Zero,
@@ -501,6 +522,7 @@ impl<T, Src, Dst> Transform2D<T, Src, Dst> {
     /// Applies a scale before self's transformation and returns the resulting transform.
     #[inline]
     #[must_use]
+    #[rustfmt::skip]
     pub fn pre_scale(&self, x: T, y: T) -> Self
     where
         T: Copy + Mul<Output = T>,
@@ -524,7 +546,7 @@ where
     pub fn transform_point(&self, point: Point2D<T, Src>) -> Point2D<T, Dst> {
         Point2D::new(
             point.x * self.m11 + point.y * self.m21 + self.m31,
-            point.x * self.m12 + point.y * self.m22 + self.m32
+            point.x * self.m12 + point.y * self.m22 + self.m32,
         )
     }
 
@@ -532,8 +554,10 @@ where
     #[inline]
     #[must_use]
     pub fn transform_vector(&self, vec: Vector2D<T, Src>) -> Vector2D<T, Dst> {
-        vec2(vec.x * self.m11 + vec.y * self.m21,
-             vec.x * self.m12 + vec.y * self.m22)
+        vec2(
+            vec.x * self.m11 + vec.y * self.m21,
+            vec.x * self.m12 + vec.y * self.m22,
+        )
     }
 
     /// Returns a rectangle that encompasses the result of transforming the given rectangle by this
@@ -554,7 +578,6 @@ where
         ])
     }
 
-
     /// Returns a box that encompasses the result of transforming the given box by this
     /// transform.
     #[inline]
@@ -571,7 +594,6 @@ where
         ])
     }
 }
-
 
 impl<T, Src, Dst> Transform2D<T, Src, Dst>
 where
@@ -597,7 +619,7 @@ where
         let _1: T = One::one();
 
         if det == _0 {
-          return None;
+            return None;
         }
 
         let inv_det = _1 / det;
@@ -612,8 +634,9 @@ where
     }
 }
 
-impl <T, Src, Dst> Default for Transform2D<T, Src, Dst>
-    where T: Zero + One
+impl<T, Src, Dst> Default for Transform2D<T, Src, Dst>
+where
+    T: Zero + One,
 {
     /// Returns the [identity transform](#method.identity).
     fn default() -> Self {
@@ -623,21 +646,26 @@ impl <T, Src, Dst> Default for Transform2D<T, Src, Dst>
 
 impl<T: ApproxEq<T>, Src, Dst> ApproxEq<T> for Transform2D<T, Src, Dst> {
     #[inline]
-    fn approx_epsilon() -> T { T::approx_epsilon() }
+    fn approx_epsilon() -> T {
+        T::approx_epsilon()
+    }
 
     /// Returns true is this transform is approximately equal to the other one, using
     /// a provided epsilon value.
     fn approx_eq_eps(&self, other: &Self, eps: &T) -> bool {
-        self.m11.approx_eq_eps(&other.m11, eps) && self.m12.approx_eq_eps(&other.m12, eps) &&
-        self.m21.approx_eq_eps(&other.m21, eps) && self.m22.approx_eq_eps(&other.m22, eps) &&
-        self.m31.approx_eq_eps(&other.m31, eps) && self.m32.approx_eq_eps(&other.m32, eps)
+        self.m11.approx_eq_eps(&other.m11, eps)
+            && self.m12.approx_eq_eps(&other.m12, eps)
+            && self.m21.approx_eq_eps(&other.m21, eps)
+            && self.m22.approx_eq_eps(&other.m22, eps)
+            && self.m31.approx_eq_eps(&other.m31, eps)
+            && self.m32.approx_eq_eps(&other.m32, eps)
     }
 }
 
 impl<T, Src, Dst> fmt::Debug for Transform2D<T, Src, Dst>
-where T: Copy + fmt::Debug +
-         PartialEq +
-         One + Zero {
+where
+    T: Copy + fmt::Debug + PartialEq + One + Zero,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.is_identity() {
             write!(f, "[I]")
@@ -649,6 +677,7 @@ where T: Copy + fmt::Debug +
 
 #[cfg(feature = "mint")]
 impl<T, Src, Dst> From<mint::RowMatrix3x2<T>> for Transform2D<T, Src, Dst> {
+    #[rustfmt::skip]
     fn from(m: mint::RowMatrix3x2<T>) -> Self {
         Transform2D {
             m11: m.x.x, m12: m.x.y,
@@ -669,12 +698,11 @@ impl<T, Src, Dst> From<Transform2D<T, Src, Dst>> for mint::RowMatrix3x2<T> {
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::default;
     use crate::approxeq::ApproxEq;
+    use crate::default;
     #[cfg(feature = "mint")]
     use mint;
 
@@ -682,7 +710,9 @@ mod test {
 
     type Mat = default::Transform2D<f32>;
 
-    fn rad(v: f32) -> Angle<f32> { Angle::radians(v) }
+    fn rad(v: f32) -> Angle<f32> {
+        Angle::radians(v)
+    }
 
     #[test]
     pub fn test_translation() {
@@ -692,7 +722,10 @@ mod test {
         assert_eq!(t1, t2);
         assert_eq!(t1, t3);
 
-        assert_eq!(t1.transform_point(Point2D::new(1.0, 1.0)), Point2D::new(2.0, 3.0));
+        assert_eq!(
+            t1.transform_point(Point2D::new(1.0, 1.0)),
+            Point2D::new(2.0, 3.0)
+        );
 
         assert_eq!(t1.then(&t1), Mat::translation(2.0, 4.0));
     }
@@ -705,9 +738,11 @@ mod test {
         assert_eq!(r1, r2);
         assert_eq!(r1, r3);
 
-        assert!(r1.transform_point(Point2D::new(1.0, 2.0)).approx_eq(&Point2D::new(-2.0, 1.0)));
+        assert!(r1
+            .transform_point(Point2D::new(1.0, 2.0))
+            .approx_eq(&Point2D::new(-2.0, 1.0)));
 
-        assert!(r1.then(&r1).approx_eq(&Mat::rotation(rad(FRAC_PI_2*2.0))));
+        assert!(r1.then(&r1).approx_eq(&Mat::rotation(rad(FRAC_PI_2 * 2.0))));
     }
 
     #[test]
@@ -718,9 +753,10 @@ mod test {
         assert_eq!(s1, s2);
         assert_eq!(s1, s3);
 
-        assert!(s1.transform_point(Point2D::new(2.0, 2.0)).approx_eq(&Point2D::new(4.0, 6.0)));
+        assert!(s1
+            .transform_point(Point2D::new(2.0, 2.0))
+            .approx_eq(&Point2D::new(4.0, 6.0)));
     }
-
 
     #[test]
     pub fn test_pre_then_scale() {
@@ -760,8 +796,12 @@ mod test {
 
     #[test]
     pub fn test_pre_post() {
-        let m1 = default::Transform2D::identity().then_scale(1.0, 2.0).then_translate(vec2(1.0, 2.0));
-        let m2 = default::Transform2D::identity().pre_translate(vec2(1.0, 2.0)).pre_scale(1.0, 2.0);
+        let m1 = default::Transform2D::identity()
+            .then_scale(1.0, 2.0)
+            .then_translate(vec2(1.0, 2.0));
+        let m2 = default::Transform2D::identity()
+            .pre_translate(vec2(1.0, 2.0))
+            .pre_scale(1.0, 2.0);
         assert!(m1.approx_eq(&m2));
 
         let r = Mat::rotation(rad(FRAC_PI_2));
@@ -769,16 +809,25 @@ mod test {
 
         let a = Point2D::new(1.0, 1.0);
 
-        assert!(r.then(&t).transform_point(a).approx_eq(&Point2D::new(1.0, 4.0)));
-        assert!(t.then(&r).transform_point(a).approx_eq(&Point2D::new(-4.0, 3.0)));
-        assert!(t.then(&r).transform_point(a).approx_eq(&r.transform_point(t.transform_point(a))));
+        assert!(r
+            .then(&t)
+            .transform_point(a)
+            .approx_eq(&Point2D::new(1.0, 4.0)));
+        assert!(t
+            .then(&r)
+            .transform_point(a)
+            .approx_eq(&Point2D::new(-4.0, 3.0)));
+        assert!(t
+            .then(&r)
+            .transform_point(a)
+            .approx_eq(&r.transform_point(t.transform_point(a))));
     }
 
     #[test]
     fn test_size_of() {
         use core::mem::size_of;
-        assert_eq!(size_of::<default::Transform2D<f32>>(), 6*size_of::<f32>());
-        assert_eq!(size_of::<default::Transform2D<f64>>(), 6*size_of::<f64>());
+        assert_eq!(size_of::<default::Transform2D<f32>>(), 6 * size_of::<f32>());
+        assert_eq!(size_of::<default::Transform2D<f64>>(), 6 * size_of::<f64>());
     }
 
     #[test]

--- a/src/transform2d.rs
+++ b/src/transform2d.rs
@@ -117,20 +117,22 @@ impl<T: Clone, Src, Dst> Clone for Transform2D<T, Src, Dst> {
 impl<T, Src, Dst> Eq for Transform2D<T, Src, Dst> where T: Eq {}
 
 impl<T, Src, Dst> PartialEq for Transform2D<T, Src, Dst>
-    where T: PartialEq
+where
+    T: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.m11 == other.m11 &&
-            self.m12 == other.m12 &&
-            self.m21 == other.m21 &&
-            self.m22 == other.m22 &&
-            self.m31 == other.m31 &&
-            self.m32 == other.m32
+        self.m11 == other.m11
+            && self.m12 == other.m12
+            && self.m21 == other.m21
+            && self.m22 == other.m22
+            && self.m31 == other.m31
+            && self.m32 == other.m32
     }
 }
 
 impl<T, Src, Dst> Hash for Transform2D<T, Src, Dst>
-    where T: Hash
+where
+    T: Hash,
 {
     fn hash<H: core::hash::Hasher>(&self, h: &mut H) {
         self.m11.hash(h);
@@ -141,7 +143,6 @@ impl<T, Src, Dst> Hash for Transform2D<T, Src, Dst>
         self.m32.hash(h);
     }
 }
-
 
 impl<T, Src, Dst> Transform2D<T, Src, Dst> {
     /// Create a transform specifying its components in using the column-major-column-vector
@@ -191,7 +192,9 @@ impl<T, Src, Dst> Transform2D<T, Src, Dst> {
     /// [`ApproxEq::approx_eq_eps()`]: ./approxeq/trait.ApproxEq.html#method.approx_eq_eps
     #[inline]
     pub fn approx_eq_eps(&self, other: &Self, eps: &T) -> bool
-    where T : ApproxEq<T> {
+    where
+        T: ApproxEq<T>,
+    {
         <Self as ApproxEq<T>>::approx_eq_eps(&self, &other, &eps)
     }
 }

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -75,14 +75,12 @@ pub struct Transform3D<T, Src, Dst> {
     pub _unit: PhantomData<(Src, Dst)>,
 }
 
-
 #[cfg(feature = "arbitrary")]
 impl<'a, T, Src, Dst> arbitrary::Arbitrary<'a> for Transform3D<T, Src, Dst>
 where
     T: arbitrary::Arbitrary<'a>,
 {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self>
-    {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let (m11, m12, m13, m14) = arbitrary::Arbitrary::arbitrary(u)?;
         let (m21, m22, m23, m24) = arbitrary::Arbitrary::arbitrary(u)?;
         let (m31, m32, m33, m34) = arbitrary::Arbitrary::arbitrary(u)?;
@@ -145,30 +143,32 @@ impl<T: Clone, Src, Dst> Clone for Transform3D<T, Src, Dst> {
 impl<T, Src, Dst> Eq for Transform3D<T, Src, Dst> where T: Eq {}
 
 impl<T, Src, Dst> PartialEq for Transform3D<T, Src, Dst>
-    where T: PartialEq
+where
+    T: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.m11 == other.m11 &&
-            self.m12 == other.m12 &&
-            self.m13 == other.m13 &&
-            self.m14 == other.m14 &&
-            self.m21 == other.m21 &&
-            self.m22 == other.m22 &&
-            self.m23 == other.m23 &&
-            self.m24 == other.m24 &&
-            self.m31 == other.m31 &&
-            self.m32 == other.m32 &&
-            self.m33 == other.m33 &&
-            self.m34 == other.m34 &&
-            self.m41 == other.m41 &&
-            self.m42 == other.m42 &&
-            self.m43 == other.m43 &&
-            self.m44 == other.m44
+        self.m11 == other.m11
+            && self.m12 == other.m12
+            && self.m13 == other.m13
+            && self.m14 == other.m14
+            && self.m21 == other.m21
+            && self.m22 == other.m22
+            && self.m23 == other.m23
+            && self.m24 == other.m24
+            && self.m31 == other.m31
+            && self.m32 == other.m32
+            && self.m33 == other.m33
+            && self.m34 == other.m34
+            && self.m41 == other.m41
+            && self.m42 == other.m42
+            && self.m43 == other.m43
+            && self.m44 == other.m44
     }
 }
 
 impl<T, Src, Dst> Hash for Transform3D<T, Src, Dst>
-    where T: Hash
+where
+    T: Hash,
 {
     fn hash<H: core::hash::Hasher>(&self, h: &mut H) {
         self.m11.hash(h);
@@ -189,7 +189,6 @@ impl<T, Src, Dst> Hash for Transform3D<T, Src, Dst>
         self.m44.hash(h);
     }
 }
-
 
 impl<T, Src, Dst> Transform3D<T, Src, Dst> {
     /// Create a transform specifying all of it's component as a 4 by 4 matrix.
@@ -326,7 +325,7 @@ impl<T: Copy, Src, Dst> Transform3D<T, Src, Dst> {
             [self.m11, self.m12, self.m13, self.m14],
             [self.m21, self.m22, self.m23, self.m24],
             [self.m31, self.m32, self.m33, self.m34],
-            [self.m41, self.m42, self.m43, self.m44]
+            [self.m41, self.m42, self.m43, self.m44],
         ]
     }
 
@@ -339,7 +338,7 @@ impl<T: Copy, Src, Dst> Transform3D<T, Src, Dst> {
             [self.m11, self.m21, self.m31, self.m41],
             [self.m12, self.m22, self.m32, self.m42],
             [self.m13, self.m23, self.m33, self.m43],
-            [self.m14, self.m24, self.m34, self.m44]
+            [self.m14, self.m24, self.m34, self.m44],
         ]
     }
 
@@ -432,15 +431,11 @@ impl<T: Copy, Src, Dst> Transform3D<T, Src, Dst> {
     ///
     /// [`self.is_2d()`]: #method.is_2d
     pub fn to_2d(&self) -> Transform2D<T, Src, Dst> {
-        Transform2D::new(
-            self.m11, self.m12,
-            self.m21, self.m22,
-            self.m41, self.m42
-        )
+        Transform2D::new(self.m11, self.m12, self.m21, self.m22, self.m41, self.m42)
     }
 }
 
-impl <T, Src, Dst> Transform3D<T, Src, Dst>
+impl<T, Src, Dst> Transform3D<T, Src, Dst>
 where
     T: Zero + One,
 {
@@ -506,17 +501,28 @@ where
         let _1 = || T::one();
 
         Self::new(
-            _1(), _0(), _0(),  _0(),
-            _0(), _1(), _0(),  _0(),
-            _0(), _0(), _1(), -_1() / d,
-            _0(), _0(), _0(),  _1(),
+            _1(),
+            _0(),
+            _0(),
+            _0(),
+            _0(),
+            _1(),
+            _0(),
+            _0(),
+            _0(),
+            _0(),
+            _1(),
+            -_1() / d,
+            _0(),
+            _0(),
+            _0(),
+            _1(),
         )
     }
 }
 
-
 /// Methods for combining generic transformations
-impl <T, Src, Dst> Transform3D<T, Src, Dst>
+impl<T, Src, Dst> Transform3D<T, Src, Dst>
 where
     T: Copy + Add<Output = T> + Mul<Output = T>,
 {

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -9,30 +9,32 @@
 
 #![cfg_attr(feature = "cargo-clippy", allow(just_underscores_and_digits))]
 
-use super::{UnknownUnit, Angle};
+use super::{Angle, UnknownUnit};
 use crate::approxeq::ApproxEq;
-use crate::homogen::HomogeneousVector;
-#[cfg(feature = "mint")]
-use mint;
-use crate::trig::Trig;
-use crate::point::{Point2D, point2, Point3D, point3};
-use crate::vector::{Vector2D, Vector3D, vec2, vec3};
-use crate::rect::Rect;
 use crate::box2d::Box2D;
 use crate::box3d::Box3D;
-use crate::transform2d::Transform2D;
-use crate::scale::Scale;
+use crate::homogen::HomogeneousVector;
 use crate::num::{One, Zero};
-use core::ops::{Add, Mul, Sub, Div, Neg};
-use core::marker::PhantomData;
-use core::fmt;
+use crate::point::{point2, point3, Point2D, Point3D};
+use crate::rect::Rect;
+use crate::scale::Scale;
+use crate::transform2d::Transform2D;
+use crate::trig::Trig;
+use crate::vector::{vec2, vec3, Vector2D, Vector3D};
+
 use core::cmp::{Eq, PartialEq};
-use core::hash::{Hash};
+use core::fmt;
+use core::hash::Hash;
+use core::marker::PhantomData;
+use core::ops::{Add, Div, Mul, Neg, Sub};
+
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Pod, Zeroable};
+#[cfg(feature = "mint")]
+use mint;
 use num_traits::NumCast;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "bytemuck")]
-use bytemuck::{Zeroable, Pod};
 
 /// A 3d transform stored as a column-major 4 by 4 matrix.
 ///
@@ -63,6 +65,7 @@ use bytemuck::{Zeroable, Pod};
     feature = "serde",
     serde(bound(serialize = "T: Serialize", deserialize = "T: Deserialize<'de>"))
 )]
+#[rustfmt::skip]
 pub struct Transform3D<T, Src, Dst> {
     pub m11: T, pub m12: T, pub m13: T, pub m14: T,
     pub m21: T, pub m22: T, pub m23: T, pub m24: T,
@@ -208,6 +211,7 @@ impl<T, Src, Dst> Transform3D<T, Src, Dst> {
     /// ```
     #[inline]
     #[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
+    #[rustfmt::skip]
     pub const fn new(
         m11: T, m12: T, m13: T, m14: T,
         m21: T, m22: T, m23: T, m24: T,
@@ -236,6 +240,7 @@ impl<T, Src, Dst> Transform3D<T, Src, Dst> {
     /// m41  m42   0   1
     /// ```
     #[inline]
+    #[rustfmt::skip]
     pub fn new_2d(m11: T, m12: T, m21: T, m22: T, m41: T, m42: T) -> Self
     where
         T: Zero + One,
@@ -251,7 +256,6 @@ impl<T, Src, Dst> Transform3D<T, Src, Dst> {
        )
     }
 
-
     /// Returns `true` if this transform can be represented with a `Transform2D`.
     ///
     /// See <https://drafts.csswg.org/css-transforms/#2d-transform>
@@ -261,11 +265,16 @@ impl<T, Src, Dst> Transform3D<T, Src, Dst> {
         T: Zero + One + PartialEq,
     {
         let (_0, _1): (T, T) = (Zero::zero(), One::one());
-        self.m31 == _0 && self.m32 == _0 &&
-        self.m13 == _0 && self.m23 == _0 &&
-        self.m43 == _0 && self.m14 == _0 &&
-        self.m24 == _0 && self.m34 == _0 &&
-        self.m33 == _1 && self.m44 == _1
+        self.m31 == _0
+            && self.m32 == _0
+            && self.m13 == _0
+            && self.m23 == _0
+            && self.m43 == _0
+            && self.m14 == _0
+            && self.m24 == _0
+            && self.m34 == _0
+            && self.m33 == _1
+            && self.m44 == _1
     }
 }
 
@@ -279,6 +288,7 @@ impl<T: Copy, Src, Dst> Transform3D<T, Src, Dst> {
     /// For example the translation terms are found on the
     /// 13th, 14th and 15th slots of the array.
     #[inline]
+    #[rustfmt::skip]
     pub fn to_array(&self) -> [T; 16] {
         [
             self.m11, self.m12, self.m13, self.m14,
@@ -297,6 +307,7 @@ impl<T: Copy, Src, Dst> Transform3D<T, Src, Dst> {
     /// For example the translation terms are found at indices 3, 7 and 11
     /// of the array.
     #[inline]
+    #[rustfmt::skip]
     pub fn to_array_transposed(&self) -> [T; 16] {
         [
             self.m11, self.m21, self.m31, self.m41,
@@ -309,6 +320,7 @@ impl<T: Copy, Src, Dst> Transform3D<T, Src, Dst> {
     /// Equivalent to `to_array` with elements packed four at a time
     /// in an array of arrays.
     #[inline]
+    #[rustfmt::skip]
     pub fn to_arrays(&self) -> [[T; 4]; 4] {
         [
             [self.m11, self.m12, self.m13, self.m14],
@@ -321,6 +333,7 @@ impl<T: Copy, Src, Dst> Transform3D<T, Src, Dst> {
     /// Equivalent to `to_array_transposed` with elements packed
     /// four at a time in an array of arrays.
     #[inline]
+    #[rustfmt::skip]
     pub fn to_arrays_transposed(&self) -> [[T; 4]; 4] {
         [
             [self.m11, self.m21, self.m31, self.m41],
@@ -337,6 +350,7 @@ impl<T: Copy, Src, Dst> Transform3D<T, Src, Dst> {
     /// column-major-column-vector matrix notation (the same order
     /// as `Transform3D::new`).
     #[inline]
+    #[rustfmt::skip]
     pub fn from_array(array: [T; 16]) -> Self {
         Self::new(
             array[0],  array[1],  array[2],  array[3],
@@ -353,6 +367,7 @@ impl<T: Copy, Src, Dst> Transform3D<T, Src, Dst> {
     /// column-major-column-vector matrix notation (the same order
     /// as `Transform3D::new`).
     #[inline]
+    #[rustfmt::skip]
     pub fn from_arrays(array: [[T; 4]; 4]) -> Self {
         Self::new(
             array[0][0], array[0][1], array[0][2], array[0][3],
@@ -364,6 +379,7 @@ impl<T: Copy, Src, Dst> Transform3D<T, Src, Dst> {
 
     /// Tag a unitless value with units.
     #[inline]
+    #[rustfmt::skip]
     pub fn from_untyped(m: &Transform3D<T, UnknownUnit, UnknownUnit>) -> Self {
         Transform3D::new(
             m.m11, m.m12, m.m13, m.m14,
@@ -375,6 +391,7 @@ impl<T: Copy, Src, Dst> Transform3D<T, Src, Dst> {
 
     /// Drop the units, preserving only the numeric value.
     #[inline]
+    #[rustfmt::skip]
     pub fn to_untyped(&self) -> Transform3D<T, UnknownUnit, UnknownUnit> {
         Transform3D::new(
             self.m11, self.m12, self.m13, self.m14,
@@ -386,6 +403,7 @@ impl<T: Copy, Src, Dst> Transform3D<T, Src, Dst> {
 
     /// Returns the same transform with a different source unit.
     #[inline]
+    #[rustfmt::skip]
     pub fn with_source<NewSrc>(&self) -> Transform3D<T, NewSrc, Dst> {
         Transform3D::new(
             self.m11, self.m12, self.m13, self.m14,
@@ -397,6 +415,7 @@ impl<T: Copy, Src, Dst> Transform3D<T, Src, Dst> {
 
     /// Returns the same transform with a different destination unit.
     #[inline]
+    #[rustfmt::skip]
     pub fn with_destination<NewDst>(&self) -> Transform3D<T, Src, NewDst> {
         Transform3D::new(
             self.m11, self.m12, self.m13, self.m14,
@@ -452,6 +471,7 @@ where
     /// Create a 2d skew transform.
     ///
     /// See <https://drafts.csswg.org/css-transforms/#funcdef-skew>
+    #[rustfmt::skip]
     pub fn skew(alpha: Angle<T>, beta: Angle<T>) -> Self
     where
         T: Trig,
@@ -505,6 +525,7 @@ where
     ///
     /// Assuming row vectors, this is equivalent to self * mat
     #[must_use]
+    #[rustfmt::skip]
     pub fn then<NewDst>(&self, other: &Transform3D<T, Dst, NewDst>) -> Transform3D<T, Src, NewDst> {
         Transform3D::new(
             self.m11 * other.m11  +  self.m12 * other.m21  +  self.m13 * other.m31  +  self.m14 * other.m41,
@@ -531,7 +552,7 @@ where
 }
 
 /// Methods for creating and combining translation transformations
-impl <T, Src, Dst> Transform3D<T, Src, Dst>
+impl<T, Src, Dst> Transform3D<T, Src, Dst>
 where
     T: Zero + One,
 {
@@ -544,6 +565,7 @@ where
     /// x y z 1
     /// ```
     #[inline]
+    #[rustfmt::skip]
     pub fn translation(x: T, y: T, z: T) -> Self {
         let _0 = || T::zero();
         let _1 = || T::one();
@@ -578,10 +600,18 @@ where
 /// Methods for creating and combining rotation transformations
 impl<T, Src, Dst> Transform3D<T, Src, Dst>
 where
-    T: Copy + Add<Output = T> + Sub<Output = T> + Mul<Output = T> + Div<Output = T> + Zero + One + Trig,
+    T: Copy
+        + Add<Output = T>
+        + Sub<Output = T>
+        + Mul<Output = T>
+        + Div<Output = T>
+        + Zero
+        + One
+        + Trig,
 {
     /// Create a 3d rotation transform from an angle / axis.
     /// The supplied axis must be normalized.
+    #[rustfmt::skip]
     pub fn rotation(x: T, y: T, z: T, theta: Angle<T>) -> Self {
         let (_0, _1): (T, T) = (Zero::zero(), One::one());
         let _2 = _1 + _1;
@@ -645,6 +675,7 @@ where
     /// 0 0 0 1
     /// ```
     #[inline]
+    #[rustfmt::skip]
     pub fn scale(x: T, y: T, z: T) -> Self {
         let _0 = || T::zero();
         let _1 = || T::one();
@@ -659,6 +690,7 @@ where
 
     /// Returns a transform with a scale applied before self's transformation.
     #[must_use]
+    #[rustfmt::skip]
     pub fn pre_scale(&self, x: T, y: T, z: T) -> Self
     where
         T: Copy + Add<Output = T> + Mul<Output = T>,
@@ -690,6 +722,7 @@ where
     ///
     /// The input point must be use the unit Src, and the returned point has the unit Dst.
     #[inline]
+    #[rustfmt::skip]
     pub fn transform_point2d_homogeneous(
         &self, p: Point2D<T, Src>
     ) -> HomogeneousVector<T, Dst> {
@@ -737,9 +770,7 @@ where
     ///
     /// The input point must be use the unit Src, and the returned point has the unit Dst.
     #[inline]
-    pub fn transform_point3d_homogeneous(
-        &self, p: Point3D<T, Src>
-    ) -> HomogeneousVector<T, Dst> {
+    pub fn transform_point3d_homogeneous(&self, p: Point3D<T, Src>) -> HomogeneousVector<T, Dst> {
         let x = p.x * self.m11 + p.y * self.m21 + p.z * self.m31 + self.m41;
         let y = p.x * self.m12 + p.y * self.m22 + p.z * self.m32 + self.m42;
         let z = p.x * self.m13 + p.y * self.m23 + p.z * self.m33 + self.m43;
@@ -821,18 +852,20 @@ where
     }
 }
 
-
-impl <T, Src, Dst> Transform3D<T, Src, Dst>
-where T: Copy +
-         Add<T, Output=T> +
-         Sub<T, Output=T> +
-         Mul<T, Output=T> +
-         Div<T, Output=T> +
-         Neg<Output=T> +
-         PartialOrd +
-         One + Zero {
-
+impl<T, Src, Dst> Transform3D<T, Src, Dst>
+where
+    T: Copy
+        + Add<T, Output = T>
+        + Sub<T, Output = T>
+        + Mul<T, Output = T>
+        + Div<T, Output = T>
+        + Neg<Output = T>
+        + PartialOrd
+        + One
+        + Zero,
+{
     /// Create an orthogonal projection transform.
+    #[rustfmt::skip]
     pub fn ortho(left: T, right: T,
                  bottom: T, top: T,
                  near: T, far: T) -> Self {
@@ -852,6 +885,7 @@ where T: Copy +
 
     /// Check whether shapes on the XY plane with Z pointing towards the
     /// screen transformed by this matrix would be facing back.
+    #[rustfmt::skip]
     pub fn is_backface_visible(&self) -> bool {
         // inverse().m33 < 0;
         let det = self.determinant();
@@ -878,6 +912,7 @@ where T: Copy +
 
         // todo(gw): this could be made faster by special casing
         // for simpler transform types.
+        #[rustfmt::skip]
         let m = Transform3D::new(
             self.m23*self.m34*self.m42 - self.m24*self.m33*self.m42 +
             self.m24*self.m32*self.m43 - self.m22*self.m34*self.m43 -
@@ -949,6 +984,7 @@ where T: Copy +
     }
 
     /// Compute the determinant of the transform.
+    #[rustfmt::skip]
     pub fn determinant(&self) -> T {
         self.m14 * self.m23 * self.m32 * self.m41 -
         self.m13 * self.m24 * self.m32 * self.m41 -
@@ -978,6 +1014,7 @@ where T: Copy +
 
     /// Multiplies all of the transform's component by a scalar and returns the result.
     #[must_use]
+    #[rustfmt::skip]
     pub fn mul_s(&self, x: T) -> Self {
         Transform3D::new(
             self.m11 * x, self.m12 * x, self.m13 * x, self.m14 * x,
@@ -993,7 +1030,7 @@ where T: Copy +
     }
 }
 
-impl <T, Src, Dst> Transform3D<T, Src, Dst>
+impl<T, Src, Dst> Transform3D<T, Src, Dst>
 where
     T: Copy + Mul<Output = T> + Div<Output = T> + Zero + One + PartialEq,
 {
@@ -1020,14 +1057,14 @@ where
         // a true 2D matrix by normalizing out the scaling effect of m44 on
         // the remaining components ahead of time.
         if self.m14 == _0 && self.m24 == _0 && self.m44 != _0 && self.m44 != _1 {
-           let scale = _1 / self.m44;
-           result.m11 = result.m11 * scale;
-           result.m12 = result.m12 * scale;
-           result.m21 = result.m21 * scale;
-           result.m22 = result.m22 * scale;
-           result.m41 = result.m41 * scale;
-           result.m42 = result.m42 * scale;
-           result.m44 = _1;
+            let scale = _1 / self.m44;
+            result.m11 = result.m11 * scale;
+            result.m12 = result.m12 * scale;
+            result.m21 = result.m21 * scale;
+            result.m22 = result.m22 * scale;
+            result.m41 = result.m41 * scale;
+            result.m42 = result.m42 * scale;
+            result.m44 = _1;
         }
 
         result
@@ -1042,6 +1079,7 @@ impl<T: NumCast + Copy, Src, Dst> Transform3D<T, Src, Dst> {
     }
 
     /// Fallible cast from one numeric representation to another, preserving the units.
+    #[rustfmt::skip]
     pub fn try_cast<NewT: NumCast>(&self) -> Option<Transform3D<NewT, Src, Dst>> {
         match (NumCast::from(self.m11), NumCast::from(self.m12),
                NumCast::from(self.m13), NumCast::from(self.m14),
@@ -1056,9 +1094,9 @@ impl<T: NumCast + Copy, Src, Dst> Transform3D<T, Src, Dst> {
              Some(m31), Some(m32), Some(m33), Some(m34),
              Some(m41), Some(m42), Some(m43), Some(m44)) => {
                 Some(Transform3D::new(m11, m12, m13, m14,
-                                                 m21, m22, m23, m24,
-                                                 m31, m32, m33, m34,
-                                                 m41, m42, m43, m44))
+                                      m21, m22, m23, m24,
+                                      m31, m32, m33, m34,
+                                      m41, m42, m43, m44))
             },
             _ => None
         }
@@ -1089,11 +1127,13 @@ impl<T: ApproxEq<T>, Src, Dst> Transform3D<T, Src, Dst> {
     }
 }
 
-
 impl<T: ApproxEq<T>, Src, Dst> ApproxEq<T> for Transform3D<T, Src, Dst> {
     #[inline]
-    fn approx_epsilon() -> T { T::approx_epsilon() }
+    fn approx_epsilon() -> T {
+        T::approx_epsilon()
+    }
 
+    #[rustfmt::skip]
     fn approx_eq_eps(&self, other: &Self, eps: &T) -> bool {
         self.m11.approx_eq_eps(&other.m11, eps) && self.m12.approx_eq_eps(&other.m12, eps) &&
         self.m13.approx_eq_eps(&other.m13, eps) && self.m14.approx_eq_eps(&other.m14, eps) &&
@@ -1106,8 +1146,9 @@ impl<T: ApproxEq<T>, Src, Dst> ApproxEq<T> for Transform3D<T, Src, Dst> {
     }
 }
 
-impl <T, Src, Dst> Default for Transform3D<T, Src, Dst>
-    where T: Zero + One
+impl<T, Src, Dst> Default for Transform3D<T, Src, Dst>
+where
+    T: Zero + One,
 {
     /// Returns the [identity transform](#method.identity).
     fn default() -> Self {
@@ -1116,9 +1157,9 @@ impl <T, Src, Dst> Default for Transform3D<T, Src, Dst>
 }
 
 impl<T, Src, Dst> fmt::Debug for Transform3D<T, Src, Dst>
-where T: Copy + fmt::Debug +
-         PartialEq +
-         One + Zero {
+where
+    T: Copy + fmt::Debug + PartialEq + One + Zero,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.is_identity() {
             write!(f, "[I]")
@@ -1130,6 +1171,7 @@ where T: Copy + fmt::Debug +
 
 #[cfg(feature = "mint")]
 impl<T, Src, Dst> From<mint::RowMatrix4<T>> for Transform3D<T, Src, Dst> {
+    #[rustfmt::skip]
     fn from(m: mint::RowMatrix4<T>) -> Self {
         Transform3D {
             m11: m.x.x, m12: m.x.y, m13: m.x.z, m14: m.x.w,
@@ -1142,6 +1184,7 @@ impl<T, Src, Dst> From<mint::RowMatrix4<T>> for Transform3D<T, Src, Dst> {
 }
 #[cfg(feature = "mint")]
 impl<T, Src, Dst> From<Transform3D<T, Src, Dst>> for mint::RowMatrix4<T> {
+    #[rustfmt::skip]
     fn from(t: Transform3D<T, Src, Dst>) -> Self {
         mint::RowMatrix4 {
             x: mint::Vector4 { x: t.m11, y: t.m12, z: t.m13, w: t.m14 },
@@ -1152,20 +1195,21 @@ impl<T, Src, Dst> From<Transform3D<T, Src, Dst>> for mint::RowMatrix4<T> {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
-    use crate::approxeq::ApproxEq;
     use super::*;
-    use crate::{point2, point3};
+    use crate::approxeq::ApproxEq;
     use crate::default;
+    use crate::{point2, point3};
 
     use core::f32::consts::{FRAC_PI_2, PI};
 
     type Mf32 = default::Transform3D<f32>;
 
     // For convenience.
-    fn rad(v: f32) -> Angle<f32> { Angle::radians(v) }
+    fn rad(v: f32) -> Angle<f32> {
+        Angle::radians(v)
+    }
 
     #[test]
     pub fn test_translation() {
@@ -1175,13 +1219,22 @@ mod tests {
         assert_eq!(t1, t2);
         assert_eq!(t1, t3);
 
-        assert_eq!(t1.transform_point3d(point3(1.0, 1.0, 1.0)), Some(point3(2.0, 3.0, 4.0)));
-        assert_eq!(t1.transform_point2d(point2(1.0, 1.0)), Some(point2(2.0, 3.0)));
+        assert_eq!(
+            t1.transform_point3d(point3(1.0, 1.0, 1.0)),
+            Some(point3(2.0, 3.0, 4.0))
+        );
+        assert_eq!(
+            t1.transform_point2d(point2(1.0, 1.0)),
+            Some(point2(2.0, 3.0))
+        );
 
         assert_eq!(t1.then(&t1), Mf32::translation(2.0, 4.0, 6.0));
 
         assert!(!t1.is_2d());
-        assert_eq!(Mf32::translation(1.0, 2.0, 3.0).to_2d(), Transform2D::translation(1.0, 2.0));
+        assert_eq!(
+            Mf32::translation(1.0, 2.0, 3.0).to_2d(),
+            Transform2D::translation(1.0, 2.0)
+        );
     }
 
     #[test]
@@ -1192,10 +1245,18 @@ mod tests {
         assert_eq!(r1, r2);
         assert_eq!(r1, r3);
 
-        assert!(r1.transform_point3d(point3(1.0, 2.0, 3.0)).unwrap().approx_eq(&point3(-2.0, 1.0, 3.0)));
-        assert!(r1.transform_point2d(point2(1.0, 2.0)).unwrap().approx_eq(&point2(-2.0, 1.0)));
+        assert!(r1
+            .transform_point3d(point3(1.0, 2.0, 3.0))
+            .unwrap()
+            .approx_eq(&point3(-2.0, 1.0, 3.0)));
+        assert!(r1
+            .transform_point2d(point2(1.0, 2.0))
+            .unwrap()
+            .approx_eq(&point2(-2.0, 1.0)));
 
-        assert!(r1.then(&r1).approx_eq(&Mf32::rotation(0.0, 0.0, 1.0, rad(FRAC_PI_2*2.0))));
+        assert!(r1
+            .then(&r1)
+            .approx_eq(&Mf32::rotation(0.0, 0.0, 1.0, rad(FRAC_PI_2 * 2.0))));
 
         assert!(r1.is_2d());
         assert!(r1.to_2d().approx_eq(&Transform2D::rotation(rad(FRAC_PI_2))));
@@ -1209,15 +1270,23 @@ mod tests {
         assert_eq!(s1, s2);
         assert_eq!(s1, s3);
 
-        assert!(s1.transform_point3d(point3(2.0, 2.0, 2.0)).unwrap().approx_eq(&point3(4.0, 6.0, 8.0)));
-        assert!(s1.transform_point2d(point2(2.0, 2.0)).unwrap().approx_eq(&point2(4.0, 6.0)));
+        assert!(s1
+            .transform_point3d(point3(2.0, 2.0, 2.0))
+            .unwrap()
+            .approx_eq(&point3(4.0, 6.0, 8.0)));
+        assert!(s1
+            .transform_point2d(point2(2.0, 2.0))
+            .unwrap()
+            .approx_eq(&point2(4.0, 6.0)));
 
         assert_eq!(s1.then(&s1), Mf32::scale(4.0, 9.0, 16.0));
 
         assert!(!s1.is_2d());
-        assert_eq!(Mf32::scale(2.0, 3.0, 0.0).to_2d(), Transform2D::scale(2.0, 3.0));
+        assert_eq!(
+            Mf32::scale(2.0, 3.0, 0.0).to_2d(),
+            Transform2D::scale(2.0, 3.0)
+        );
     }
-
 
     #[test]
     pub fn test_pre_then_scale() {
@@ -1226,8 +1295,8 @@ mod tests {
         assert_eq!(m.then(&s), m.then_scale(2.0, 3.0, 4.0));
     }
 
-
     #[test]
+    #[rustfmt::skip]
     pub fn test_ortho() {
         let (left, right, bottom, top) = (0.0f32, 1.0f32, 0.1f32, 1.0f32);
         let (near, far) = (-1.0f32, 1.0f32);
@@ -1249,6 +1318,7 @@ mod tests {
     }
 
     #[test]
+    #[rustfmt::skip]
     pub fn test_new_2d() {
         let m1 = Mf32::new_2d(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
         let m2 = Mf32::new(
@@ -1314,8 +1384,12 @@ mod tests {
 
     #[test]
     pub fn test_pre_post() {
-        let m1 = default::Transform3D::identity().then_scale(1.0, 2.0, 3.0).then_translate(vec3(1.0, 2.0, 3.0));
-        let m2 = default::Transform3D::identity().pre_translate(vec3(1.0, 2.0, 3.0)).pre_scale(1.0, 2.0, 3.0);
+        let m1 = default::Transform3D::identity()
+            .then_scale(1.0, 2.0, 3.0)
+            .then_translate(vec3(1.0, 2.0, 3.0));
+        let m2 = default::Transform3D::identity()
+            .pre_translate(vec3(1.0, 2.0, 3.0))
+            .pre_scale(1.0, 2.0, 3.0);
         assert!(m1.approx_eq(&m2));
 
         let r = Mf32::rotation(0.0, 0.0, 1.0, rad(FRAC_PI_2));
@@ -1323,28 +1397,46 @@ mod tests {
 
         let a = point3(1.0, 1.0, 1.0);
 
-        assert!(r.then(&t).transform_point3d(a).unwrap().approx_eq(&point3(1.0, 4.0, 1.0)));
-        assert!(t.then(&r).transform_point3d(a).unwrap().approx_eq(&point3(-4.0, 3.0, 1.0)));
-        assert!(t.then(&r).transform_point3d(a).unwrap().approx_eq(&r.transform_point3d(t.transform_point3d(a).unwrap()).unwrap()));
+        assert!(r
+            .then(&t)
+            .transform_point3d(a)
+            .unwrap()
+            .approx_eq(&point3(1.0, 4.0, 1.0)));
+        assert!(t
+            .then(&r)
+            .transform_point3d(a)
+            .unwrap()
+            .approx_eq(&point3(-4.0, 3.0, 1.0)));
+        assert!(t.then(&r).transform_point3d(a).unwrap().approx_eq(
+            &r.transform_point3d(t.transform_point3d(a).unwrap())
+                .unwrap()
+        ));
     }
 
     #[test]
     fn test_size_of() {
         use core::mem::size_of;
-        assert_eq!(size_of::<default::Transform3D<f32>>(), 16*size_of::<f32>());
-        assert_eq!(size_of::<default::Transform3D<f64>>(), 16*size_of::<f64>());
+        assert_eq!(
+            size_of::<default::Transform3D<f32>>(),
+            16 * size_of::<f32>()
+        );
+        assert_eq!(
+            size_of::<default::Transform3D<f64>>(),
+            16 * size_of::<f64>()
+        );
     }
 
     #[test]
+    #[rustfmt::skip]
     pub fn test_transform_associativity() {
         let m1 = Mf32::new(3.0, 2.0, 1.5, 1.0,
-                                 0.0, 4.5, -1.0, -4.0,
-                                 0.0, 3.5, 2.5, 40.0,
-                                 0.0, 3.0, 0.0, 1.0);
+                           0.0, 4.5, -1.0, -4.0,
+                           0.0, 3.5, 2.5, 40.0,
+                           0.0, 3.0, 0.0, 1.0);
         let m2 = Mf32::new(1.0, -1.0, 3.0, 0.0,
-                                 -1.0, 0.5, 0.0, 2.0,
-                                 1.5, -2.0, 6.0, 0.0,
-                                 -2.5, 6.0, 1.0, 1.0);
+                           -1.0, 0.5, 0.0, 2.0,
+                           1.5, -2.0, 6.0, 0.0,
+                           -2.5, 6.0, 1.0, 1.0);
 
         let p = point3(1.0, 3.0, 5.0);
         let p1 = m1.then(&m2).transform_point3d(p).unwrap();
@@ -1396,6 +1488,7 @@ mod tests {
 
     #[test]
     pub fn test_homogeneous() {
+        #[rustfmt::skip]
         let m = Mf32::new(
             1.0, 2.0, 0.5, 5.0,
             3.0, 4.0, 0.25, 6.0,

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -11,16 +11,18 @@ use crate::num::*;
 use crate::UnknownUnit;
 use crate::{point2, point3, vec2, vec3, Box2D, Box3D, Rect, Size2D};
 use crate::{Point2D, Point3D, Transform2D, Transform3D, Vector2D, Vector3D};
+
 use core::cmp::{Eq, PartialEq};
 use core::fmt;
 use core::hash::Hash;
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Neg, Sub, SubAssign};
+
+#[cfg(feature = "bytemuck")]
+use bytemuck::{Pod, Zeroable};
 use num_traits::NumCast;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "bytemuck")]
-use bytemuck::{Zeroable, Pod};
 
 /// A 2d transformation from a space to another that can only express translations.
 ///
@@ -63,8 +65,7 @@ impl<'a, T, Src, Dst> arbitrary::Arbitrary<'a> for Translation2D<T, Src, Dst>
 where
     T: arbitrary::Arbitrary<'a>,
 {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self>
-    {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let (x, y) = arbitrary::Arbitrary::arbitrary(u)?;
         Ok(Translation2D {
             x,
@@ -676,7 +677,11 @@ impl<T: NumCast + Copy, Src, Dst> Translation3D<T, Src, Dst> {
     /// as one would expect from a simple cast, but this behavior does not always make sense
     /// geometrically. Consider using `round()`, `ceil()` or `floor()` before casting.
     pub fn try_cast<NewT: NumCast>(self) -> Option<Translation3D<NewT, Src, Dst>> {
-        match (NumCast::from(self.x), NumCast::from(self.y), NumCast::from(self.z)) {
+        match (
+            NumCast::from(self.x),
+            NumCast::from(self.y),
+            NumCast::from(self.z),
+        ) {
             (Some(x), Some(y), Some(z)) => Some(Translation3D::new(x, y, z)),
             _ => None,
         }

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -33,7 +33,7 @@ use num_traits::{Float, NumCast, Signed};
 use serde;
 
 #[cfg(feature = "bytemuck")]
-use bytemuck::{Zeroable, Pod};
+use bytemuck::{Pod, Zeroable};
 
 /// A 2d Vector tagged with a unit.
 #[repr(C)]
@@ -96,8 +96,7 @@ impl<'a, T, U> arbitrary::Arbitrary<'a> for Vector2D<T, U>
 where
     T: arbitrary::Arbitrary<'a>,
 {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self>
-    {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let (x, y) = arbitrary::Arbitrary::arbitrary(u)?;
         Ok(Vector2D {
             x,
@@ -775,13 +774,13 @@ impl<T: Add + Copy, U> Add<&Self> for Vector2D<T, U> {
 }
 
 impl<T: Add<Output = T> + Zero, U> Sum for Vector2D<T, U> {
-    fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::zero(), Add::add)
     }
 }
 
 impl<'a, T: 'a + Add<Output = T> + Copy + Zero, U: 'a> Sum<&'a Self> for Vector2D<T, U> {
-    fn sum<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
+    fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
         iter.fold(Self::zero(), Add::add)
     }
 }
@@ -1684,13 +1683,13 @@ impl<'a, T: 'a + Add + Copy, U: 'a> Add<&Self> for Vector3D<T, U> {
 }
 
 impl<T: Add<Output = T> + Zero, U> Sum for Vector3D<T, U> {
-    fn sum<I: Iterator<Item=Self>>(iter: I) -> Self {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
         iter.fold(Self::zero(), Add::add)
     }
 }
 
 impl<'a, T: 'a + Add<Output = T> + Copy + Zero, U: 'a> Sum<&'a Self> for Vector3D<T, U> {
-    fn sum<I: Iterator<Item=&'a Self>>(iter: I) -> Self {
+    fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
         iter.fold(Self::zero(), Add::add)
     }
 }
@@ -1723,11 +1722,7 @@ impl<T: Copy + Mul, U> Mul<T> for Vector3D<T, U> {
 
     #[inline]
     fn mul(self, scale: T) -> Self::Output {
-        vec3(
-            self.x * scale,
-            self.y * scale,
-            self.z * scale,
-        )
+        vec3(self.x * scale, self.y * scale, self.z * scale)
     }
 }
 
@@ -1743,11 +1738,7 @@ impl<T: Copy + Mul, U1, U2> Mul<Scale<T, U1, U2>> for Vector3D<T, U1> {
 
     #[inline]
     fn mul(self, scale: Scale<T, U1, U2>) -> Self::Output {
-        vec3(
-            self.x * scale.0,
-            self.y * scale.0,
-            self.z * scale.0,
-        )
+        vec3(self.x * scale.0, self.y * scale.0, self.z * scale.0)
     }
 }
 
@@ -1765,11 +1756,7 @@ impl<T: Copy + Div, U> Div<T> for Vector3D<T, U> {
 
     #[inline]
     fn div(self, scale: T) -> Self::Output {
-        vec3(
-            self.x / scale,
-            self.y / scale,
-            self.z / scale,
-        )
+        vec3(self.x / scale, self.y / scale, self.z / scale)
     }
 }
 
@@ -1785,11 +1772,7 @@ impl<T: Copy + Div, U1, U2> Div<Scale<T, U1, U2>> for Vector3D<T, U2> {
 
     #[inline]
     fn div(self, scale: Scale<T, U1, U2>) -> Self::Output {
-        vec3(
-            self.x / scale.0,
-            self.y / scale.0,
-            self.z / scale.0,
-        )
+        vec3(self.x / scale.0, self.y / scale.0, self.z / scale.0)
     }
 }
 
@@ -2299,7 +2282,7 @@ mod vector2d {
         let vecs = [
             Vector2DMm::new(1.0, 2.0),
             Vector2DMm::new(3.0, 4.0),
-            Vector2DMm::new(5.0, 6.0)
+            Vector2DMm::new(5.0, 6.0),
         ];
         let sum = Vector2DMm::new(9.0, 12.0);
         assert_eq!(vecs.iter().sum::<Vector2DMm<_>>(), sum);
@@ -2364,7 +2347,7 @@ mod vector3d {
         let vecs = [
             Vec3::new(1.0, 2.0, 3.0),
             Vec3::new(4.0, 5.0, 6.0),
-            Vec3::new(7.0, 8.0, 9.0)
+            Vec3::new(7.0, 8.0, 9.0),
         ];
         let sum = Vec3::new(12.0, 15.0, 18.0);
         assert_eq!(vecs.iter().sum::<Vec3>(), sum);


### PR DESCRIPTION
This PR does 3 things:

1. Apply rustfmt. The last PR that did this was #442.
2. _Unlike_ previous formatting PRs, add `#[rustfmt::skip]` to matrix code so that future formatting does not require manual reverts/exemptions.
3. Add a formatting check to CI.

I hope that this will make future contributions easier, because authors will be able to use automatic formatting with no manual intervention and no superfluous changes.