### PR TITLE
Remove dependency on `derive` feature of `arbitrary`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ libm = ["num-traits/libm"]
 num-traits = { version = "0.2.15", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["serde_derive"], optional = true }
 mint = { version = "0.5.1", optional = true }
-arbitrary = { version = "1", optional = true, features = ["derive"] }
+arbitrary = { version = "1", optional = true }
 bytemuck = { version = "1.9", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
It has not been used since commit be0a34130ad5b4cc89848d48d3447f659e310006 aka PR <https://github.com/servo/euclid/pull/505>.