### PR TITLE
Loosen bounds on `RigidTransform3D`.

### DIFF
--- a/src/rigid.rs
+++ b/src/rigid.rs
@@ -5,6 +5,9 @@
 use crate::approxeq::ApproxEq;
 use crate::trig::Trig;
 use crate::{Rotation3D, Transform3D, UnknownUnit, Vector3D};
+
+use core::{fmt, hash};
+
 use num_traits::real::Real;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -19,7 +22,6 @@ use bytemuck::{Zeroable, Pod};
 ///
 /// This can be more efficient to use over full matrices, especially if you
 /// have to deal with the decomposed quantities often.
-#[derive(Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(C)]
 pub struct RigidTransform3D<T, Src, Dst> {
@@ -182,6 +184,29 @@ impl<T: Real + ApproxEq<T>, Src, Dst> RigidTransform3D<T, Src, Dst> {
             rotation: Rotation3D::from_untyped(&transform.rotation),
             translation: Vector3D::from_untyped(transform.translation),
         }
+    }
+}
+
+impl<T: fmt::Debug, Src, Dst> fmt::Debug for RigidTransform3D<T, Src, Dst> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RigidTransform3D")
+            .field("rotation", &self.rotation)
+            .field("translation", &self.translation)
+            .finish()
+    }
+}
+
+impl<T: PartialEq, Src, Dst> PartialEq for RigidTransform3D<T, Src, Dst> {
+    fn eq(&self, other: &Self) -> bool {
+        self.rotation == other.rotation && self.translation == other.translation
+    }
+}
+impl<T: Eq, Src, Dst> Eq for RigidTransform3D<T, Src, Dst> {}
+
+impl<T: hash::Hash, Src, Dst> hash::Hash for RigidTransform3D<T, Src, Dst> {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        self.rotation.hash(state);
+        self.translation.hash(state);
     }
 }
 


### PR DESCRIPTION
The derived trait implementations were requiring the `Src` and `Dst` unit types to implement traits they don't actually need to because they are phantom data.