### PR TITLE
Set rust-version in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "euclid"
 version = "0.22.9"
 authors = ["The Servo Project Developers"]
 edition = "2021"
+rust-version = "1.56.0"
 description = "Geometry primitives"
 documentation = "https://docs.rs/euclid/"
 repository = "https://github.com/servo/euclid"


### PR DESCRIPTION
Now that the MSRV is 1.56 it should be safe to set rust-version.