### PR TITLE
Rename `master` branch to `main`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
   workflow_dispatch:
   merge_group:


### PR DESCRIPTION
This is in line with a new policy for the Servo organization discussed by the Servo TSC. We consider `main` to be easier to type, friendlier, and more modern so we are standardizing on this branch name for all projects in the organization.