### PR TITLE
Improve doc formatting and linking.

### DIFF
--- a/src/angle.rs
+++ b/src/angle.rs
@@ -132,7 +132,7 @@ impl<T> Angle<T>
 where
     T: Float,
 {
-    /// Returns true if the angle is a finite number.
+    /// Returns `true` if the angle is a finite number.
     #[inline]
     pub fn is_finite(self) -> bool {
         self.radians.is_finite()
@@ -143,7 +143,7 @@ impl<T> Angle<T>
 where
     T: Real,
 {
-    /// Returns (sin(self), cos(self)).
+    /// Returns `(sin(self), cos(self))`.
     pub fn sin_cos(self) -> (T, T) {
         self.radians.sin_cos()
     }

--- a/src/approxeq.rs
+++ b/src/approxeq.rs
@@ -12,12 +12,12 @@ pub trait ApproxEq<Eps> {
     /// Default epsilon value
     fn approx_epsilon() -> Eps;
 
-    /// Returns `true` is this object is approximately equal to the other one, using
+    /// Returns `true` if this object is approximately equal to the other one, using
     /// a provided epsilon value.
     fn approx_eq_eps(&self, other: &Self, approx_epsilon: &Eps) -> bool;
 
-    /// Returns `true` is this object is approximately equal to the other one, using
-    /// the `approx_epsilon()` epsilon value.
+    /// Returns `true` if this object is approximately equal to the other one, using
+    /// the [`approx_epsilon`](ApproxEq::approx_epsilon) epsilon value.
     fn approx_eq(&self, other: &Self) -> bool {
         self.approx_eq_eps(other, &Self::approx_epsilon())
     }

--- a/src/box2d.rs
+++ b/src/box2d.rs
@@ -53,11 +53,10 @@ use core::ops::{Add, Div, DivAssign, Mul, MulAssign, Range, Sub};
 /// - it's area is negative (`min.x > max.x` or `min.y > max.y`),
 /// - it contains NaNs.
 ///
-/// [`Rect`]: struct.Rect.html
-/// [`intersection`]: #method.intersection
-/// [`is_empty`]: #method.is_empty
-/// [`union`]: #method.union
-/// [`size`]: #method.size
+/// [`intersection`]: Self::intersection
+/// [`is_empty`]: Self::is_empty
+/// [`union`]: Self::union
+/// [`size`]: Self::size
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
@@ -139,7 +138,7 @@ impl<T, U> Box2D<T, U> {
         }
     }
 
-    /// Creates a Box2D of the given size, at offset zero.
+    /// Creates a `Box2D` of the given size, at offset zero.
     #[inline]
     pub fn from_size(size: Size2D<T, U>) -> Self
     where
@@ -156,7 +155,7 @@ impl<T, U> Box2D<T, U>
 where
     T: PartialOrd,
 {
-    /// Returns true if the box has a negative area.
+    /// Returns `true` if the box has a negative area.
     ///
     /// The common interpretation for a negative box is to consider it empty. It can be obtained
     /// by calculating the intersection of two boxes that do not intersect.
@@ -165,7 +164,7 @@ where
         self.max.x < self.min.x || self.max.y < self.min.y
     }
 
-    /// Returns true if the size is zero, negative or NaN.
+    /// Returns `true` if the size is zero, negative or NaN.
     #[inline]
     pub fn is_empty(&self) -> bool {
         !(self.max.x > self.min.x && self.max.y > self.min.y)
@@ -240,7 +239,7 @@ where
     ///
     /// The result is a negative box if the boxes do not intersect.
     /// This can be useful for computing the intersection of more than two boxes, as
-    /// it is possible to chain multiple intersection_unchecked calls and check for
+    /// it is possible to chain multiple `intersection_unchecked` calls and check for
     /// empty/negative result at the end.
     #[inline]
     pub fn intersection_unchecked(&self, other: &Self) -> Self {
@@ -553,7 +552,11 @@ impl<T: NumCast + Copy, U> Box2D<T, U> {
     ///
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
-    /// geometrically. Consider using round(), round_in or round_out() before casting.
+    /// geometrically. Consider using [`round`], [`round_in`] or [`round_out`] before casting.
+    ///
+    /// [`round`]: Self::round
+    /// [`round_in`]: Self::round_in
+    /// [`round_out`]: Self::round_out
     #[inline]
     pub fn cast<NewT: NumCast>(&self) -> Box2D<NewT, U> {
         Box2D::new(self.min.cast(), self.max.cast())
@@ -563,7 +566,11 @@ impl<T: NumCast + Copy, U> Box2D<T, U> {
     ///
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
-    /// geometrically. Consider using round(), round_in or round_out() before casting.
+    /// geometrically. Consider using [`round`], [`round_in`] or [`round_out`] before casting.
+    ///
+    /// [`round`]: Self::round
+    /// [`round_in`]: Self::round_in
+    /// [`round_out`]: Self::round_out
     pub fn try_cast<NewT: NumCast>(&self) -> Option<Box2D<NewT, U>> {
         match (self.min.try_cast(), self.max.try_cast()) {
             (Some(a), Some(b)) => Some(Box2D::new(a, b)),
@@ -627,7 +634,7 @@ impl<T: NumCast + Copy, U> Box2D<T, U> {
 }
 
 impl<T: Float, U> Box2D<T, U> {
-    /// Returns true if all members are finite.
+    /// Returns `true` if all members are finite.
     #[inline]
     pub fn is_finite(self) -> bool {
         self.min.is_finite() && self.max.is_finite()

--- a/src/box3d.rs
+++ b/src/box3d.rs
@@ -113,7 +113,7 @@ impl<T, U> Box3D<T, U> {
         }
     }
 
-    /// Creates a Box3D of the given size, at offset zero.
+    /// Creates a `Box3D` of the given size, at offset zero.
     #[inline]
     pub fn from_size(size: Size3D<T, U>) -> Self
     where
@@ -130,7 +130,7 @@ impl<T, U> Box3D<T, U>
 where
     T: PartialOrd,
 {
-    /// Returns true if the box has a negative volume.
+    /// Returns `true` if the box has a negative volume.
     ///
     /// The common interpretation for a negative box is to consider it empty. It can be obtained
     /// by calculating the intersection of two boxes that do not intersect.
@@ -139,7 +139,7 @@ where
         self.max.x < self.min.x || self.max.y < self.min.y || self.max.z < self.min.z
     }
 
-    /// Returns true if the size is zero, negative or NaN.
+    /// Returns `true` if the size is zero, negative or NaN.
     #[inline]
     pub fn is_empty(&self) -> bool {
         !(self.max.x > self.min.x && self.max.y > self.min.y && self.max.z > self.min.z)
@@ -556,7 +556,11 @@ impl<T: NumCast + Copy, U> Box3D<T, U> {
     ///
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
-    /// geometrically. Consider using round(), round_in or round_out() before casting.
+    /// geometrically. Consider using [`round`], [`round_in`] or [`round_out`] before casting.
+    ///
+    /// [`round`]: Self::round
+    /// [`round_in`]: Self::round_in
+    /// [`round_out`]: Self::round_out
     #[inline]
     pub fn cast<NewT: NumCast>(&self) -> Box3D<NewT, U> {
         Box3D::new(self.min.cast(), self.max.cast())
@@ -566,7 +570,11 @@ impl<T: NumCast + Copy, U> Box3D<T, U> {
     ///
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
-    /// geometrically. Consider using round(), round_in or round_out() before casting.
+    /// geometrically. Consider using [`round`], [`round_in`] or [`round_out`] before casting.
+    ///
+    /// [`round`]: Self::round
+    /// [`round_in`]: Self::round_in
+    /// [`round_out`]: Self::round_out
     pub fn try_cast<NewT: NumCast>(&self) -> Option<Box3D<NewT, U>> {
         match (self.min.try_cast(), self.max.try_cast()) {
             (Some(a), Some(b)) => Some(Box3D::new(a, b)),
@@ -630,7 +638,7 @@ impl<T: NumCast + Copy, U> Box3D<T, U> {
 }
 
 impl<T: Float, U> Box3D<T, U> {
-    /// Returns true if all members are finite.
+    /// Returns `true` if all members are finite.
     #[inline]
     pub fn is_finite(self) -> bool {
         self.min.is_finite() && self.max.is_finite()

--- a/src/homogen.rs
+++ b/src/homogen.rs
@@ -143,7 +143,7 @@ impl<T, U> HomogeneousVector<T, U> {
 impl<T: Copy + Div<T, Output = T> + Zero + PartialOrd, U> HomogeneousVector<T, U> {
     /// Convert into Cartesian 2D point.
     ///
-    /// Returns None if the point is on or behind the W=0 hemisphere.
+    /// Returns `None` if the point is on or behind the W=0 hemisphere.
     #[inline]
     pub fn to_point2d(self) -> Option<Point2D<T, U>> {
         if self.w > T::zero() {
@@ -155,7 +155,7 @@ impl<T: Copy + Div<T, Output = T> + Zero + PartialOrd, U> HomogeneousVector<T, U
 
     /// Convert into Cartesian 3D point.
     ///
-    /// Returns None if the point is on or behind the W=0 hemisphere.
+    /// Returns `None` if the point is on or behind the W=0 hemisphere.
     #[inline]
     pub fn to_point3d(self) -> Option<Point3D<T, U>> {
         if self.w > T::zero() {

--- a/src/length.rs
+++ b/src/length.rs
@@ -36,10 +36,8 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// expression that requires a different unit.  It may be a type without values, such as an empty
 /// enum.
 ///
-/// You can multiply a `Length` by a `scale::Scale` to convert it from one unit to
+/// You can multiply a `Length` by a [`Scale`] to convert it from one unit to
 /// another. See the [`Scale`] docs for an example.
-///
-/// [`Scale`]: struct.Scale.html
 #[repr(C)]
 pub struct Length<T, Unit>(pub T, #[doc(hidden)] pub PhantomData<Unit>);
 

--- a/src/point.rs
+++ b/src/point.rs
@@ -148,7 +148,7 @@ impl<T, U> Point2D<T, U> {
         point2(Zero::zero(), Zero::zero())
     }
 
-    /// The same as [`origin()`](#method.origin).
+    /// The same as [`Point2D::origin`].
     #[inline]
     pub fn zero() -> Self
     where
@@ -509,7 +509,7 @@ impl<T: NumCast + Copy, U> Point2D<T, U> {
         self.cast()
     }
 
-    /// Cast into an i32 point, truncating decimals if any.
+    /// Cast into an `i32` point, truncating decimals if any.
     ///
     /// When casting from floating point points, it is worth considering whether
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
@@ -519,7 +519,7 @@ impl<T: NumCast + Copy, U> Point2D<T, U> {
         self.cast()
     }
 
-    /// Cast into an i64 point, truncating decimals if any.
+    /// Cast into an `i64` point, truncating decimals if any.
     ///
     /// When casting from floating point points, it is worth considering whether
     /// to `round()`, `ceil()` or `floor()` before the cast in order to obtain
@@ -531,7 +531,7 @@ impl<T: NumCast + Copy, U> Point2D<T, U> {
 }
 
 impl<T: Float, U> Point2D<T, U> {
-    /// Returns true if all members are finite.
+    /// Returns `true` if all members are finite.
     #[inline]
     pub fn is_finite(self) -> bool {
         self.x.is_finite() && self.y.is_finite()
@@ -710,7 +710,7 @@ impl<T: Zero, U> Zero for Point2D<T, U> {
 }
 
 impl<T: Round, U> Round for Point2D<T, U> {
-    /// See [Point2D::round()](#method.round)
+    /// See [`Point2D::round`].
     #[inline]
     fn round(self) -> Self {
         self.round()
@@ -718,7 +718,7 @@ impl<T: Round, U> Round for Point2D<T, U> {
 }
 
 impl<T: Ceil, U> Ceil for Point2D<T, U> {
-    /// See [Point2D::ceil()](#method.ceil)
+    /// See [`Point2D::ceil`].
     #[inline]
     fn ceil(self) -> Self {
         self.ceil()
@@ -726,7 +726,7 @@ impl<T: Ceil, U> Ceil for Point2D<T, U> {
 }
 
 impl<T: Floor, U> Floor for Point2D<T, U> {
-    /// See [Point2D::floor()](#method.floor)
+    /// See [`Point2D::floor`].
     #[inline]
     fn floor(self) -> Self {
         self.floor()
@@ -944,7 +944,7 @@ impl<T, U> Point3D<T, U> {
         point3(Zero::zero(), Zero::zero(), Zero::zero())
     }
 
-    /// The same as [`origin()`](#method.origin).
+    /// The same as [`Point3D::origin`].
     #[inline]
     pub fn zero() -> Self
     where
@@ -1356,7 +1356,7 @@ impl<T: NumCast + Copy, U> Point3D<T, U> {
 }
 
 impl<T: Float, U> Point3D<T, U> {
-    /// Returns true if all members are finite.
+    /// Returns `true` if all members are finite.
     #[inline]
     pub fn is_finite(self) -> bool {
         self.x.is_finite() && self.y.is_finite() && self.z.is_finite()
@@ -1551,7 +1551,7 @@ impl<T: Zero, U> Zero for Point3D<T, U> {
 }
 
 impl<T: Round, U> Round for Point3D<T, U> {
-    /// See [Point3D::round()](#method.round)
+    /// See [`Point3D::round`].
     #[inline]
     fn round(self) -> Self {
         self.round()
@@ -1559,7 +1559,7 @@ impl<T: Round, U> Round for Point3D<T, U> {
 }
 
 impl<T: Ceil, U> Ceil for Point3D<T, U> {
-    /// See [Point3D::ceil()](#method.ceil)
+    /// See [`Point3D::ceil`].
     #[inline]
     fn ceil(self) -> Self {
         self.ceil()
@@ -1567,7 +1567,7 @@ impl<T: Ceil, U> Ceil for Point3D<T, U> {
 }
 
 impl<T: Floor, U> Floor for Point3D<T, U> {
-    /// See [Point3D::floor()](#method.floor)
+    /// See [`Point3D::floor`].
     #[inline]
     fn floor(self) -> Self {
         self.floor()

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -43,8 +43,7 @@ use core::ops::{Add, Div, DivAssign, Mul, MulAssign, Range, Sub};
 /// - it's area is negative (`size.x < 0` or `size.y < 0`),
 /// - it contains NaNs.
 ///
-/// [`is_empty`]: #method.is_empty
-/// [`Box2D`]: struct.Box2D.html
+/// [`is_empty`]: Self::is_empty
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
@@ -214,7 +213,7 @@ impl<T, U> Rect<T, U>
 where
     T: Copy + PartialOrd + Add<T, Output = T>,
 {
-    /// Returns true if this rectangle contains the point. Points are considered
+    /// Returns `true` if this rectangle contains the point. Points are considered
     /// in the rectangle if they are on the left or top edge, but outside if they
     /// are on the right or bottom edge.
     #[inline]
@@ -265,8 +264,8 @@ impl<T, U> Rect<T, U>
 where
     T: Copy + Zero + PartialOrd + Add<T, Output = T>,
 {
-    /// Returns true if this rectangle contains the interior of rect. Always
-    /// returns true if rect is empty, and always returns false if rect is
+    /// Returns `true` if this rectangle contains the interior of `rect`. Always
+    /// returns `true` if `rect` is empty, and always returns `false` if `rect` is
     /// nonempty but this rectangle is empty.
     #[inline]
     pub fn contains_rect(&self, rect: &Self) -> bool {
@@ -508,7 +507,11 @@ impl<T: NumCast + Copy, U> Rect<T, U> {
     ///
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
-    /// geometrically. Consider using round(), round_in or round_out() before casting.
+    /// geometrically. Consider using [`round`], [`round_in`] or [`round_out`] before casting.
+    ///
+    /// [`round`]: Self::round
+    /// [`round_in`]: Self::round_in
+    /// [`round_out`]: Self::round_out
     #[inline]
     pub fn cast<NewT: NumCast>(&self) -> Rect<NewT, U> {
         Rect::new(self.origin.cast(), self.size.cast())
@@ -518,7 +521,11 @@ impl<T: NumCast + Copy, U> Rect<T, U> {
     ///
     /// When casting from floating point to integer coordinates, the decimals are truncated
     /// as one would expect from a simple cast, but this behavior does not always make sense
-    /// geometrically. Consider using round(), round_in or round_out() before casting.
+    /// geometrically. Consider using [`round`], [`round_in`] or [`round_out` before casting.
+    ///
+    /// [`round`]: Self::round
+    /// [`round_in`]: Self::round_in
+    /// [`round_out`]: Self::round_out
     pub fn try_cast<NewT: NumCast>(&self) -> Option<Rect<NewT, U>> {
         match (self.origin.try_cast(), self.size.try_cast()) {
             (Some(origin), Some(size)) => Some(Rect::new(origin, size)),
@@ -592,7 +599,7 @@ impl<T: NumCast + Copy, U> Rect<T, U> {
 }
 
 impl<T: Float, U> Rect<T, U> {
-    /// Returns true if all members are finite.
+    /// Returns `true` if all members are finite.
     #[inline]
     pub fn is_finite(self) -> bool {
         self.origin.is_finite() && self.size.is_finite()
@@ -612,10 +619,8 @@ impl<T: Floor + Ceil + Round + Add<T, Output = T> + Sub<T, Output = T>, U> Rect<
     ///
     /// # Usage notes
     /// Note, that when using with floating-point `T` types that method can significantly
-    /// loose precision for large values, so if you need to call this method very often it
+    /// lose precision for large values, so if you need to call this method very often it
     /// is better to use [`Box2D`].
-    ///
-    /// [`Box2D`]: struct.Box2D.html
     #[must_use]
     pub fn round(&self) -> Self {
         self.to_box2d().round().to_rect()
@@ -626,10 +631,8 @@ impl<T: Floor + Ceil + Round + Add<T, Output = T> + Sub<T, Output = T>, U> Rect<
     ///
     /// # Usage notes
     /// Note, that when using with floating-point `T` types that method can significantly
-    /// loose precision for large values, so if you need to call this method very often it
+    /// lose precision for large values, so if you need to call this method very often it
     /// is better to use [`Box2D`].
-    ///
-    /// [`Box2D`]: struct.Box2D.html
     #[must_use]
     pub fn round_in(&self) -> Self {
         self.to_box2d().round_in().to_rect()
@@ -640,10 +643,8 @@ impl<T: Floor + Ceil + Round + Add<T, Output = T> + Sub<T, Output = T>, U> Rect<
     ///
     /// # Usage notes
     /// Note, that when using with floating-point `T` types that method can significantly
-    /// loose precision for large values, so if you need to call this method very often it
+    /// lose precision for large values, so if you need to call this method very often it
     /// is better to use [`Box2D`].
-    ///
-    /// [`Box2D`]: struct.Box2D.html
     #[must_use]
     pub fn round_out(&self) -> Self {
         self.to_box2d().round_out().to_rect()

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -257,12 +257,15 @@ where
 /// A transform that can represent rotations in 3d, represented as a quaternion.
 ///
 /// Most methods expect the quaternion to be normalized.
-/// When in doubt, use `unit_quaternion` instead of `quaternion` to create
+/// When in doubt, use [`unit_quaternion`] instead of [`quaternion`] to create
 /// a rotation as the former will ensure that its result is normalized.
 ///
 /// Some people use the `x, y, z, w` (or `w, x, y, z`) notations. The equivalence is
 /// as follows: `x -> i`, `y -> j`, `z -> k`, `w -> r`.
 /// The memory layout of this type corresponds to the `x, y, z, w` notation
+///
+/// [`quaternion`]: Self::quaternion
+/// [`unit_quaternion`]: Self::unit_quaternion
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
@@ -351,7 +354,7 @@ impl<T, Src, Dst> Rotation3D<T, Src, Dst> {
     ///
     /// The resulting quaternion is not necessarily normalized. See [`unit_quaternion`].
     ///
-    /// [`unit_quaternion`]: #method.unit_quaternion
+    /// [`unit_quaternion`]: Self::unit_quaternion
     #[inline]
     pub fn quaternion(a: T, b: T, c: T, r: T) -> Self {
         Rotation3D {
@@ -553,7 +556,7 @@ where
 
     /// Returns `true` if [norm] of this quaternion is (approximately) one.
     ///
-    /// [norm]: #method.norm
+    /// [norm]: Self::norm
     #[inline]
     pub fn is_normalized(&self) -> bool
     where

--- a/src/size.rs
+++ b/src/size.rs
@@ -143,9 +143,9 @@ impl<T: Default, U> Default for Size2D<T, U> {
 }
 
 impl<T, U> Size2D<T, U> {
-    /// The same as [`Zero::zero()`] but available without importing trait.
+    /// The same as [`Zero::zero`] but available without importing trait.
     ///
-    /// [`Zero::zero()`]: ./num/trait.Zero.html#tymethod.zero
+    /// [`Zero::zero`]: crate::num::Zero::zero
     #[inline]
     pub fn zero() -> Self
     where
@@ -401,7 +401,7 @@ impl<T: NumCast + Copy, U> Size2D<T, U> {
 }
 
 impl<T: Float, U> Size2D<T, U> {
-    /// Returns true if all members are finite.
+    /// Returns `true` if all members are finite.
     #[inline]
     pub fn is_finite(self) -> bool {
         self.width.is_finite() && self.height.is_finite()
@@ -502,7 +502,7 @@ impl<T: PartialEq, U> Size2D<T, U> {
 }
 
 impl<T: Round, U> Round for Size2D<T, U> {
-    /// See [`Size2D::round()`](#method.round).
+    /// See [`Size2D::round`].
     #[inline]
     fn round(self) -> Self {
         self.round()
@@ -510,7 +510,7 @@ impl<T: Round, U> Round for Size2D<T, U> {
 }
 
 impl<T: Ceil, U> Ceil for Size2D<T, U> {
-    /// See [`Size2D::ceil()`](#method.ceil).
+    /// See [`Size2D::ceil`].
     #[inline]
     fn ceil(self) -> Self {
         self.ceil()
@@ -518,7 +518,7 @@ impl<T: Ceil, U> Ceil for Size2D<T, U> {
 }
 
 impl<T: Floor, U> Floor for Size2D<T, U> {
-    /// See [`Size2D::floor()`](#method.floor).
+    /// See [`Size2D::floor`].
     #[inline]
     fn floor(self) -> Self {
         self.floor()
@@ -1058,9 +1058,9 @@ impl<T: Default, U> Default for Size3D<T, U> {
 }
 
 impl<T, U> Size3D<T, U> {
-    /// The same as [`Zero::zero()`] but available without importing trait.
+    /// The same as [`Zero::zero`] but available without importing trait.
     ///
-    /// [`Zero::zero()`]: ./num/trait.Zero.html#tymethod.zero
+    /// [`Zero::zero`]: crate::num::Zero::zero
     pub fn zero() -> Self
     where
         T: Zero,
@@ -1311,7 +1311,7 @@ impl<T: NumCast + Copy, U> Size3D<T, U> {
 }
 
 impl<T: Float, U> Size3D<T, U> {
-    /// Returns true if all members are finite.
+    /// Returns `true` if all members are finite.
     #[inline]
     pub fn is_finite(self) -> bool {
         self.width.is_finite() && self.height.is_finite() && self.depth.is_finite()
@@ -1422,7 +1422,7 @@ impl<T: PartialEq, U> Size3D<T, U> {
 }
 
 impl<T: Round, U> Round for Size3D<T, U> {
-    /// See [`Size3D::round()`](#method.round).
+    /// See [`Size3D::round`].
     #[inline]
     fn round(self) -> Self {
         self.round()
@@ -1430,7 +1430,7 @@ impl<T: Round, U> Round for Size3D<T, U> {
 }
 
 impl<T: Ceil, U> Ceil for Size3D<T, U> {
-    /// See [`Size3D::ceil()`](#method.ceil).
+    /// See [`Size3D::ceil`].
     #[inline]
     fn ceil(self) -> Self {
         self.ceil()
@@ -1438,7 +1438,7 @@ impl<T: Ceil, U> Ceil for Size3D<T, U> {
 }
 
 impl<T: Floor, U> Floor for Size3D<T, U> {
-    /// See [`Size3D::floor()`](#method.floor).
+    /// See [`Size3D::floor`].
     #[inline]
     fn floor(self) -> Self {
         self.floor()

--- a/src/transform2d.rs
+++ b/src/transform2d.rs
@@ -54,10 +54,10 @@ use serde::{Deserialize, Serialize};
 ///  |   0   0   1 |   |1|   |1 |
 /// ```
 ///
-/// When translating Transform2D into general matrix representations, consider that the
+/// When translating `Transform2D` into general matrix representations, consider that the
 /// representation follows the column-major notation with column vectors.
 ///
-/// The translation terms are m31 and m32.
+/// The translation terms are `m31` and `m32`.
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
@@ -170,12 +170,10 @@ impl<T, Src, Dst> Transform2D<T, Src, Dst> {
         }
     }
 
-    /// Returns true is this transform is approximately equal to the other one, using
-    /// T's default epsilon value.
+    /// Returns `true` if this transform is approximately equal to the other one, using
+    /// `T`'s default epsilon value.
     ///
-    /// The same as [`ApproxEq::approx_eq()`] but available without importing trait.
-    ///
-    /// [`ApproxEq::approx_eq()`]: ./approxeq/trait.ApproxEq.html#method.approx_eq
+    /// The same as [`ApproxEq::approx_eq`] but available without importing trait.
     #[inline]
     pub fn approx_eq(&self, other: &Self) -> bool
     where
@@ -184,12 +182,10 @@ impl<T, Src, Dst> Transform2D<T, Src, Dst> {
         <Self as ApproxEq<T>>::approx_eq(&self, &other)
     }
 
-    /// Returns true is this transform is approximately equal to the other one, using
+    /// Returns `true` if this transform is approximately equal to the other one, using
     /// a provided epsilon value.
     ///
-    /// The same as [`ApproxEq::approx_eq_eps()`] but available without importing trait.
-    ///
-    /// [`ApproxEq::approx_eq_eps()`]: ./approxeq/trait.ApproxEq.html#method.approx_eq_eps
+    /// The same as [`ApproxEq::approx_eq_eps`] but available without importing trait.
     #[inline]
     pub fn approx_eq_eps(&self, other: &Self, eps: &T) -> bool
     where
@@ -203,7 +199,7 @@ impl<T: Copy, Src, Dst> Transform2D<T, Src, Dst> {
     /// Returns an array containing this transform's terms.
     ///
     /// The terms are laid out in the same order as they are
-    /// specified in `Transform2D::new`, that is following the
+    /// specified in [`Transform2D::new`], that is following the
     /// column-major-column-vector matrix notation.
     ///
     /// For example the translation terms are found in the
@@ -641,7 +637,7 @@ impl<T, Src, Dst> Default for Transform2D<T, Src, Dst>
 where
     T: Zero + One,
 {
-    /// Returns the [identity transform](#method.identity).
+    /// Returns the [identity transform](Transform2D::identity).
     fn default() -> Self {
         Self::identity()
     }
@@ -653,7 +649,7 @@ impl<T: ApproxEq<T>, Src, Dst> ApproxEq<T> for Transform2D<T, Src, Dst> {
         T::approx_epsilon()
     }
 
-    /// Returns true is this transform is approximately equal to the other one, using
+    /// Returns `true` if this transform is approximately equal to the other one, using
     /// a provided epsilon value.
     fn approx_eq_eps(&self, other: &Self, eps: &T) -> bool {
         self.m11.approx_eq_eps(&other.m11, eps)

--- a/src/transform3d.rs
+++ b/src/transform3d.rs
@@ -48,7 +48,7 @@ use serde::{Deserialize, Serialize};
 /// applied before the rest of the transformation, while post-transformations (`then_*`
 /// methods) add an operation that is applied after.
 ///
-/// When translating Transform3D into general matrix representations, consider that the
+/// When translating `Transform3D` into general matrix representations, consider that the
 /// representation follows the column major notation with column vectors.
 ///
 /// ```text
@@ -58,7 +58,7 @@ use serde::{Deserialize, Serialize};
 ///  |w |   | m41 m42 m43 m44 |   |1|
 /// ```
 ///
-/// The translation terms are m41, m42 and m43.
+/// The translation terms are `m41`, `m42` and `m43`.
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
@@ -427,9 +427,9 @@ impl<T: Copy, Src, Dst> Transform3D<T, Src, Dst> {
     /// Create a 2D transform picking the relevant terms from this transform.
     ///
     /// This method assumes that self represents a 2d transformation, callers
-    /// should check that [`self.is_2d()`] returns `true` beforehand.
+    /// should check that [`is_2d`] returns `true` beforehand.
     ///
-    /// [`self.is_2d()`]: #method.is_2d
+    /// [`is_2d`]: Self::is_2d
     pub fn to_2d(&self) -> Transform2D<T, Src, Dst> {
         Transform2D::new(self.m11, self.m12, self.m21, self.m22, self.m41, self.m42)
     }
@@ -1110,23 +1110,19 @@ impl<T: NumCast + Copy, Src, Dst> Transform3D<T, Src, Dst> {
 }
 
 impl<T: ApproxEq<T>, Src, Dst> Transform3D<T, Src, Dst> {
-    /// Returns true is this transform is approximately equal to the other one, using
-    /// T's default epsilon value.
+    /// Returns `true` if this transform is approximately equal to the other one, using
+    /// `T`'s default epsilon value.
     ///
-    /// The same as [`ApproxEq::approx_eq()`] but available without importing trait.
-    ///
-    /// [`ApproxEq::approx_eq()`]: ./approxeq/trait.ApproxEq.html#method.approx_eq
+    /// The same as [`ApproxEq::approx_eq`] but available without importing trait.
     #[inline]
     pub fn approx_eq(&self, other: &Self) -> bool {
         <Self as ApproxEq<T>>::approx_eq(&self, &other)
     }
 
-    /// Returns true is this transform is approximately equal to the other one, using
+    /// Returns `true` if this transform is approximately equal to the other one, using
     /// a provided epsilon value.
     ///
-    /// The same as [`ApproxEq::approx_eq_eps()`] but available without importing trait.
-    ///
-    /// [`ApproxEq::approx_eq_eps()`]: ./approxeq/trait.ApproxEq.html#method.approx_eq_eps
+    /// The same as [`ApproxEq::approx_eq_eps`] but available without importing trait.
     #[inline]
     pub fn approx_eq_eps(&self, other: &Self, eps: &T) -> bool {
         <Self as ApproxEq<T>>::approx_eq_eps(&self, &other, &eps)
@@ -1156,7 +1152,7 @@ impl<T, Src, Dst> Default for Transform3D<T, Src, Dst>
 where
     T: Zero + One,
 {
-    /// Returns the [identity transform](#method.identity).
+    /// Returns the [identity transform](Self::identity).
     fn default() -> Self {
         Self::identity()
     }

--- a/src/translation.rs
+++ b/src/translation.rs
@@ -26,8 +26,8 @@ use serde::{Deserialize, Serialize};
 
 /// A 2d transformation from a space to another that can only express translations.
 ///
-/// The main benefit of this type over a Vector2D is the ability to cast
-/// between a source and a destination spaces.
+/// The main benefit of this type over a [`Vector2D`] is the ability to cast
+/// between source and destination spaces.
 ///
 /// Example:
 ///
@@ -408,8 +408,8 @@ impl<T: fmt::Debug, Src, Dst> fmt::Debug for Translation2D<T, Src, Dst> {
 
 /// A 3d transformation from a space to another that can only express translations.
 ///
-/// The main benefit of this type over a Vector3D is the ability to cast
-/// between a source and a destination spaces.
+/// The main benefit of this type over a [`Vector3D`] is the ability to cast
+/// between source and destination spaces.
 #[repr(C)]
 pub struct Translation3D<T, Src, Dst> {
     pub x: T,

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -497,7 +497,7 @@ impl<T: Float, U> Vector2D<T, U> {
         }
     }
 
-    /// Returns true if all members are finite.
+    /// Returns `true` if all members are finite.
     #[inline]
     pub fn is_finite(self) -> bool {
         self.x.is_finite() && self.y.is_finite()
@@ -520,7 +520,7 @@ impl<T: Real, U> Vector2D<T, U> {
 
     /// Returns the vector with length of one unit.
     ///
-    /// Unlike [`Vector2D::normalize`](#method.normalize), this returns None in the case that the
+    /// Unlike [`Vector2D::normalize`], this returns `None` in the case that the
     /// length of the vector is zero.
     #[inline]
     #[must_use]
@@ -875,7 +875,7 @@ impl<T: Copy + DivAssign, U> DivAssign<Scale<T, U, U>> for Vector2D<T, U> {
 }
 
 impl<T: Round, U> Round for Vector2D<T, U> {
-    /// See [`Vector2D::round()`](#method.round)
+    /// See [`Vector2D::round`].
     #[inline]
     fn round(self) -> Self {
         self.round()
@@ -883,7 +883,7 @@ impl<T: Round, U> Round for Vector2D<T, U> {
 }
 
 impl<T: Ceil, U> Ceil for Vector2D<T, U> {
-    /// See [`Vector2D::ceil()`](#method.ceil)
+    /// See [`Vector2D::ceil`].
     #[inline]
     fn ceil(self) -> Self {
         self.ceil()
@@ -891,7 +891,7 @@ impl<T: Ceil, U> Ceil for Vector2D<T, U> {
 }
 
 impl<T: Floor, U> Floor for Vector2D<T, U> {
-    /// See [`Vector2D::floor()`](#method.floor)
+    /// See [`Vector2D::floor`].
     #[inline]
     fn floor(self) -> Self {
         self.floor()
@@ -1399,7 +1399,7 @@ impl<T: Float, U> Vector3D<T, U> {
         }
     }
 
-    /// Returns true if all members are finite.
+    /// Returns `true` if all members are finite.
     #[inline]
     pub fn is_finite(self) -> bool {
         self.x.is_finite() && self.y.is_finite() && self.z.is_finite()
@@ -1435,7 +1435,7 @@ impl<T: Real, U> Vector3D<T, U> {
 
     /// Returns the vector with length of one unit.
     ///
-    /// Unlike [`Vector2D::normalize`](#method.normalize), this returns None in the case that the
+    /// Unlike [`Vector2D::normalize`], this returns `None` in the case that the
     /// length of the vector is zero.
     #[inline]
     #[must_use]
@@ -1802,7 +1802,7 @@ impl<T: Copy + DivAssign, U> DivAssign<Scale<T, U, U>> for Vector3D<T, U> {
 }
 
 impl<T: Round, U> Round for Vector3D<T, U> {
-    /// See [`Vector3D::round()`](#method.round)
+    /// See [`Vector3D::round`].
     #[inline]
     fn round(self) -> Self {
         self.round()
@@ -1810,7 +1810,7 @@ impl<T: Round, U> Round for Vector3D<T, U> {
 }
 
 impl<T: Ceil, U> Ceil for Vector3D<T, U> {
-    /// See [`Vector3D::ceil()`](#method.ceil)
+    /// See [`Vector3D::ceil`].
     #[inline]
     fn ceil(self) -> Self {
         self.ceil()
@@ -1818,7 +1818,7 @@ impl<T: Ceil, U> Ceil for Vector3D<T, U> {
 }
 
 impl<T: Floor, U> Floor for Vector3D<T, U> {
-    /// See [`Vector3D::floor()`](#method.floor)
+    /// See [`Vector3D::floor`].
     #[inline]
     fn floor(self) -> Self {
         self.floor()


### PR DESCRIPTION
* Update to modern intradoc links that are checked by the Rust tools.
* Add some missing backticks and links.
* Fix some grammar errors.
* Fix `clippy::doc_markdown` lints.