### PR TITLE
Implement `Arbitrary` for all remaining types.

### DIFF
--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -101,6 +101,19 @@ impl<T: fmt::Debug, U> fmt::Debug for Box2D<T, U> {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a, T, U> arbitrary::Arbitrary<'a> for Box2D<T, U>
+where
+    T: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Box2D::new(
+            arbitrary::Arbitrary::arbitrary(u)?,
+            arbitrary::Arbitrary::arbitrary(u)?,
+        ))
+    }
+}
+
 #[cfg(feature = "bytemuck")]
 unsafe impl<T: Zeroable, U> Zeroable for Box2D<T, U> {}
 

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -71,6 +71,19 @@ impl<T: fmt::Debug, U> fmt::Debug for Box3D<T, U> {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a, T, U> arbitrary::Arbitrary<'a> for Box3D<T, U>
+where
+    T: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Box3D::new(
+            arbitrary::Arbitrary::arbitrary(u)?,
+            arbitrary::Arbitrary::arbitrary(u)?,
+        ))
+    }
+}
+
 #[cfg(feature = "bytemuck")]
 unsafe impl<T: Zeroable, U> Zeroable for Box3D<T, U> {}
 

--- a/src/homogen.rs
+++ b/src/homogen.rs
@@ -80,6 +80,23 @@ where
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a, T, U> arbitrary::Arbitrary<'a> for HomogeneousVector<T, U>
+where
+    T: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let (x, y, z, w) = arbitrary::Arbitrary::arbitrary(u)?;
+        Ok(HomogeneousVector {
+            x,
+            y,
+            z,
+            w,
+            _unit: PhantomData,
+        })
+    }
+}
+
 #[cfg(feature = "bytemuck")]
 unsafe impl<T: Zeroable, U> Zeroable for HomogeneousVector<T, U> {}
 

--- a/src/length.rs
+++ b/src/length.rs
@@ -77,6 +77,16 @@ where
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a, T, U> arbitrary::Arbitrary<'a> for Length<T, U>
+where
+    T: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Length(arbitrary::Arbitrary::arbitrary(u)?, PhantomData))
+    }
+}
+
 #[cfg(feature = "bytemuck")]
 unsafe impl<T: Zeroable, U> Zeroable for Length<T, U> {}
 

--- a/src/point.rs
+++ b/src/point.rs
@@ -874,6 +874,22 @@ where
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a, T, U> arbitrary::Arbitrary<'a> for Point3D<T, U>
+where
+    T: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let (x, y, z) = arbitrary::Arbitrary::arbitrary(u)?;
+        Ok(Point3D {
+            x,
+            y,
+            z,
+            _unit: PhantomData,
+        })
+    }
+}
+
 #[cfg(feature = "bytemuck")]
 unsafe impl<T: Zeroable, U> Zeroable for Point3D<T, U> {}
 

--- a/src/rigid.rs
+++ b/src/rigid.rs
@@ -223,6 +223,19 @@ impl<T: Clone, Src, Dst> Clone for RigidTransform3D<T, Src, Dst> {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a, T, Src, Dst> arbitrary::Arbitrary<'a> for RigidTransform3D<T, Src, Dst>
+where
+    T: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(RigidTransform3D {
+            rotation: arbitrary::Arbitrary::arbitrary(u)?,
+            translation: arbitrary::Arbitrary::arbitrary(u)?,
+        })
+    }
+}
+
 #[cfg(feature = "bytemuck")]
 unsafe impl<T: Zeroable, Src, Dst> Zeroable for RigidTransform3D<T, Src, Dst> {}
 

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -73,6 +73,16 @@ where
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a, T, Src, Dst> arbitrary::Arbitrary<'a> for Rotation2D<T, Src, Dst>
+where
+    T: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Rotation2D::new(arbitrary::Arbitrary::arbitrary(u)?))
+    }
+}
+
 #[cfg(feature = "bytemuck")]
 unsafe impl<T: Zeroable, Src, Dst> Zeroable for Rotation2D<T, Src, Dst> {}
 
@@ -309,6 +319,20 @@ where
         self.j.hash(h);
         self.k.hash(h);
         self.r.hash(h);
+    }
+}
+
+/// Note: the quaternions produced by this implementation are not normalized
+/// (nor even necessarily finite). That is, this is not appropriate to use to
+/// choose an actual “arbitrary rotation”, at least not without postprocessing.
+#[cfg(feature = "arbitrary")]
+impl<'a, T, Src, Dst> arbitrary::Arbitrary<'a> for Rotation3D<T, Src, Dst>
+where
+    T: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let (i, j, k, r) = arbitrary::Arbitrary::arbitrary(u)?;
+        Ok(Rotation3D::quaternion(i, j, k, r))
     }
 }
 

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -324,6 +324,16 @@ impl<T: NumCast, Src, Dst> Scale<T, Src, Dst> {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a, T, Src, Dst> arbitrary::Arbitrary<'a> for Scale<T, Src, Dst>
+where
+    T: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Scale::new(arbitrary::Arbitrary::arbitrary(u)?))
+    }
+}
+
 #[cfg(feature = "bytemuck")]
 unsafe impl<T: Zeroable, Src, Dst> Zeroable for Scale<T, Src, Dst> {}
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -997,6 +997,22 @@ where
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a, T, U> arbitrary::Arbitrary<'a> for Size3D<T, U>
+where
+    T: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let (width, height, depth) = arbitrary::Arbitrary::arbitrary(u)?;
+        Ok(Size3D {
+            width,
+            height,
+            depth,
+            _unit: PhantomData,
+        })
+    }
+}
+
 #[cfg(feature = "bytemuck")]
 unsafe impl<T: Zeroable, U> Zeroable for Size3D<T, U> {}
 

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -419,6 +419,22 @@ pub struct Translation3D<T, Src, Dst> {
     pub _unit: PhantomData<(Src, Dst)>,
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a, T, Src, Dst> arbitrary::Arbitrary<'a> for Translation3D<T, Src, Dst>
+where
+    T: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let (x, y, z) = arbitrary::Arbitrary::arbitrary(u)?;
+        Ok(Translation3D {
+            x,
+            y,
+            z,
+            _unit: PhantomData,
+        })
+    }
+}
+
 impl<T: Copy, Src, Dst> Copy for Translation3D<T, Src, Dst> {}
 
 impl<T: Clone, Src, Dst> Clone for Translation3D<T, Src, Dst> {

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1000,6 +1000,22 @@ where
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a, T, U> arbitrary::Arbitrary<'a> for Vector3D<T, U>
+where
+    T: arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let (x, y, z) = arbitrary::Arbitrary::arbitrary(u)?;
+        Ok(Vector3D {
+            x,
+            y,
+            z,
+            _unit: PhantomData,
+        })
+    }
+}
+
 #[cfg(feature = "bytemuck")]
 unsafe impl<T: Zeroable, U> Zeroable for Vector3D<T, U> {}
 
@@ -2051,6 +2067,27 @@ impl BoolVector3D {
             x: self.y,
             y: self.z,
         }
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for BoolVector2D {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(BoolVector2D {
+            x: arbitrary::Arbitrary::arbitrary(u)?,
+            y: arbitrary::Arbitrary::arbitrary(u)?,
+        })
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for BoolVector3D {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(BoolVector3D {
+            x: arbitrary::Arbitrary::arbitrary(u)?,
+            y: arbitrary::Arbitrary::arbitrary(u)?,
+            z: arbitrary::Arbitrary::arbitrary(u)?,
+        })
     }
 }
 


### PR DESCRIPTION
* `BoolVector2D`
* `BoolVector3D`
* `Box2D`
* `Box3D`
* `HomogeneousVector`
* `Length`
* `Point3D`
* `RigidTransform3D`
* `Rotation2D`
* `Rotation3D`
* `Size3D`
* `Translation3D`
* `Vector3D`