### PR TITLE
Expand docs for Box{2,3}D::{contains,contains_inclusive,from_points}

### DIFF
--- a/src/rect.rs
+++ b/src/rect.rs
@@ -328,10 +328,12 @@ where
     ///
     /// Note: This function has a behavior that can be surprising because
     /// the right-most and bottom-most points are exactly on the edge
-    /// of the rectangle while the `contains` function is has exclusive
+    /// of the rectangle while the [`Rect::contains`] function is has exclusive
     /// semantic on these edges. This means that the right-most and bottom-most
-    /// points provided to `from_points` will count as not contained by the rect.
+    /// points provided to [`Rect::from_points`] will count as not contained by the rect.
     /// This behavior may change in the future.
+    ///
+    /// See [`Box2D::from_points`] for more details.
     pub fn from_points<I>(points: I) -> Self
     where
         I: IntoIterator,


### PR DESCRIPTION
Resolves #519.

This patch expands the docstrings of `Box2D::from_points` and `Box3D::from_points`, to lift the ambiguity reported in #519. The docstring in `Rect::from_points` already contained a relevant comment, added in #255.

Also add examples to `Box2D::contains`, `Box2D::contains_inclusive` and the corresponding `Box3D` associated functions.

This patch does not contain any functional code, only documentation, changes.